### PR TITLE
makeIcon takes CharSequence not String

### DIFF
--- a/demo/src/com/google/maps/android/utils/demo/IconGeneratorDemoActivity.java
+++ b/demo/src/com/google/maps/android/utils/demo/IconGeneratorDemoActivity.java
@@ -17,11 +17,18 @@
 package com.google.maps.android.utils.demo;
 
 import android.graphics.Color;
+import android.text.SpannableStringBuilder;
+import android.text.style.StyleSpan;
+
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.MarkerOptions;
 import com.google.maps.android.ui.IconGenerator;
+
+import static android.graphics.Typeface.BOLD;
+import static android.graphics.Typeface.ITALIC;
+import static android.text.Spannable.SPAN_EXCLUSIVE_EXCLUSIVE;
 
 public class IconGeneratorDemoActivity extends BaseDemoActivity {
 
@@ -47,14 +54,29 @@ public class IconGeneratorDemoActivity extends BaseDemoActivity {
         iconFactory.setContentRotation(90);
         iconFactory.setStyle(IconGenerator.STYLE_GREEN);
         addIcon(iconFactory, "ContentRotate=90", new LatLng(-33.7677, 151.244));
+
+        iconFactory.setRotation(0);
+        iconFactory.setContentRotation(0);
+        iconFactory.setStyle(IconGenerator.STYLE_ORANGE);
+        addIcon(iconFactory, makeCharSequence(), new LatLng(-33.77720, 151.12412));
     }
 
-    private void addIcon(IconGenerator iconFactory, String text, LatLng position) {
+    private void addIcon(IconGenerator iconFactory, CharSequence text, LatLng position) {
         MarkerOptions markerOptions = new MarkerOptions().
                 icon(BitmapDescriptorFactory.fromBitmap(iconFactory.makeIcon(text))).
                 position(position).
                 anchor(iconFactory.getAnchorU(), iconFactory.getAnchorV());
 
         getMap().addMarker(markerOptions);
+    }
+
+    private CharSequence makeCharSequence() {
+        String prefix = "Mixing ";
+        String suffix = "different fonts";
+        String sequence = prefix + suffix;
+        SpannableStringBuilder ssb = new SpannableStringBuilder(sequence);
+        ssb.setSpan(new StyleSpan(ITALIC), 0, prefix.length(), SPAN_EXCLUSIVE_EXCLUSIVE);
+        ssb.setSpan(new StyleSpan(BOLD), prefix.length(), sequence.length(), SPAN_EXCLUSIVE_EXCLUSIVE);
+        return ssb;
     }
 }

--- a/library/src/com/google/maps/android/ui/IconGenerator.java
+++ b/library/src/com/google/maps/android/ui/IconGenerator.java
@@ -69,7 +69,7 @@ public class IconGenerator {
      *
      * @param text the text content to display inside the icon.
      */
-    public Bitmap makeIcon(String text) {
+    public Bitmap makeIcon(CharSequence text) {
         if (mTextView != null) {
             mTextView.setText(text);
         }


### PR DESCRIPTION
The underlying TextView API takes a CharSequence, so this is a simple change that lets us use different fonts etc when creating our icons. I've updated the sample app to show it in use.

![sample_screenshot](https://cloud.githubusercontent.com/assets/2290987/13105590/dcb1796c-d55b-11e5-85ba-4382ce09adde.png)
