### PR TITLE
Improve PolyUtil.isLocationOnPath to also tell where the location is on the polyline

### DIFF
--- a/library/src/com/google/maps/android/PolyUtil.java
+++ b/library/src/com/google/maps/android/PolyUtil.java
@@ -178,20 +178,22 @@ public class PolyUtil {
     }
 
     /**
-     * Computes whether (and where) the given point lies on or near a polyline, within a specified
-     * tolerance in meters. The polyline is composed of great circle segments if geodesic
-     * is true, and of Rhumb segments otherwise. The polyline is not closed -- the closing
-     * segment between the first point and the last point is not included.
-     * Return values:
-     * 0 if point is between poly[0] and poly[1] (inclusive),
-     * 1 if between poly[1] and poly[2],
-     * ...,
-     * poly.size()-2 if between poly[poly.size() - 2] and poly[poly.size() - 1]
-     * -1 if point does not lie on or near the polyline.
+     * Computes whether (and where) a given point lies on or near a polyline, within a specified tolerance.
+     * The polyline is not closed -- the closing segment between the first point and the last point is not included.
+     * @param point our needle
+     * @param poly our haystack
+     * @param geodesic the polyline is composed of great circle segments if geodesic
+     *                 is true, and of Rhumb segments otherwise
+     * @param tolerance tolerance (in meters)
+     * @return -1 if point does not lie on or near the polyline.
+     *          0 if point is between poly[0] and poly[1] (inclusive),
+     *          1 if between poly[1] and poly[2],
+     *          ...,
+     *          poly.size()-2 if between poly[poly.size() - 2] and poly[poly.size() - 1]
      */
