### PR TITLE
Include only maps component of Google Play Services library

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     compile project(':library')
     // Or, fetch from Maven:
     // compile 'com.google.maps.android:android-maps-utils:0.3+'
-    compile 'com.google.android.gms:play-services:7.8.0'
+    compile 'com.google.android.gms:play-services-maps:7.8.0'
 }
 
 android {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -16,7 +16,7 @@ archivesBaseName = 'android-maps-utils'
 group = 'com.google.maps.android'
 
 dependencies {
-    compile 'com.google.android.gms:play-services:7.8.0'
+    compile 'com.google.android.gms:play-services-maps:7.8.0'
 }
 
 


### PR DESCRIPTION
This was originally implemented in https://github.com/googlemaps/android-maps-utils/commit/85258dec6c217c5189b453478f691375f2a14db1 and https://github.com/googlemaps/android-maps-utils/commit/68609ef0c734b5971c9829fe11978ecd24816324, but seems to have been mistakenly reverted in the GeoJSON commit https://github.com/googlemaps/android-maps-utils/commit/46a4e20b034880c659689ff106931827ccaf2510.  As far as I can tell the other Google Play Services components aren't needed for GeoJSON.