### PR TITLE
Fix cluster click listeners

### DIFF
--- a/library/src/com/google/maps/android/clustering/ClusterManager.java
+++ b/library/src/com/google/maps/android/clustering/ClusterManager.java
@@ -57,6 +57,7 @@ public class ClusterManager<T extends ClusterItem> implements GoogleMap.OnCamera
         mRenderer = new DefaultClusterRenderer<T>(context, map, this);
         mAlgorithm = new PreCachingAlgorithmDecorator<T>(new NonHierarchicalDistanceBasedAlgorithm<T>());
         mClusterTask = new ClusterTask();
+        mRenderer.onAdd();
     }
 
     public MarkerManager.Collection getMarkerCollection() {


### PR DESCRIPTION
Hi,

I wasn't able to have ClusterManager call the OnClusterClickListener and OnClusterItemClickListener callbacks that I attached. This pull request fixes the problem I had.

I patched ClusteringDemoActivity in the demo application to act on the mentioned callbacks for testing, available here:  https://github.com/infinityb/android-maps-utils/tree/demo-with-toasts

Regards,
Stacey Ell
