### PR TITLE
Equals for cluster subclasses

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,3 +9,4 @@
 * Mihai Preda, https://github.com/preda
 * Iris Uy, https://github.com/irisu
 * Emma Yeap, https://github.com/microcat
+* Stefanos Togoulidis, https://github.com/hypest

--- a/library/src/com/google/maps/android/clustering/algo/NonHierarchicalDistanceBasedAlgorithm.java
+++ b/library/src/com/google/maps/android/clustering/algo/NonHierarchicalDistanceBasedAlgorithm.java
@@ -183,5 +183,19 @@ public class NonHierarchicalDistanceBasedAlgorithm<T extends ClusterItem> implem
         public int getSize() {
             return 1;
         }
+
+        @Override
+        public int hashCode() {
+            return mClusterItem.hashCode();
+        };
+
+        @Override
+        public boolean equals(Object other) {
+            if (!(other instanceof QuadItem<?>)) {
+                return false;
+            }
+
+            return ((QuadItem<?>) other).mClusterItem.equals(mClusterItem);
+        }
     }
 }

--- a/library/src/com/google/maps/android/clustering/algo/NonHierarchicalDistanceBasedAlgorithm.java
+++ b/library/src/com/google/maps/android/clustering/algo/NonHierarchicalDistanceBasedAlgorithm.java
@@ -71,8 +71,13 @@ public class NonHierarchicalDistanceBasedAlgorithm<T extends ClusterItem> implem
 
     @Override
     public void removeItem(T item) {
-        // TODO: delegate QuadItem#hashCode and QuadItem#equals to its item.
-        throw new UnsupportedOperationException("NonHierarchicalDistanceBasedAlgorithm.remove not implemented");
+        // QuadItem delegates hashcode() and equals() to its item so,
+        //   removing any QuadItem to that item will remove the item
+        final QuadItem<T> quadItem = new QuadItem<T>(item);
+        synchronized (mQuadTree) {
+            mItems.remove(quadItem);
+            mQuadTree.remove(quadItem);
+        }
     }
 
     @Override

--- a/library/src/com/google/maps/android/clustering/algo/StaticCluster.java
+++ b/library/src/com/google/maps/android/clustering/algo/StaticCluster.java
@@ -49,4 +49,19 @@ public class StaticCluster<T extends ClusterItem> implements Cluster<T> {
                 ", mItems.size=" + mItems.size() +
                 '}';
     }
+
+    @Override
+    public int hashCode() {
+        return mCenter.hashCode() + mItems.hashCode();
+    };
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof StaticCluster<?>)) {
+            return false;
+        }
+
+        return ((StaticCluster<?>) other).mCenter.equals(mCenter)
+                && ((StaticCluster<?>) other).mItems.equals(mItems);
+    }
 }

--- a/library/tests/src/com/google/maps/android/clustering/QuadItemTest.java
+++ b/library/tests/src/com/google/maps/android/clustering/QuadItemTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Stefanos Togoulidis, all rights reserved.
+ * Copyright 2015 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/tests/src/com/google/maps/android/clustering/QuadItemTest.java
+++ b/library/tests/src/com/google/maps/android/clustering/QuadItemTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015 Stefanos Togoulidis, all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.maps.android.clustering;
+
+import com.google.android.gms.maps.model.LatLng;
+import com.google.maps.android.clustering.algo.NonHierarchicalDistanceBasedAlgorithm;
+
+import junit.framework.TestCase;
+
+public class QuadItemTest extends TestCase {
+
+    public class TestingItem implements ClusterItem {
+        private final LatLng mPosition;
+
+        public TestingItem(double lat, double lng) {
+            mPosition = new LatLng(lat, lng);
+        }
+
+        @Override
+        public LatLng getPosition() {
+            return mPosition;
+        }
+    }
+
+    public void setUp() {
+        // nothing to setup
+    }
+
+    public void testRemoval() {
+        TestingItem item_1_5 = new TestingItem(0.1, 0.5);
+        TestingItem item_2_3 = new TestingItem(0.2, 0.3);
+
+        NonHierarchicalDistanceBasedAlgorithm<ClusterItem> algo
+                = new NonHierarchicalDistanceBasedAlgorithm<ClusterItem>();
+        algo.addItem(item_1_5);
+        algo.addItem(item_2_3);
+
+        assertEquals(2, algo.getItems().size());
+
+        algo.removeItem(item_1_5);
+
+        assertEquals(1, algo.getItems().size());
+
+        assertFalse(algo.getItems().contains(item_1_5));
+        assertTrue(algo.getItems().contains(item_2_3));
+    }
+}

--- a/library/tests/src/com/google/maps/android/clustering/StaticClusterTest.java
+++ b/library/tests/src/com/google/maps/android/clustering/StaticClusterTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 Stefanos Togoulidis, all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.maps.android.clustering;
+
+import com.google.android.gms.maps.model.LatLng;
+import com.google.maps.android.clustering.algo.StaticCluster;
+
+import junit.framework.TestCase;
+
+public class StaticClusterTest extends TestCase {
+
+    private StaticCluster<ClusterItem> mCluster;
+
+    public void setUp() {
+        mCluster = new StaticCluster<ClusterItem>(new LatLng(0.1, 0.5));
+    }
+
+    public void testEquality() {
+        StaticCluster<ClusterItem> cluster_1_5 = new StaticCluster<ClusterItem>(
+                new LatLng(0.1, 0.5));
+
+        assertEquals(cluster_1_5, mCluster);
+        assertNotSame(cluster_1_5, mCluster);
+        assertEquals(cluster_1_5.hashCode(), mCluster.hashCode());
+    }
+
+    public void testUnequality() {
+        StaticCluster<ClusterItem> cluster_2_3 = new StaticCluster<ClusterItem>(
+                new LatLng(0.2, 0.3));
+
+        assertFalse(mCluster.equals(cluster_2_3));
+        assertFalse(cluster_2_3.hashCode() == mCluster.hashCode());
+    }
+}

--- a/library/tests/src/com/google/maps/android/clustering/StaticClusterTest.java
+++ b/library/tests/src/com/google/maps/android/clustering/StaticClusterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Stefanos Togoulidis, all rights reserved.
+ * Copyright 2015 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is a re-submission of https://github.com/googlemaps/android-maps-utils/pull/169 since I no longer have commit access to that one.

For reference, here's the original PR introduction:

> Adds implementations of "equals()" and "hashCode()" in StaticCluster and QuadItem classes. Benefit is the ability to reliably compare (and identify) instances of those classes.
> 
> As a bonus (and an implicit way to test QuadItem::hashCode() without exposing the inner class) this PR also includes an implementation of NonHierarchicalDistanceBasedAlgorithm::removeItem(). By the way, this would effectively fix issue #133.
> 
> PR commits include relevant tests. Let me know if more testing should be added.
> 
> Also, the added test files are new and thus copyrighted after myself, but still under the Apache v2 license. Let me know if this needs to be revised somehow.
> 
> Cheers!

Let me know if this causes any problems. Thanks!