### PR TITLE
Handle altitudes and parse Track and MultiTrack objects

### DIFF
--- a/library/src/com/google/maps/android/data/geojson/GeoJsonLineString.java
+++ b/library/src/com/google/maps/android/data/geojson/GeoJsonLineString.java
@@ -10,6 +10,7 @@ import java.util.List;
  * com.google.android.gms.maps.model.LatLng}s.
  */
 public class GeoJsonLineString extends LineString {
+    private final List<Double> mAltitudes;
 
     /**
      * Creates a new GeoJsonLineString object
@@ -17,7 +18,19 @@ public class GeoJsonLineString extends LineString {
      * @param coordinates list of coordinates of GeoJsonLineString to store
      */
     public GeoJsonLineString(List<LatLng> coordinates) {
+        this(coordinates, null);
+    }
+
+    /**
+     * Creates a new GeoJsonLineString object
+     *
+     * @param coordinates array of coordinates
+     * @param altitudes array of altitudes
+     */
+    public GeoJsonLineString(List<LatLng> coordinates, List<Double> altitudes) {
         super(coordinates);
+
+        this.mAltitudes = altitudes;
     }
 
     /**
@@ -37,5 +50,14 @@ public class GeoJsonLineString extends LineString {
      */
     public List<LatLng> getCoordinates() {
         return getGeometryObject();
+    }
+
+    /**
+     * Gets the altitudes of the GeoJsonLineString
+     *
+     * @return list of altitudes of the GeoJsonLineString
+     */
+    public List <Double> getAltitudes() {
+        return mAltitudes;
     }
 }

--- a/library/src/com/google/maps/android/data/geojson/GeoJsonParser.java
+++ b/library/src/com/google/maps/android/data/geojson/GeoJsonParser.java
@@ -72,6 +72,21 @@ import java.util.Iterator;
     private LatLngBounds mBoundingBox;
 
     /**
+     * Internal helper class to store latLng and altitude in a single object.
+     * This allows to parse [lon,lat,altitude] tuples in GeoJson files more efficiently.
+     * Note that altitudes are generally optional so they can be null.
+     */
+    private static class LatLngAlt {
+        public final LatLng latLng;
+        public final Double altitude;
+
+        LatLngAlt(LatLng latLng, Double altitude) {
+            this.latLng = latLng;
+            this.altitude = altitude;
+        }
+    }
+
+    /**
      * Creates a new GeoJsonParser
      *
      * @param geoJsonFile GeoJSON file to parse
@@ -235,7 +250,8 @@ import java.util.Iterator;
      * @throws JSONException if coordinates cannot be parsed
      */
     private static GeoJsonPoint createPoint(JSONArray coordinates) throws JSONException {
-        return new GeoJsonPoint(parseCoordinate(coordinates));
+        LatLngAlt latLngAlt = parseCoordinate(coordinates);
+        return new GeoJsonPoint(latLngAlt.latLng, latLngAlt.altitude);
     }
 
     /**
@@ -261,7 +277,18 @@ import java.util.Iterator;
      * @throws JSONException if coordinates cannot be parsed
      */
     private static GeoJsonLineString createLineString(JSONArray coordinates) throws JSONException {
-        return new GeoJsonLineString(parseCoordinatesArray(coordinates));
+        ArrayList<LatLngAlt> latLngAlts = parseCoordinatesArray(coordinates);
+        ArrayList<LatLng> latLngs = new ArrayList<>();
+        ArrayList<Double> altitudes = new ArrayList<>();
+
+        for (LatLngAlt latLngAlt : latLngAlts) {
+            latLngs.add(latLngAlt.latLng);
+            if (latLngAlt.altitude != null) {
+                altitudes.add(latLngAlt.altitude);
+            }
+        }
+
+        return new GeoJsonLineString(latLngs, altitudes);
     }
 
     /**
@@ -331,15 +358,18 @@ import java.util.Iterator;
     }
 
     /**
-     * Parses an array containing a coordinate into a LatLng object
+     * Parses an array containing a coordinate into a LatLngAlt object
      *
      * @param coordinates array containing the GeoJSON coordinate
-     * @return LatLng object
+     * @return LatLngAlt object
      * @throws JSONException if coordinate cannot be parsed
      */
