### PR TITLE
Null GeoJson feature properties

### DIFF
--- a/demo/src/com/google/maps/android/utils/demo/GeoJsonDemoActivity.java
+++ b/demo/src/com/google/maps/android/utils/demo/GeoJsonDemoActivity.java
@@ -63,7 +63,7 @@ public class GeoJsonDemoActivity extends BaseDemoActivity {
         // Iterate over all the features stored in the layer
         for (GeoJsonFeature feature : mLayer.getFeatures()) {
             // Check if the magnitude property exists
-            if (feature.hasProperty("mag") && feature.hasProperty("place")) {
+            if (feature.getProperty("mag") != null && feature.hasProperty("place")) {
                 double magnitude = Double.parseDouble(feature.getProperty("mag"));
 
                 // Get the icon for the feature

--- a/library/src/com/google/maps/android/geojson/GeoJsonParser.java
+++ b/library/src/com/google/maps/android/geojson/GeoJsonParser.java
@@ -196,7 +196,7 @@ import java.util.Iterator;
         Iterator propertyKeys = properties.keys();
         while (propertyKeys.hasNext()) {
             String key = (String) propertyKeys.next();
-            propertiesMap.put(key, properties.getString(key));
+            propertiesMap.put(key, properties.isNull(key) ? null : properties.getString(key));
         }
         return propertiesMap;
     }

--- a/library/tests/src/com/google/maps/android/geojson/GeoJsonFeatureTest.java
+++ b/library/tests/src/com/google/maps/android/geojson/GeoJsonFeatureTest.java
@@ -5,6 +5,8 @@ import com.google.android.gms.maps.model.LatLngBounds;
 
 import junit.framework.TestCase;
 
+import org.json.JSONObject;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -35,6 +37,15 @@ public class GeoJsonFeatureTest extends TestCase {
         assertEquals("5", feature.removeProperty("Width"));
         assertNull(feature.setProperty("Width", "10"));
         assertEquals("10", feature.setProperty("Width", "500"));
+    }
+
+    public void testNullProperty() throws Exception {
+        GeoJsonLayer layer = new GeoJsonLayer(null, createFeatureCollection());
+        GeoJsonFeature feature = layer.getFeatures().iterator().next();
+        assertTrue(feature.hasProperty("prop0"));
+        assertNull(feature.getProperty("prop0"));
+        assertFalse(feature.hasProperty("prop1"));
+        assertNull(feature.getProperty("prop1"));
     }
 
     public void testPointStyle() {
@@ -108,5 +119,19 @@ public class GeoJsonFeatureTest extends TestCase {
         assertEquals(boundingBox, feature.getBoundingBox());
     }
 
+    private JSONObject createFeatureCollection() throws Exception {
+        return new JSONObject(
+                "{ \"type\": \"FeatureCollection\",\n"
+                        + "\"bbox\": [-150.0, -80.0, 150.0, 80.0],"
+                        + "    \"features\": [\n"
+                        + "      { \"type\": \"Feature\",\n"
+                        + "        \"id\": \"point\", \n"
+                        + "        \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]},\n"
+                        + "        \"properties\": {\"prop0\": null}\n"
+                        + "        }\n"
+                        + "       ]\n"
+                        + "     }"
+        );
+    }
 
 }


### PR DESCRIPTION
GeoJson can contain null values, but the parser stored them as the string "null", this fixes that.

@markmcd PTAL
