### PR TITLE
Increasing ADB timeout to stabalise builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta5'
     }
 }
 /**

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        // TODO: move this to a stable release as soon as one becomes available
+        classpath 'com.android.tools.build:gradle:2.0.0-beta5'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jun 11 17:25:05 CEST 2015
+#Thu Feb 25 11:15:38 AEDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        // TODO: move this to a stable release as soon as one becomes available
+        classpath 'com.android.tools.build:gradle:2.0.0-beta5'
     }
 }
 
@@ -35,6 +36,13 @@ android {
             java.srcDirs = ['tests/src']
         }
     }
+
+    // This enables long timeouts required on slow environments, e.g. Travis
+    adbOptions {
+        timeOutInMs 10 * 60 * 1000  // 10 minutes
+        installOptions "-d","-t"
+    }
+
 }
 
 task instrumentTest(dependsOn: connectedCheck)


### PR DESCRIPTION
PTAL @jfschmakeit @domesticmouse @barbeau 

Tests look fine but I'm very slightly concerned with using an unstable version of the gradle plugin. We can always revert this if we have to but I am thoroughly sick of restarting travis builds every goddamn day, so think it's worth the risk.