### PR TITLE
ConcurrentHashMap backed sets to avoid concurrent modification exceptions

### DIFF
--- a/library/src/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
+++ b/library/src/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
@@ -71,7 +71,7 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
      * Markers that are currently on the map.
      */
     private Set<MarkerWithPosition> mMarkers = Collections.newSetFromMap(
-        new ConcurrentHashMap<MarkerWithPosition,Boolean>());
+            new ConcurrentHashMap<MarkerWithPosition, Boolean>());
 
     /**
      * Icons for each bucket.
@@ -362,7 +362,7 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
 
             // Create the new markers and animate them to their new positions.
             final Set<MarkerWithPosition> newMarkers = Collections.newSetFromMap(
-                new ConcurrentHashMap<MarkerWithPosition,Boolean>());
+                    new ConcurrentHashMap<MarkerWithPosition, Boolean>());
             for (Cluster<T> c : clusters) {
                 boolean onScreen = visibleBounds.contains(c.getPosition());
                 if (zoomingIn && onScreen && SHOULD_ANIMATE) {


### PR DESCRIPTION
Using the sledgehammer of ConcurrentHashMap to avoid concurrent modification exceptions. Not an elegant fix of the root cause (newMarkers in markerModifier tasks?), but makes the problem stop occurring.
