### PR TITLE
Added build rules for Maps for Business library.

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 apply plugin: 'android'
 
 dependencies {
-    compile project(':library')
+    compile project(path: ':library', configuration: 'gmsRelease')
     // Or, fetch from Maven:
     // compile 'com.google.maps.android:android-maps-utils:0.3+'
     compile 'com.google.android.gms:play-services-maps:6.+'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -21,10 +21,6 @@ android {
     defaultPublishConfig "release"
     publishNonDefault true
 
-    packagingOptions {
-        exclude 'libs/maps_m4b.jar'
-    }
-
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -15,32 +15,92 @@ apply plugin: 'signing'
 archivesBaseName = 'android-maps-utils'
 group = 'com.google.maps.android'
 
-dependencies {
-    compile 'com.google.android.gms:play-services-maps:6.5.87'
-}
-
-
 android {
     compileSdkVersion 19
     buildToolsVersion "21.1.2"
+    defaultPublishConfig "release"
+    publishNonDefault true
 
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
+        }
+
+        gms{
             java.srcDirs = ['src']
             res.srcDirs = ['res']
+        }
+
+        m4b {
+            java.srcDirs = ['m4b/src']
+            res.srcDirs = ['m4b/res']
         }
 
         androidTest {
             java.srcDirs = ['tests/src']
         }
     }
+
+    productFlavors {
+        gms {
+            dependencies {
+                compile 'com.google.android.gms:play-services-maps:6.5.87'
+            }
+        }
+
+        m4b {
+            dependencies {
+                compile files('../maps_m4b.jar')
+            }
+        }
+    }
 }
+
+task buildM4b (dependsOn: build)
+
+gradle.taskGraph.whenReady { TaskExecutionGraph graph ->
+    def isM4bEnabled = graph.hasTask(buildM4b)
+    for (task in graph.allTasks) {
+        if (task.name.indexOf("M4b") > 0) {
+            task.enabled = isM4bEnabled
+        }
+    }
+}
+
+task genM4bSrc(type: Copy) {
+    from('src'){
+        include '**/*.java'
+        filter({
+            line -> line.replaceAll("com.google.android.gms.maps",
+                    "com.google.android.m4b.maps")
+        })
+    }
+    from('src'){
+        exclude '**/*.java'
+    }
+    into 'm4b/src'
+}
+
+task genM4bRes(type: Copy) {
+    from('res'){
+        include '**/*.xml'
+        filter({
+            line -> line.replaceAll("com.google.android.gms.maps",
+                    "com.google.android.m4b.maps")
+        })
+    }
+    from('res'){
+        exclude '**/*.xml'
+    }
+    into 'm4b/res'
+}
+
+preBuild.dependsOn genM4bSrc, genM4bRes
 
 task instrumentTest(dependsOn: connectedCheck)
 
 task apklib(type: Zip) {
-    dependsOn 'packageReleaseJar'
+    dependsOn 'packageGmsReleaseJar'
     appendix = extension = 'apklib'
 
     from 'AndroidManifest.xml'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -21,12 +21,16 @@ android {
     defaultPublishConfig "release"
     publishNonDefault true
 
+    packagingOptions {
+        exclude 'libs/maps_m4b.jar'
+    }
+
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
         }
 
-        gms{
+        gms {
             java.srcDirs = ['src']
             res.srcDirs = ['res']
         }
@@ -43,27 +47,22 @@ android {
 
     productFlavors {
         gms {
-            dependencies {
-                compile 'com.google.android.gms:play-services-maps:6.5.87'
-            }
         }
 
         m4b {
-            dependencies {
-                compile files('../maps_m4b.jar')
-            }
         }
     }
 }
 
-task buildM4b (dependsOn: build)
+dependencies {
+    compile 'com.google.android.gms:play-services-maps:6.5.87'
+    m4bCompile files ('../maps_m4b.jar')
 
-gradle.taskGraph.whenReady { TaskExecutionGraph graph ->
-    def isM4bEnabled = graph.hasTask(buildM4b)
-    for (task in graph.allTasks) {
-        if (task.name.indexOf("M4b") > 0) {
-            task.enabled = isM4bEnabled
-        }
+}
+
+android.libraryVariants.all { variant ->
+    variant.outputs.each { output ->
+        output.packageLibrary.exclude('libs/maps_m4b.jar')
     }
 }
 
@@ -145,6 +144,10 @@ uploadArchives {
 
             modifyPom(addFilter('apklib') { artifact, file ->
                 artifact.name == 'android-maps-utils-apklib'
+            })
+
+            modifyPom(addFilter('m4b') { artifact, file ->
+                artifact.name == 'android-maps-utils-m4b'
             })
 
             // There's no official apklib for Google Play services, so we


### PR DESCRIPTION
The Maps for Business library uses another Java package:
https://developers.google.com/maps/documentation/business/mobile/android/

The additional rules generate the src and res folders for the Maps for Business library by replacing the package names in the original src and res folders. The rules will be skipped by default. If a developer want a build for Maps for Business library, the buildM4b task should be invoked directly, then library-m4b-release.aar can be found in library/build/outputs/aar/.