### PR TITLE
Decode marker icon from local FS

### DIFF
--- a/library/src/com/google/maps/android/kml/KmlRenderer.java
+++ b/library/src/com/google/maps/android/kml/KmlRenderer.java
@@ -823,9 +823,9 @@ import java.util.Iterator;
             try {
                 return BitmapFactory.decodeStream((InputStream) new URL(mIconUrl).getContent());
             } catch (MalformedURLException e) {
-                e.printStackTrace();
+                return BitmapFactory.decodeFile(mIconUrl);
             } catch (IOException e) {
-                e.printStackTrace();
+                Log.e(LOG_TAG, "Image [" + mIconUrl + "] download issue", e);
             }
             return null;
         }
@@ -872,9 +872,9 @@ import java.util.Iterator;
                 return BitmapFactory
                         .decodeStream((InputStream) new URL(mGroundOverlayUrl).getContent());
             } catch (MalformedURLException e) {
-                e.printStackTrace();
+                return BitmapFactory.decodeFile(mGroundOverlayUrl);
             } catch (IOException e) {
-                e.printStackTrace();
+                Log.e(LOG_TAG, "Image [" + mGroundOverlayUrl + "] download issue", e);
             }
             return null;
         }

--- a/library/src/com/google/maps/android/kml/KmlStyle.java
+++ b/library/src/com/google/maps/android/kml/KmlStyle.java
@@ -1,11 +1,11 @@
 package com.google.maps.android.kml;
 
+import android.graphics.Color;
+
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import com.google.android.gms.maps.model.MarkerOptions;
 import com.google.android.gms.maps.model.PolygonOptions;
 import com.google.android.gms.maps.model.PolylineOptions;
-
-import android.graphics.Color;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -185,10 +185,6 @@ import java.util.Random;
      */
     /* package */ void setIconUrl(String iconUrl) {
         mIconUrl = iconUrl;
-        if (!mIconUrl.startsWith("http://")) {
-            // Icon stored locally
-            mMarkerOptions.icon(BitmapDescriptorFactory.fromPath(iconUrl));
-        }
         mStylesSet.add("iconUrl");
     }
 


### PR DESCRIPTION
Major problem with [BitmapDescriptorFactory.fromPath(iconUrl)](https://developers.google.com/android/reference/com/google/android/gms/maps/model/BitmapDescriptorFactory.html) is that it requires **absolute** path and throws RuntimeException if file not found.

But KML files are often created with tools and by people who are not really aware of Android filesystem which gives:
```xml
		<Style id='icon-ci-1-normal'>
			<IconStyle>
				<scale>1.1</scale>
				<Icon>
					<href>images/icon-1.png</href>
				</Icon>
			</IconStyle>
			<LabelStyle>
				<scale>0.0</scale>
			</LabelStyle>
		</Style>
```

And it would simply crash at `KmlStyle.setIconUrl`.

There are two approaches to solve this:
 - Use `BitmapFactory.decodeFile(mIconUrl)` if `mIconUrl` is not really an URL, but a path on local FS
 - Try to guess where the file is placed:
```java
        private Bitmap tryDecodeLocalBitmap() {
            InputStream stream = null;
            try {
                stream = mContext.getAssets().open(mImageUrl);
                return BitmapFactory.decodeStream(stream);
            } catch (IOException assetsIOE) {
                try {
                    stream = mContext.getContentResolver().openInputStream(Uri.parse(mImageUrl));
                    return BitmapFactory.decodeStream(stream);
                } catch (IOException contentIOE) {
                    return BitmapFactory.decodeFile(mImageUrl);
                }
            } finally {
                closeSilently(stream);
            }
        }
```

The issue with second approach is that it's not really deterministic - it can pick unwanted files. That's why we stick with simple strategy - just decode local file.

P.S. fix of https://github.com/googlemaps/android-maps-utils/issues/220