### PR TITLE
Fix #284 - Tweak Travis script to fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,15 @@ env:
     - ANDROID_API_LEVEL=23
     - EMULATOR_API_LEVEL=21
     - ANDROID_BUILD_TOOLS_VERSION=23.0.2
-    - ANDROID_ABI=google_apis/armeabi-v7a
+    - ANDROID_ABI=armeabi-v7a
+    - ANDROID_TAG=google_apis
     - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)
 
 android:
   components:
+    - tools # to get the new `repository-11.xml`
     - platform-tools
-    - tools
+    - tools # to install Android SDK tools 25.1.x
     - build-tools-$ANDROID_BUILD_TOOLS_VERSION
     - android-$ANDROID_API_LEVEL
     - android-$EMULATOR_API_LEVEL
@@ -34,12 +36,12 @@ android:
     - extra-google-m2repository
     - extra-android-m2repository
     # Specify at least one system image
-    - sys-img-armeabi-v7a-addon-google_apis-google-$ANDROID_API_LEVEL
-    - sys-img-armeabi-v7a-addon-google_apis-google-$EMULATOR_API_LEVEL
+    - sys-img-armeabi-v7a-google_apis-$ANDROID_API_LEVEL
+    - sys-img-armeabi-v7a-google_apis-$EMULATOR_API_LEVEL
 
 before_script:
   # Create and start emulator
-  - echo no | android create avd --force -n test -t "Google Inc.:Google APIs:"$EMULATOR_API_LEVEL --abi $ANDROID_ABI
+  - echo no | android create avd --force -n test -t "android-"$EMULATOR_API_LEVEL --abi $ANDROID_ABI --tag $ANDROID_TAG
   - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
 


### PR DESCRIPTION
* Add separate ANDOID_TAG ABI tag variable
* Duplicate tools to get the new `repository-11.xml` and to install Android SDK tools 25.1.x
* Change system image names to match new Android SDK
* Change emulator start command to use new ABI tag variable to specify Google APIs

See https://github.com/travis-ci/travis-ci/issues/6122#issuecomment-239073557 for details.

I tested this patch and [it passes](https://travis-ci.org/barbeau/android-maps-utils/builds/151550713).

A huuuuuge thanks to @ardock who shared his solution in the above Travis CI issue. :+1: :+1: 