### PR TITLE
Add new containsLocation() that takes latitude and longitude instead `LatLng`

### DIFF
--- a/library/src/com/google/maps/android/PolyUtil.java
+++ b/library/src/com/google/maps/android/PolyUtil.java
@@ -87,6 +87,10 @@ public class PolyUtil {
             mercator(lat3) >= mercatorLatRhumb(lat1, lat2, lng2, lng3);
     }
 
+    public static boolean containsLocation(LatLng point, List<LatLng> polygon, boolean geodesic) {
+        return containsLocation(point.latitude, point.longitude, polygon, geodesic);
+    }
+
     /**
      * Computes whether the given point lies inside the specified polygon.
      * The polygon is always considered closed, regardless of whether the last point equals
@@ -95,13 +99,13 @@ public class PolyUtil {
      * The polygon is formed of great circle segments if geodesic is true, and of rhumb
      * (loxodromic) segments otherwise.
      */
-    public static boolean containsLocation(LatLng point, List<LatLng> polygon, boolean geodesic) {
+    public static boolean containsLocation(double latitude, double longitude, List<LatLng> polygon, boolean geodesic) {
         final int size = polygon.size();
         if (size == 0) {
             return false;
         }
-        double lat3 = toRadians(point.latitude);
-        double lng3 = toRadians(point.longitude);
+        double lat3 = toRadians(latitude);
+        double lng3 = toRadians(longitude);
         LatLng prev = polygon.get(size - 1);
         double lat1 = toRadians(prev.latitude);
         double lng1 = toRadians(prev.longitude);


### PR DESCRIPTION
In our project, we use different data structure to represent coordinates rather than `LatLng`. As a result, in order to utilize `containsLocation()`, we have to convert into `LatLng` which causes an allocation. So if we call it inside a loop through a list of coordinates, that will cause a lot more allocations.

For example:
```java
for (Location location : locations) {
  if (PolyUtil.containsLocation(new LatLng(location.lat(), location.lng()), polygon, true)) {
    return true;
  }
}
```

So it'd be better if we don't allocate `LatLng`s:
```java
for (Location location : locations) {
  if (PolyUtil.containsLocation(location.lat(), location.lng(), polygon, true)) {
    return true;
  }
}
```