### PR TITLE
New camera listeners

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,13 @@ buildscript {
     }
 }
 
+allprojects {
+    repositories {
+        mavenLocal()
+        jcenter()
+    }
+}
+
 /**
  * Improve build server performance by allowing disabling of pre-dexing
  * (see http://tools.android.com/tech-docs/new-build-system/tips#TOC-Improving-Build-Server-performance.)

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     compile project(':library')
     // Or, fetch from Maven:
     // compile 'com.google.maps.android:android-maps-utils:0.3+'
-    compile 'com.google.android.gms:play-services-maps:9.2.0'
+    compile 'com.google.android.gms:play-services-maps:9.4.0'
 }
 
 android {

--- a/demo/src/com/google/maps/android/utils/demo/BigClusteringDemoActivity.java
+++ b/demo/src/com/google/maps/android/utils/demo/BigClusteringDemoActivity.java
@@ -37,7 +37,7 @@ public class BigClusteringDemoActivity extends BaseDemoActivity {
 
         mClusterManager = new ClusterManager<MyItem>(this, getMap());
 
-        getMap().setOnCameraChangeListener(mClusterManager);
+        getMap().setOnCameraIdleListener(mClusterManager);
         try {
             readItems();
         } catch (JSONException e) {

--- a/demo/src/com/google/maps/android/utils/demo/ClusteringDemoActivity.java
+++ b/demo/src/com/google/maps/android/utils/demo/ClusteringDemoActivity.java
@@ -20,7 +20,6 @@ import android.widget.Toast;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.model.LatLng;
-import com.google.maps.android.clustering.Cluster;
 import com.google.maps.android.clustering.ClusterManager;
 import com.google.maps.android.utils.demo.model.MyItem;
 
@@ -40,7 +39,7 @@ public class ClusteringDemoActivity extends BaseDemoActivity {
         getMap().moveCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(51.503186, -0.126446), 10));
 
         mClusterManager = new ClusterManager<MyItem>(this, getMap());
-        getMap().setOnCameraChangeListener(mClusterManager);
+        getMap().setOnCameraIdleListener(mClusterManager);
 
         try {
             readItems();

--- a/demo/src/com/google/maps/android/utils/demo/CustomMarkerClusteringDemoActivity.java
+++ b/demo/src/com/google/maps/android/utils/demo/CustomMarkerClusteringDemoActivity.java
@@ -161,7 +161,7 @@ public class CustomMarkerClusteringDemoActivity extends BaseDemoActivity impleme
 
         mClusterManager = new ClusterManager<Person>(this, getMap());
         mClusterManager.setRenderer(new PersonRenderer());
-        getMap().setOnCameraChangeListener(mClusterManager);
+        getMap().setOnCameraIdleListener(mClusterManager);
         getMap().setOnMarkerClickListener(mClusterManager);
         getMap().setOnInfoWindowClickListener(mClusterManager);
         mClusterManager.setOnClusterClickListener(this);

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -6,9 +6,8 @@ archivesBaseName = 'android-maps-utils'
 group = 'com.google.maps.android'
 
 dependencies {
-    compile 'com.google.android.gms:play-services-maps:9.2.0'
+    compile 'com.google.android.gms:play-services-maps:9.4.0'
 }
-
 
 android {
     compileSdkVersion 23

--- a/library/src/com/google/maps/android/clustering/ClusterManager.java
+++ b/library/src/com/google/maps/android/clustering/ClusterManager.java
@@ -38,10 +38,14 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 /**
  * Groups many items on a map based on zoom level.
  * <p/>
- * ClusterManager should be added to the map as an: <ul> <li>{@link com.google.android.gms.maps.GoogleMap.OnCameraChangeListener}</li>
+ * ClusterManager should be added to the map as an: <ul> <li>{@link com.google.android.gms.maps.GoogleMap.OnCameraIdleListener}</li>
  * <li>{@link com.google.android.gms.maps.GoogleMap.OnMarkerClickListener}</li> </ul>
  */
-public class ClusterManager<T extends ClusterItem> implements GoogleMap.OnCameraChangeListener, GoogleMap.OnMarkerClickListener, GoogleMap.OnInfoWindowClickListener {
+public class ClusterManager<T extends ClusterItem> implements
+        GoogleMap.OnCameraIdleListener,
+        GoogleMap.OnMarkerClickListener,
+        GoogleMap.OnInfoWindowClickListener {
+
     private final MarkerManager mMarkerManager;
     private final MarkerManager.Collection mMarkers;
     private final MarkerManager.Collection mClusterMarkers;
@@ -181,13 +185,11 @@ public class ClusterManager<T extends ClusterItem> implements GoogleMap.OnCamera
 
     /**
      * Might re-cluster.
-     *
-     * @param cameraPosition
      */
     @Override
-    public void onCameraChange(CameraPosition cameraPosition) {
-        if (mRenderer instanceof GoogleMap.OnCameraChangeListener) {
-            ((GoogleMap.OnCameraChangeListener) mRenderer).onCameraChange(cameraPosition);
+    public void onCameraIdle() {
+        if (mRenderer instanceof GoogleMap.OnCameraIdleListener) {
+            ((GoogleMap.OnCameraIdleListener) mRenderer).onCameraIdle();
         }
 
         // Don't re-compute clusters if the map has just been panned/tilted/rotated.


### PR DESCRIPTION
Updates deprecated camera listener in clustering, as per: https://developers.google.com/maps/documentation/android-api/events#camera_change_events

PTAL @markmcd 