### PR TITLE
Fixes Bounds.contains() for issue #71

### DIFF
--- a/library/src/com/google/maps/android/geometry/Bounds.java
+++ b/library/src/com/google/maps/android/geometry/Bounds.java
@@ -40,7 +40,7 @@ public class Bounds {
     }
 
     public boolean contains(double x, double y) {
-        return minX <= x && x < maxX && minY <= y && y < maxY;
+        return minX <= x && x <= maxX && minY <= y && y <= maxY;
     }
 
     public boolean contains(Point point) {


### PR DESCRIPTION
Changes the contains function to be inclusive for maxX and maxY values. This fixes the PointQuadTree from excluding the points with maxX and maxY values from the heat map.
