### PR TITLE
Handle KML colors with missing leading zero

### DIFF
--- a/library/src/com/google/maps/android/kml/KmlStyle.java
+++ b/library/src/com/google/maps/android/kml/KmlStyle.java
@@ -233,10 +233,14 @@ import java.util.Random;
         String newColor;
         if (color.length() > 6) {
             newColor = color.substring(0, 2) + color.substring(6, 8)
-                    + color.substring(4,6)+ color.substring(2, 4);
+                    + color.substring(4, 6)+ color.substring(2, 4);
         } else {
-            newColor = color.substring(4,6) + color.substring(2,4) +
-                    color.substring(0,2);
+            newColor = color.substring(4, 6) + color.substring(2, 4) +
+                    color.substring(0, 2);
+        }
+        // Maps exports KML colors with a leading 0 as a space.
+        if (newColor.substring(0, 1).equals(" ")) {
+            newColor = "0" + newColor.substring(1, newColor.length());
         }
         return newColor;
     }

--- a/library/tests/src/com/google/maps/android/kml/KmlStyleTest.java
+++ b/library/tests/src/com/google/maps/android/kml/KmlStyleTest.java
@@ -29,6 +29,16 @@ public class KmlStyleTest extends TestCase {
         assertEquals(fillColor, kmlStyle.getPolygonOptions().getFillColor());
     }
 
+    public void testColorFormatting() throws Exception {
+        KmlStyle kmlStyle = new KmlStyle();
+        // AABBGGRR -> AARRGGBB.
+        kmlStyle.setFillColor("ff579D00");
+        assertEquals(Color.parseColor("#009D57"), kmlStyle.getPolygonOptions().getFillColor());
+        // Alpha w/ missing 0.
+        kmlStyle.setFillColor(" D579D00");
+        assertEquals(Color.parseColor("#0D009D57"), kmlStyle.getPolygonOptions().getFillColor());
+    }
+
     public void testHeading() throws Exception {
         KmlStyle kmlStyle = new KmlStyle();
         assertNotNull(kmlStyle);
@@ -67,12 +77,5 @@ public class KmlStyleTest extends TestCase {
         assertNotNull(kmlStyle);
         assertNotNull(kmlStyle.getMarkerOptions());
     }
-
-
-
-
-
-
-
 
 }


### PR DESCRIPTION
As reported in #232 - I've verified My Maps exports KML colors as reported.

@markmcd PTAL