### PR TITLE
Fix #115 by updating gradle build info and manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.7.+'
+        classpath 'com.android.tools.build:gradle:0.12.2'
         classpath 'com.github.townsfolk:gradle-release:1.2'
     }
 }
-
 apply plugin: 'release'

--- a/demo/AndroidManifest.xml
+++ b/demo/AndroidManifest.xml
@@ -5,7 +5,7 @@
           android:versionName="1.0">
 
     <uses-sdk
-            android:minSdkVersion="8"
+            android:minSdkVersion="9"
             android:targetSdkVersion="19"/>
 
     <permission

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.1"
+    buildToolsVersion "19.1.0"
 
     sourceSets {
         main {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Wed Oct 08 10:43:50 MDT 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.9-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -19,9 +19,10 @@ dependencies {
     compile 'com.google.android.gms:play-services:4.3+'
 }
 
+
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.1"
+    buildToolsVersion "19.1.0"
 
     sourceSets {
         main {
@@ -30,7 +31,7 @@ android {
             res.srcDirs = ['res']
         }
 
-        instrumentTest {
+        androidTest {
             java.srcDirs = ['tests/src']
         }
     }


### PR DESCRIPTION
This fix to update the gradle build at least works for me with android studio 0.8.9

I essentially hacked my way through http://tools.android.com/tech-docs/new-build-system/migrating_to_09 until it seemed to work. I can now run the demo app.