-    public static int locationIndexOnPath(LatLng point, List<LatLng> polyline,
+    public static int locationIndexOnPath(LatLng point, List<LatLng> poly,
                                            boolean geodesic, double tolerance) {
-        return locationIndexOnEdgeOrPath(point, polyline, false, geodesic, tolerance);
+        return locationIndexOnEdgeOrPath(point, poly, false, geodesic, tolerance);
     }
 
     /**
@@ -205,16 +207,19 @@ public class PolyUtil {
     }
 
     /**
-     * Computes whether (and where) the given point lies on or near a polyline, within a specified
-     * tolerance in meters. The polyline is composed of great circle segments if geodesic
-     * is true, and of Rhumb segments otherwise.
+     * Computes whether (and where) a given point lies on or near a polyline, within a specified tolerance.
      * If closed, the closing segment between the last and first points of the polyline is not considered.
-     * Return values:
-     * -1 if point does not lie on or near the polyline.
-     * 0 if point is between poly[0] and poly[1] (inclusive),
-     * 1 if between poly[1] and poly[2],
-     * ...,
-     * poly.size()-2 if between poly[poly.size() - 2] and poly[poly.size() - 1]
+     * @param point our needle
+     * @param poly our haystack
+     * @param closed whether the polyline should be considered closed by a segment connecting the last point back to the first one
+     * @param geodesic the polyline is composed of great circle segments if geodesic
+     *                 is true, and of Rhumb segments otherwise
+     * @param toleranceEarth tolerance (in meters)
+     * @return -1 if point does not lie on or near the polyline.
+     *          0 if point is between poly[0] and poly[1] (inclusive),
+     *          1 if between poly[1] and poly[2],
+     *          ...,
+     *          poly.size()-2 if between poly[poly.size() - 2] and poly[poly.size() - 1]
      */
     private static int locationIndexOnEdgeOrPath(LatLng point, List<LatLng> poly, boolean closed,
                                           boolean geodesic, double toleranceEarth) {

--- a/library/src/com/google/maps/android/PolyUtil.java
+++ b/library/src/com/google/maps/android/PolyUtil.java
@@ -178,10 +178,12 @@ public class PolyUtil {
     }
 
     /**
-     * Computes whether (add where) the given point lies on or near a polyline, within a specified
+     * Computes whether (and where) the given point lies on or near a polyline, within a specified
      * tolerance in meters. The polyline is composed of great circle segments if geodesic
      * is true, and of Rhumb segments otherwise. The polyline is not closed -- the closing
      * segment between the first point and the last point is not included.
+     * Returns 0 if point is between poly[0] and poly[1], 1 if between poly[1] and poly[2], etc.
+     * Returns a negative value if point does not lie on or near the polyline.
      */
     public static int locationIndexOnPath(LatLng point, List<LatLng> polyline,
                                            boolean geodesic, double tolerance) {

--- a/library/src/com/google/maps/android/PolyUtil.java
+++ b/library/src/com/google/maps/android/PolyUtil.java
@@ -182,8 +182,12 @@ public class PolyUtil {
      * tolerance in meters. The polyline is composed of great circle segments if geodesic
      * is true, and of Rhumb segments otherwise. The polyline is not closed -- the closing
      * segment between the first point and the last point is not included.
-     * Returns 0 if point is between poly[0] and poly[1], 1 if between poly[1] and poly[2], etc.
-     * Returns a negative value if point does not lie on or near the polyline.
+     * Return values:
+     * 0 if point is between poly[0] and poly[1] (inclusive),
+     * 1 if between poly[1] and poly[2],
+     * ...,
+     * poly.size()-2 if between poly[poly.size() - 2] and poly[poly.size() - 1]
+     * -1 if point does not lie on or near the polyline.
      */
     public static int locationIndexOnPath(LatLng point, List<LatLng> polyline,
                                            boolean geodesic, double tolerance) {
@@ -200,6 +204,18 @@ public class PolyUtil {
         return locationIndexOnPath(point, polyline, geodesic, DEFAULT_TOLERANCE);
     }
 
+    /**
+     * Computes whether (and where) the given point lies on or near a polyline, within a specified
+     * tolerance in meters. The polyline is composed of great circle segments if geodesic
+     * is true, and of Rhumb segments otherwise.
+     * If closed, the closing segment between the last and first points of the polyline is not considered.
+     * Return values:
+     * -1 if point does not lie on or near the polyline.
+     * 0 if point is between poly[0] and poly[1] (inclusive),
+     * 1 if between poly[1] and poly[2],
+     * ...,
+     * poly.size()-2 if between poly[poly.size() - 2] and poly[poly.size() - 1]
+     */
     private static int locationIndexOnEdgeOrPath(LatLng point, List<LatLng> poly, boolean closed,
                                           boolean geodesic, double toleranceEarth) {
         int size = poly.size();
@@ -219,7 +235,7 @@ public class PolyUtil {
                 double lat2 = toRadians(point2.latitude);
                 double lng2 = toRadians(point2.longitude);
                 if (isOnSegmentGC(lat1, lng1, lat2, lng2, lat3, lng3, havTolerance)) {
-                    return idx;
+                    return Math.max(0, idx - 1);
                 }
                 lat1 = lat2;
                 lng1 = lng2;
@@ -257,7 +273,7 @@ public class PolyUtil {
                         double latClosest = inverseMercator(yClosest);
                         double havDist = havDistance(lat3, latClosest, x3 - xClosest);
                         if (havDist < havTolerance) {
-                            return idx;
+                            return Math.max(0, idx - 1);
                         }
                     }
                 }

--- a/library/tests/src/com/google/maps/android/PolyUtilTest.java
+++ b/library/tests/src/com/google/maps/android/PolyUtilTest.java
@@ -81,6 +81,16 @@ public class PolyUtilTest extends TestCase {
         locationIndexCase(false, poly, point, idx);
     }
 
+    private static void locationIndexToleranceCase(boolean geodesic,
+                                          List<LatLng> poly, LatLng point, double tolerance, int idx) {
+        Assert.assertTrue(idx == PolyUtil.locationIndexOnPath(point, poly, geodesic, tolerance));
+    }
+
+    private static void locationIndexToleranceCase(List<LatLng> poly, LatLng point, double tolerance, int idx) {
+        locationIndexToleranceCase(true, poly, point, tolerance, idx);
+        locationIndexToleranceCase(false, poly, point, tolerance, idx);
+    }
+
     public void testOnEdge() {
         // Empty
         onEdgeCase(makeList(), makeList(), makeList(0, 0));
@@ -136,9 +146,6 @@ public class PolyUtilTest extends TestCase {
     }
 
     public void testLocationIndex() {
-        final double small = 5e-7;  // About 5m on equator, half the default tolerance.
-        final double big   = 2e-6;  // About 10cm on equator, double the default tolerance.
-
         // Empty.
         locationIndexCase(makeList(), new LatLng(0, 0), -1);
 
@@ -151,14 +158,27 @@ public class PolyUtilTest extends TestCase {
         locationIndexCase(makeList(1, 2, 3, 5), new LatLng(3, 5), 0);
         locationIndexCase(makeList(1, 2, 3, 5), new LatLng(4, 6), -1);
 
-        // Three points on equator.
-        locationIndexCase(makeList(0, 90-small, 0, 90, 0, 90+small), new LatLng(0, 90), 0);
-        locationIndexCase(makeList(0, 90-small, 0, 90, 0, 90+small), new LatLng(0, 90+small), 0);
-        locationIndexCase(makeList(0, 90-small, 0, 90, 0, 90+small), new LatLng(0, 90+2*small), 1);
-        locationIndexCase(makeList(0, 90-small, 0, 90, 0, 90+small), new LatLng(0, 90+3*small), -1);
-        locationIndexCase(makeList(0, 90-big, 0, 90, 0, 90+big), new LatLng(0, 90), 0);
-        locationIndexCase(makeList(0, 90-big, 0, 90, 0, 90+big), new LatLng(0, 90+big), 1);
-        locationIndexCase(makeList(0, 90-big, 0, 90, 0, 90+big), new LatLng(0, 90+2*big), -1);
+        // Three points.
+        locationIndexCase(makeList(0, 80, 0, 90, 0, 100), new LatLng(0, 80), 0);
+        locationIndexCase(makeList(0, 80, 0, 90, 0, 100), new LatLng(0, 85), 0);
+        locationIndexCase(makeList(0, 80, 0, 90, 0, 100), new LatLng(0, 90), 0);
+        locationIndexCase(makeList(0, 80, 0, 90, 0, 100), new LatLng(0, 95), 1);
+        locationIndexCase(makeList(0, 80, 0, 90, 0, 100), new LatLng(0, 100), 1);
+        locationIndexCase(makeList(0, 80, 0, 90, 0, 100), new LatLng(0, 110), -1);
+    }
+
+    public void testLocationIndexTolerance() {
+        final double small = 5e-7;  // About 5cm on equator, half the default tolerance.
+        final double big   = 2e-6;  // About 10cm on equator, double the default tolerance.
+
+        // Test tolerance.
+        locationIndexToleranceCase(makeList(0, 90-small, 0, 90, 0, 90+small), new LatLng(0, 90), 0.1, 0);
+        locationIndexToleranceCase(makeList(0, 90-small, 0, 90, 0, 90+small), new LatLng(0, 90+small), 0.1, 0);
+        locationIndexToleranceCase(makeList(0, 90-small, 0, 90, 0, 90+small), new LatLng(0, 90+2*small), 0.1, 1);
+        locationIndexToleranceCase(makeList(0, 90-small, 0, 90, 0, 90+small), new LatLng(0, 90+3*small), 0.1, -1);
+        locationIndexToleranceCase(makeList(0, 90-big, 0, 90, 0, 90+big), new LatLng(0, 90), 0.1, 0);
+        locationIndexToleranceCase(makeList(0, 90-big, 0, 90, 0, 90+big), new LatLng(0, 90+big), 0.1, 1);
+        locationIndexToleranceCase(makeList(0, 90-big, 0, 90, 0, 90+big), new LatLng(0, 90+2*big), 0.1, -1);
     }
 
     public void testContainsLocation() {

--- a/library/tests/src/com/google/maps/android/PolyUtilTest.java
+++ b/library/tests/src/com/google/maps/android/PolyUtilTest.java
@@ -65,12 +65,22 @@ public class PolyUtilTest extends TestCase {
             Assert.assertFalse(PolyUtil.isLocationOnPath(point, poly, geodesic));
         }
     }
-    
+
     private static void onEdgeCase(List<LatLng> poly, List<LatLng> yes, List<LatLng> no) {
         onEdgeCase(true, poly, yes, no);
         onEdgeCase(false, poly, yes, no);
     }
-    
+
+    private static void locationIndexCase(boolean geodesic,
+                                          List<LatLng> poly, LatLng point, int idx) {
+        Assert.assertTrue(idx == PolyUtil.locationIndexOnPath(point, poly, geodesic));
+    }
+
+    private static void locationIndexCase(List<LatLng> poly, LatLng point, int idx) {
+        locationIndexCase(true, poly, point, idx);
+        locationIndexCase(false, poly, point, idx);
+    }
+
     public void testOnEdge() {
         // Empty
         onEdgeCase(makeList(), makeList(), makeList(0, 0));
@@ -123,6 +133,28 @@ public class PolyUtilTest extends TestCase {
         onEdgeCase(false, makeList(80, 0, 80, 180-small),
                    makeList(80-small, 0, 80+small, 0, 80, 90),
                    makeList(79, big, 90-small, -90, 90, -135));
+    }
+
+    public void testLocationIndex() {
+        final double small = 5e-7;  // About 5cm on equator, half the default tolerance.
+        final double big   = 2e-6;  // About 10cm on equator, double the default tolerance.
+
+        // Empty.
+        locationIndexCase(makeList(), new LatLng(0, 0), -1);
+
+        // One point.
+        locationIndexCase(makeList(1, 2), new LatLng(1, 2), 0);
+        locationIndexCase(makeList(1, 2), new LatLng(3, 5), -1);
+
+        // Two points.
+        locationIndexCase(makeList(1, 2, 3, 5), new LatLng(1, 2), 0);
+        locationIndexCase(makeList(1, 2, 3, 5), new LatLng(3, 5), 1);
+        locationIndexCase(makeList(1, 2, 3, 5), new LatLng(4, 6), -1);
+
+        // Three points on equator.
+        locationIndexCase(makeList(0, 90-small, 0, 90, 0, 90+small), new LatLng(0, 90), 0);
+        locationIndexCase(makeList(0, 90-big, 0, 90, 0, 90+big), new LatLng(0, 90), 1);
+        locationIndexCase(makeList(0, 90-small, 0, 90, 0, 90+small), new LatLng(0, 90+big), -1);
     }
 
     public void testContainsLocation() {

--- a/library/tests/src/com/google/maps/android/PolyUtilTest.java
+++ b/library/tests/src/com/google/maps/android/PolyUtilTest.java
@@ -136,7 +136,7 @@ public class PolyUtilTest extends TestCase {
     }
 
     public void testLocationIndex() {
-        final double small = 5e-7;  // About 5cm on equator, half the default tolerance.
+        final double small = 5e-7;  // About 5m on equator, half the default tolerance.
         final double big   = 2e-6;  // About 10cm on equator, double the default tolerance.
 
         // Empty.
@@ -148,13 +148,17 @@ public class PolyUtilTest extends TestCase {
 
         // Two points.
         locationIndexCase(makeList(1, 2, 3, 5), new LatLng(1, 2), 0);
-        locationIndexCase(makeList(1, 2, 3, 5), new LatLng(3, 5), 1);
+        locationIndexCase(makeList(1, 2, 3, 5), new LatLng(3, 5), 0);
         locationIndexCase(makeList(1, 2, 3, 5), new LatLng(4, 6), -1);
 
         // Three points on equator.
         locationIndexCase(makeList(0, 90-small, 0, 90, 0, 90+small), new LatLng(0, 90), 0);
-        locationIndexCase(makeList(0, 90-big, 0, 90, 0, 90+big), new LatLng(0, 90), 1);
-        locationIndexCase(makeList(0, 90-small, 0, 90, 0, 90+small), new LatLng(0, 90+big), -1);
+        locationIndexCase(makeList(0, 90-small, 0, 90, 0, 90+small), new LatLng(0, 90+small), 0);
+        locationIndexCase(makeList(0, 90-small, 0, 90, 0, 90+small), new LatLng(0, 90+2*small), 1);
+        locationIndexCase(makeList(0, 90-small, 0, 90, 0, 90+small), new LatLng(0, 90+3*small), -1);
+        locationIndexCase(makeList(0, 90-big, 0, 90, 0, 90+big), new LatLng(0, 90), 0);
+        locationIndexCase(makeList(0, 90-big, 0, 90, 0, 90+big), new LatLng(0, 90+big), 1);
+        locationIndexCase(makeList(0, 90-big, 0, 90, 0, 90+big), new LatLng(0, 90+2*big), -1);
     }
 
     public void testContainsLocation() {

--- a/library/tests/src/com/google/maps/android/data/kml/KmlPolygonTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlPolygonTest.java
@@ -5,7 +5,6 @@ import com.google.android.gms.maps.model.LatLng;
 import junit.framework.TestCase;
 
 import java.util.ArrayList;
-import java.util.List;
 
 public class KmlPolygonTest extends TestCase {
 
@@ -17,13 +16,13 @@ public class KmlPolygonTest extends TestCase {
     }
 
     public KmlPolygon createRegularPolygon() {
-        List<LatLng> outerCoordinates = new ArrayList<LatLng>();
+        ArrayList<LatLng> outerCoordinates = new ArrayList<LatLng>();
         outerCoordinates.add(new LatLng(10, 10));
         outerCoordinates.add(new LatLng(20, 20));
         outerCoordinates.add(new LatLng(30, 30));
         outerCoordinates.add(new LatLng(10, 10));
-        List<List<LatLng>> innerCoordinates = new  ArrayList<List<LatLng>>();
-        List<LatLng> innerHole = new ArrayList<LatLng>();
+        ArrayList<ArrayList<LatLng>> innerCoordinates = new  ArrayList<ArrayList<LatLng>>();
+        ArrayList<LatLng> innerHole = new ArrayList<LatLng>();
         innerHole.add(new LatLng(20, 20));
         innerHole.add(new LatLng(10, 10));
         innerHole.add(new LatLng(20, 20));

--- a/library/tests/src/com/google/maps/android/data/kml/KmlPolygonTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlPolygonTest.java
@@ -5,6 +5,7 @@ import com.google.android.gms.maps.model.LatLng;
 import junit.framework.TestCase;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class KmlPolygonTest extends TestCase {
 
@@ -16,13 +17,13 @@ public class KmlPolygonTest extends TestCase {
     }
 
     public KmlPolygon createRegularPolygon() {
-        ArrayList<LatLng> outerCoordinates = new ArrayList<LatLng>();
+        List<LatLng> outerCoordinates = new ArrayList<LatLng>();
         outerCoordinates.add(new LatLng(10, 10));
         outerCoordinates.add(new LatLng(20, 20));
         outerCoordinates.add(new LatLng(30, 30));
         outerCoordinates.add(new LatLng(10, 10));
-        ArrayList<ArrayList<LatLng>> innerCoordinates = new  ArrayList<ArrayList<LatLng>>();
-        ArrayList<LatLng> innerHole = new ArrayList<LatLng>();
+        List<List<LatLng>> innerCoordinates = new  ArrayList<List<LatLng>>();
+        List<LatLng> innerHole = new ArrayList<LatLng>();
         innerHole.add(new LatLng(20, 20));
         innerHole.add(new LatLng(10, 10));
         innerHole.add(new LatLng(20, 20));


### PR DESCRIPTION
The methods provided to know whether a given location lies on the path of a polyline are good, but they could be even better if they also told where on the polyline the location is.

This in turn allows, for instance, to tap on any point on a polyline and get statistical information about the tapped point:
![screenshot_20170222-000613-640](https://cloud.githubusercontent.com/assets/475725/23190435/1882050a-f898-11e6-86a8-20d1ae65cb6e.png)
