### PR TITLE
Exclude files generated by ADT from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 *.iml
 build
 local.properties
+.classpath
+.project
+library/bin
+library/gen
+project.properties


### PR DESCRIPTION
When I configure android-maps-utils as library in ADT, the IDE will generate files that I think should be excluded from git.
