### PR TITLE
Make getColor protected in DefaultClusterRenderer

### DIFF
--- a/library/src/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
+++ b/library/src/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
@@ -198,7 +198,7 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
         return squareTextView;
     }
 
-    private int getColor(int clusterSize) {
+    protected int getColor(int clusterSize) {
         final float hueRange = 220;
         final float sizeRange = 300;
         final float size = Math.min(clusterSize, sizeRange);


### PR DESCRIPTION
I'd like to use the `DefaultClusterRenderer` in my project but override the colors.

This PR changes the access level of the `getColor` method so that it can be overridden in subclasses of `DefaultClusterRenderer`.