-    private static LatLng parseCoordinate(JSONArray coordinates) throws JSONException {
+    private static LatLngAlt parseCoordinate(JSONArray coordinates) throws JSONException {
         // GeoJSON stores coordinates as Lng, Lat so we need to reverse
-        return new LatLng(coordinates.getDouble(1), coordinates.getDouble(0));
+        LatLng latLng = new LatLng(coordinates.getDouble(1), coordinates.getDouble(0));
+        Double altitude = (coordinates.length() < 3) ? null : coordinates.getDouble(2);
+
+        return new LatLngAlt(latLng, altitude);
     }
 
     /**
@@ -349,9 +379,9 @@ import java.util.Iterator;
      * @return ArrayList of LatLng objects
      * @throws JSONException if coordinates cannot be parsed
      */
-    private static ArrayList<LatLng> parseCoordinatesArray(JSONArray coordinates)
+    private static ArrayList<LatLngAlt> parseCoordinatesArray(JSONArray coordinates)
             throws JSONException {
-        ArrayList<LatLng> coordinatesArray = new ArrayList<>();
+        ArrayList<LatLngAlt> coordinatesArray = new ArrayList<>();
         for (int i = 0; i < coordinates.length(); i++) {
             coordinatesArray.add(parseCoordinate(coordinates.getJSONArray(i)));
         }
@@ -370,7 +400,13 @@ import java.util.Iterator;
             throws JSONException {
         ArrayList<ArrayList<LatLng>> coordinatesArray = new ArrayList<>();
         for (int i = 0; i < coordinates.length(); i++) {
-            coordinatesArray.add(parseCoordinatesArray(coordinates.getJSONArray(i)));
+            ArrayList<LatLngAlt> latLngAlts = parseCoordinatesArray(coordinates.getJSONArray(i));
+            //this method is called for polygons, which do not have altitude values
+            ArrayList<LatLng> latLngs = new ArrayList<>();
+            for (LatLngAlt latLngAlt : latLngAlts) {
+                latLngs.add(latLngAlt.latLng);
+            }
+            coordinatesArray.add(latLngs);
         }
         return coordinatesArray;
     }

--- a/library/src/com/google/maps/android/data/geojson/GeoJsonPoint.java
+++ b/library/src/com/google/maps/android/data/geojson/GeoJsonPoint.java
@@ -7,6 +7,7 @@ import com.google.maps.android.data.Point;
  * A GeoJsonPoint geometry contains a single {@link com.google.android.gms.maps.model.LatLng}.
  */
 public class GeoJsonPoint extends Point {
+    private final Double mAltitude;
 
     /**
      * Creates a new GeoJsonPoint
@@ -14,7 +15,19 @@ public class GeoJsonPoint extends Point {
      * @param coordinates coordinates of GeoJsonPoint to store
      */
     public GeoJsonPoint(LatLng coordinates) {
+        this(coordinates, null);
+    }
+
+    /**
+     * Creates a new GeoJsonPoint
+     *
+     * @param coordinates coordinates of the KmlPoint
+     * @param altitude altitude of the KmlPoint
+     */
+    public GeoJsonPoint(LatLng coordinates, Double altitude) {
         super(coordinates);
+
+        this.mAltitude = altitude;
     }
 
     /**
@@ -36,4 +49,12 @@ public class GeoJsonPoint extends Point {
         return getGeometryObject();
     }
 
+    /**
+     * Gets the altitude of the GeoJsonPoint
+     *
+     * @return altitude of the GeoJsonPoint
+     */
+    public Double getAltitude() {
+        return mAltitude;
+    }
 }

--- a/library/src/com/google/maps/android/data/kml/KmlLineString.java
+++ b/library/src/com/google/maps/android/data/kml/KmlLineString.java
@@ -10,6 +10,7 @@ import java.util.List;
  * Represents a KML LineString. Contains a single array of coordinates.
  */
 public class KmlLineString extends LineString {
+    private final ArrayList<Double> mAltitudes;
 
     /**
      * Creates a new KmlLineString object
@@ -17,7 +18,28 @@ public class KmlLineString extends LineString {
      * @param coordinates array of coordinates
      */
     public KmlLineString(ArrayList<LatLng> coordinates) {
+        this(coordinates, null);
+    }
+
+    /**
+     * Creates a new KmlLineString object
+     *
+     * @param coordinates array of coordinates
+     * @param altitudes array of altitudes
+     */
+    public KmlLineString(ArrayList<LatLng> coordinates, ArrayList<Double> altitudes) {
         super(coordinates);
+
+        this.mAltitudes = altitudes;
+    }
+
+    /**
+     * Gets the altitudes
+     *
+     * @return ArrayList of Double
+     */
+    public ArrayList <Double> getAltitudes() {
+        return mAltitudes;
     }
 
     /**

--- a/library/src/com/google/maps/android/data/kml/KmlMultiTrack.java
+++ b/library/src/com/google/maps/android/data/kml/KmlMultiTrack.java
@@ -1,0 +1,30 @@
+package com.google.maps.android.data.kml;
+
+import com.google.maps.android.data.Geometry;
+
+import java.util.ArrayList;
+
+/**
+ * Created by thorin on 22/02/2017.
+ */
+
+public class KmlMultiTrack extends KmlMultiGeometry {
+    /**
+     * Creates a new MultiGeometry object
+     *
+     * @param tracks array of KmlTrack objects contained in the MultiGeometry
+     */
+    public KmlMultiTrack(ArrayList<KmlTrack> tracks) {
+        super(createGeometries(tracks));
+    }
+
+    private static ArrayList<Geometry> createGeometries(ArrayList<KmlTrack> tracks) {
+        ArrayList <Geometry> geometries = new ArrayList<>();
+
+        for (KmlTrack track : tracks) {
+            geometries.add(track);
+        }
+
+        return geometries;
+    }
+}

--- a/library/src/com/google/maps/android/data/kml/KmlMultiTrack.java
+++ b/library/src/com/google/maps/android/data/kml/KmlMultiTrack.java
@@ -21,6 +21,10 @@ public class KmlMultiTrack extends KmlMultiGeometry {
     private static ArrayList<Geometry> createGeometries(ArrayList<KmlTrack> tracks) {
         ArrayList <Geometry> geometries = new ArrayList<>();
 
+        if (tracks == null) {
+            throw new IllegalArgumentException("Tracks cannot be null");
+        }
+
         for (KmlTrack track : tracks) {
             geometries.add(track);
         }

--- a/library/src/com/google/maps/android/data/kml/KmlPoint.java
+++ b/library/src/com/google/maps/android/data/kml/KmlPoint.java
@@ -7,6 +7,7 @@ import com.google.maps.android.data.Point;
  * Represents a KML Point. Contains a single coordinate.
  */
 public class KmlPoint extends Point {
+    private final Double mAltitude;
 
     /**
      * Creates a new KmlPoint
@@ -14,7 +15,22 @@ public class KmlPoint extends Point {
      * @param coordinates coordinates of the KmlPoint
      */
     public KmlPoint(LatLng coordinates) {
-        super(coordinates);
+        this(coordinates, null);
     }
 
+    /**
+     * Creates a new KmlPoint
+     *
+     * @param coordinates coordinates of the KmlPoint
+     * @param altitude altitude of the KmlPoint
+     */
+    public KmlPoint(LatLng coordinates, Double altitude) {
+        super(coordinates);
+
+        this.mAltitude = altitude;
+    }
+
+    public Double getAltitude() {
+        return mAltitude;
+    }
 }

--- a/library/src/com/google/maps/android/data/kml/KmlTrack.java
+++ b/library/src/com/google/maps/android/data/kml/KmlTrack.java
@@ -1,0 +1,41 @@
+package com.google.maps.android.data.kml;
+
+import android.util.Log;
+
+import com.google.android.gms.maps.model.LatLng;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Created by thorin on 22/02/2017.
+ */
+
+public class KmlTrack extends KmlLineString {
+    private final ArrayList<Long> mTimestamps;
+    private final HashMap<String, String> mProperties;
+
+    /**
+     * Creates a new KmlTrack object
+     *
+     * @param coordinates array of coordinates
+     * @param altitudes array of altitudes
+     * @param timestamps array of timestamps
+     * @param properties hashmap of properties
+     */
+    public KmlTrack(ArrayList<LatLng> coordinates, ArrayList<Double> altitudes, ArrayList <Long> timestamps, HashMap<String, String> properties) {
+        super(coordinates, altitudes);
+
+        this.mTimestamps = timestamps;
+        this.mProperties = properties;
+    }
+
+    public ArrayList <Long> getTimestamps() {
+        return mTimestamps;
+    }
+
+    public HashMap<String, String> getProperties() {
+        return mProperties;
+    }
+}

--- a/library/tests/src/com/google/maps/android/data/geojson/GeoJsonLineStringTest.java
+++ b/library/tests/src/com/google/maps/android/data/geojson/GeoJsonLineStringTest.java
@@ -34,4 +34,20 @@ public class GeoJsonLineStringTest extends TestCase {
             assertEquals("Coordinates cannot be null", e.getMessage());
         }
     }
+
+    public void testGetAltitudes() throws Exception {
+        ArrayList<LatLng> coordinates = new ArrayList<LatLng>();
+        coordinates.add(new LatLng(0, 0));
+        coordinates.add(new LatLng(50, 50));
+        coordinates.add(new LatLng(100, 100));
+        ArrayList<Double> altitudes = new ArrayList<Double>();
+        altitudes.add(new Double(100));
+        altitudes.add(new Double(200));
+        altitudes.add(new Double(300));
+        ls = new GeoJsonLineString(coordinates,altitudes);
+        assertEquals(altitudes, ls.getAltitudes());
+        assertEquals(ls.getAltitudes().get(0), 100.0);
+        assertEquals(ls.getAltitudes().get(1), 200.0);
+        assertEquals(ls.getAltitudes().get(2), 300.0);
+    }
 }

--- a/library/tests/src/com/google/maps/android/data/geojson/GeoJsonPointTest.java
+++ b/library/tests/src/com/google/maps/android/data/geojson/GeoJsonPointTest.java
@@ -23,4 +23,9 @@ public class GeoJsonPointTest extends TestCase {
             assertEquals("Coordinates cannot be null", e.getMessage());
         }
     }
+
+    public void testGetAltitude() throws Exception {
+        p = new GeoJsonPoint(new LatLng(0, 0), new Double(100));
+        assertEquals(new Double(100), p.getAltitude());
+    }
 }

--- a/library/tests/src/com/google/maps/android/data/kml/KmlLineStringTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlLineStringTest.java
@@ -17,6 +17,18 @@ public class KmlLineStringTest extends TestCase {
         return new KmlLineString(coordinates);
     }
 
+    public KmlLineString createSimpleLineStringWithAltitudes() {
+        ArrayList<LatLng> coordinates = new ArrayList<LatLng>();
+        ArrayList<Double> altitudes = new ArrayList<Double>();
+        coordinates.add(new LatLng(0, 0));
+        coordinates.add(new LatLng(50, 50));
+        coordinates.add(new LatLng(100, 100));
+        altitudes.add(new Double(100));
+        altitudes.add(new Double(200));
+        altitudes.add(new Double(300));
+        return new KmlLineString(coordinates, altitudes);
+    }
+
     public KmlLineString createLoopedLineString() {
         ArrayList<LatLng> coordinates = new ArrayList<LatLng>();
         coordinates.add(new LatLng(0, 0));
@@ -52,5 +64,20 @@ public class KmlLineStringTest extends TestCase {
         assertEquals(kmlLineString.getGeometryObject().get(1).latitude, 50.0);
         assertEquals(kmlLineString.getGeometryObject().get(2).latitude, 0.0);
 
+    }
+
+    public void testLineStringAltitudes() throws Exception {
+        //test linestring without altitudes
+        kmlLineString = createSimpleLineString();
+        assertNotNull(kmlLineString);
+        assertNull(kmlLineString.getAltitudes());
+
+        //test linestring with altitudes
+        kmlLineString = createSimpleLineStringWithAltitudes();
+        assertNotNull(kmlLineString);
+        assertNotNull(kmlLineString.getAltitudes());
+        assertEquals(kmlLineString.getAltitudes().get(0), 100.0);
+        assertEquals(kmlLineString.getAltitudes().get(1), 200.0);
+        assertEquals(kmlLineString.getAltitudes().get(2), 300.0);
     }
 }

--- a/library/tests/src/com/google/maps/android/data/kml/KmlMultiTrackTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlMultiTrackTest.java
@@ -1,0 +1,62 @@
+package com.google.maps.android.data.kml;
+
+import com.google.android.gms.maps.model.LatLng;
+import com.google.maps.android.data.Geometry;
+
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class KmlMultiTrackTest extends TestCase {
+    KmlMultiTrack kmlMultiTrack;
+
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    public KmlMultiTrack createMultiTrack() {
+        ArrayList<KmlTrack> kmlTracks = new ArrayList<KmlTrack>();
+        ArrayList<LatLng> coordinates = new ArrayList<LatLng>();
+        ArrayList<Double> altitudes = new ArrayList<Double>();
+        ArrayList <Long> timestamps = new ArrayList<Long>();
+        HashMap<String, String> properties = new HashMap<String, String>();
+        coordinates.add(new LatLng(0, 0));
+        coordinates.add(new LatLng(50, 50));
+        coordinates.add(new LatLng(90, 90));
+        altitudes.add(new Double(100));
+        altitudes.add(new Double(200));
+        altitudes.add(new Double(300));
+        timestamps.add(new Long(1000));
+        timestamps.add(new Long(2000));
+        timestamps.add(new Long(3000));
+        properties.put("key", "value");
+        KmlTrack kmlTrack = new KmlTrack(coordinates, altitudes, timestamps, properties);
+        kmlTracks.add(kmlTrack);
+        return new KmlMultiTrack(kmlTracks);
+    }
+
+    public void testGetKmlGeometryType() throws Exception {
+        kmlMultiTrack = createMultiTrack();
+        assertNotNull(kmlMultiTrack);
+        assertNotNull(kmlMultiTrack.getGeometryType());
+        assertEquals("MultiGeometry", kmlMultiTrack.getGeometryType());
+    }
+
+    public void testGetGeometry() throws Exception {
+        kmlMultiTrack = createMultiTrack();
+        assertNotNull(kmlMultiTrack);
+        assertEquals(kmlMultiTrack.getGeometryObject().size(), 1);
+        KmlTrack lineString = ((KmlTrack) kmlMultiTrack.getGeometryObject().get(0));
+        assertNotNull(lineString);
+    }
+
+    public void testNullGeometry() {
+        try {
+            kmlMultiTrack = new KmlMultiTrack(null);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("Tracks cannot be null", e.getMessage());
+        }
+    }
+}

--- a/library/tests/src/com/google/maps/android/data/kml/KmlPointTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlPointTest.java
@@ -1,0 +1,48 @@
+package com.google.maps.android.data.kml;
+
+import com.google.android.gms.maps.model.LatLng;
+
+import junit.framework.TestCase;
+
+public class KmlPointTest extends TestCase {
+    KmlPoint kmlPoint;
+
+    public KmlPoint createSimplePoint() {
+        LatLng coordinates = new LatLng(0, 50);
+        return new KmlPoint(coordinates);
+    }
+
+    public KmlPoint createSimplePointWithAltitudes() {
+        LatLng coordinates = new LatLng(0, 50);
+        Double altitude = new Double(100);
+        return new KmlPoint(coordinates, altitude);
+    }
+
+    public void testGetType() throws Exception {
+        kmlPoint = createSimplePoint();
+        assertNotNull(kmlPoint);
+        assertNotNull(kmlPoint.getGeometryType());
+        assertEquals("Point", kmlPoint.getGeometryType());
+    }
+
+    public void testGetKmlGeometryObject() throws Exception {
+        kmlPoint = createSimplePoint();
+        assertNotNull(kmlPoint);
+        assertNotNull(kmlPoint.getGeometryObject());
+        assertEquals(kmlPoint.getGeometryObject().latitude, 0.0);
+        assertEquals(kmlPoint.getGeometryObject().longitude, 50.0);
+    }
+
+    public void testPointAltitude() throws Exception {
+        //test point without altitude
+        kmlPoint = createSimplePoint();
+        assertNotNull(kmlPoint);
+        assertNull(kmlPoint.getAltitude());
+
+        //test point with altitude
+        kmlPoint = createSimplePointWithAltitudes();
+        assertNotNull(kmlPoint);
+        assertNotNull(kmlPoint.getAltitude());
+        assertEquals(kmlPoint.getAltitude(), 100.0);
+    }
+}

--- a/library/tests/src/com/google/maps/android/data/kml/KmlPolygonTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlPolygonTest.java
@@ -5,7 +5,6 @@ import com.google.android.gms.maps.model.LatLng;
 import junit.framework.TestCase;
 
 import java.util.ArrayList;
-import java.util.List;
 
 public class KmlPolygonTest extends TestCase {
 
@@ -17,13 +16,13 @@ public class KmlPolygonTest extends TestCase {
     }
 
     public KmlPolygon createRegularPolygon() {
-        List<LatLng> outerCoordinates = new ArrayList<LatLng>();
+        ArrayList<LatLng> outerCoordinates = new ArrayList<LatLng>();
         outerCoordinates.add(new LatLng(10, 10));
         outerCoordinates.add(new LatLng(20, 20));
         outerCoordinates.add(new LatLng(30, 30));
         outerCoordinates.add(new LatLng(10, 10));
-        List<List<LatLng>> innerCoordinates = new  ArrayList<List<LatLng>>();
-        List<LatLng> innerHole = new ArrayList<LatLng>();
+        ArrayList<ArrayList<LatLng>> innerCoordinates = new  ArrayList<ArrayList<LatLng>>();
+        ArrayList<LatLng> innerHole = new ArrayList<LatLng>();
         innerHole.add(new LatLng(20, 20));
         innerHole.add(new LatLng(10, 10));
         innerHole.add(new LatLng(20, 20));

--- a/library/tests/src/com/google/maps/android/data/kml/KmlPolygonTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlPolygonTest.java
@@ -5,6 +5,7 @@ import com.google.android.gms.maps.model.LatLng;
 import junit.framework.TestCase;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class KmlPolygonTest extends TestCase {
 
@@ -16,13 +17,13 @@ public class KmlPolygonTest extends TestCase {
     }
 
     public KmlPolygon createRegularPolygon() {
-        ArrayList<LatLng> outerCoordinates = new ArrayList<LatLng>();
+        List<LatLng> outerCoordinates = new ArrayList<LatLng>();
         outerCoordinates.add(new LatLng(10, 10));
         outerCoordinates.add(new LatLng(20, 20));
         outerCoordinates.add(new LatLng(30, 30));
         outerCoordinates.add(new LatLng(10, 10));
-        ArrayList<ArrayList<LatLng>> innerCoordinates = new  ArrayList<ArrayList<LatLng>>();
-        ArrayList<LatLng> innerHole = new ArrayList<LatLng>();
+        List<List<LatLng>> innerCoordinates = new  ArrayList<List<LatLng>>();
+        List<LatLng> innerHole = new ArrayList<LatLng>();
         innerHole.add(new LatLng(20, 20));
         innerHole.add(new LatLng(10, 10));
         innerHole.add(new LatLng(20, 20));

--- a/library/tests/src/com/google/maps/android/data/kml/KmlTrackTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlTrackTest.java
@@ -1,0 +1,76 @@
+package com.google.maps.android.data.kml;
+
+import com.google.android.gms.maps.model.LatLng;
+
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class KmlTrackTest extends TestCase {
+    KmlTrack kmlTrack;
+
+    public KmlTrack createSimpleTrack() {
+        ArrayList<LatLng> coordinates = new ArrayList<LatLng>();
+        ArrayList<Double> altitudes = new ArrayList<Double>();
+        ArrayList <Long> timestamps = new ArrayList<Long>();
+        HashMap<String, String> properties = new HashMap<String, String>();
+        coordinates.add(new LatLng(0, 0));
+        coordinates.add(new LatLng(50, 50));
+        coordinates.add(new LatLng(90, 90));
+        altitudes.add(new Double(100));
+        altitudes.add(new Double(200));
+        altitudes.add(new Double(300));
+        timestamps.add(new Long(1000));
+        timestamps.add(new Long(2000));
+        timestamps.add(new Long(3000));
+        properties.put("key", "value");
+        return new KmlTrack(coordinates, altitudes, timestamps, properties);
+    }
+
+    public void testGetType() throws Exception {
+        kmlTrack = createSimpleTrack();
+        assertNotNull(kmlTrack);
+        assertNotNull(kmlTrack.getGeometryType());
+        assertEquals("LineString", kmlTrack.getGeometryType());
+    }
+
+    public void testGetKmlGeometryObject() throws Exception {
+        kmlTrack = createSimpleTrack();
+        assertNotNull(kmlTrack);
+        assertNotNull(kmlTrack.getGeometryObject());
+        assertEquals(kmlTrack.getGeometryObject().size(), 3);
+        assertEquals(kmlTrack.getGeometryObject().get(0).latitude, 0.0);
+        assertEquals(kmlTrack.getGeometryObject().get(1).latitude, 50.0);
+        assertEquals(kmlTrack.getGeometryObject().get(2).latitude, 90.0);
+    }
+
+    public void testAltitudes() throws Exception {
+        kmlTrack = createSimpleTrack();
+        assertNotNull(kmlTrack);
+        assertNotNull(kmlTrack.getAltitudes());
+        assertEquals(kmlTrack.getAltitudes().size(), 3);
+        assertEquals(kmlTrack.getAltitudes().get(0), 100.0);
+        assertEquals(kmlTrack.getAltitudes().get(1), 200.0);
+        assertEquals(kmlTrack.getAltitudes().get(2), 300.0);
+    }
+
+    public void testTimestamps() throws Exception {
+        kmlTrack = createSimpleTrack();
+        assertNotNull(kmlTrack);
+        assertNotNull(kmlTrack.getTimestamps());
+        assertEquals(kmlTrack.getTimestamps().size(), 3);
+        assertEquals(kmlTrack.getTimestamps().get(0), Long.valueOf(1000L));
+        assertEquals(kmlTrack.getTimestamps().get(1), Long.valueOf(2000L));
+        assertEquals(kmlTrack.getTimestamps().get(2), Long.valueOf(3000L));
+    }
+
+    public void testProperties() throws Exception {
+        kmlTrack = createSimpleTrack();
+        assertNotNull(kmlTrack);
+        assertNotNull(kmlTrack.getProperties());
+        assertEquals(kmlTrack.getProperties().size(), 1);
+        assertEquals(kmlTrack.getProperties().get("key"), "value");
+        assertNull(kmlTrack.getProperties().get("missingKey"));
+    }
+}


### PR DESCRIPTION
This pull request extends the KML file parsing capabilities by:
- adding support for altitudes to KmlPoint and KmlMultiline objects
- adding support for <Track> and <MultiTrack> geometries in KML files (including, of course, altitudes)

The change is backwards compatible: features have been added to existing objects but their pre-existing structure has otherwise been left untouched.

The new KmlTrack object inherits from KmlLineString.
The new KmlMultiTrack object inherits from KmlMultiGeometry and contains a list of KmlTrack objects.

Both objects, once parsed, can be rendered without further hassle with the existing infrastructure.

On an unrelated note, is there any particular reason why KmlParser is package private? I'm using this library to parse data from KML files and load it into my own application, which has its own storage model for tracks, routes and waypoints. I suspect that many applications could benefit from the robust KML parsing that this library offers, but like mine have uses for the parsed data other than immediate rendering on a MapView...