### PR TITLE
Relative urls directory

### DIFF
--- a/library/src/com/google/maps/android/data/kml/KmlLayer.java
+++ b/library/src/com/google/maps/android/data/kml/KmlLayer.java
@@ -16,17 +16,38 @@ import java.io.InputStream;
  */
 public class KmlLayer extends Layer {
 
+
+    /**
+     * Same as {@link KmlLayer#KmlLayer(GoogleMap, int, Context, String)} but with a null directoryName.
+     */
+     public KmlLayer(GoogleMap map, int resourceId, Context context)
+             throws XmlPullParserException, IOException {
+         this(map, resourceId, context, null);
+     }
+
+
+    /**
+     * Same as {@link KmlLayer#KmlLayer(GoogleMap, InputStream, Context, String)} but with a null directoryName.
+     */
+     public KmlLayer(GoogleMap map, InputStream stream, Context context)
+             throws XmlPullParserException, IOException {
+         this(map, stream, context, null);
+     }
+
+
     /**
      * Creates a new KmlLayer object - addLayerToMap() must be called to trigger rendering onto a map.
      *
      * @param map        GoogleMap object
      * @param resourceId Raw resource KML file
      * @param context    Context object
+     * @param directoryName the fully qualified directory name to look in (in the android file
+     *                      system) for any relative-path images, or null to only look online.
      * @throws XmlPullParserException if file cannot be parsed
      */
-    public KmlLayer(GoogleMap map, int resourceId, Context context)
+    public KmlLayer(GoogleMap map, int resourceId, Context context, String directoryName)
             throws XmlPullParserException, IOException {
-        this(map, context.getResources().openRawResource(resourceId), context);
+        this(map, context.getResources().openRawResource(resourceId), context, directoryName);
     }
 
     /**
@@ -34,9 +55,11 @@ public class KmlLayer extends Layer {
      *
      * @param map    GoogleMap object
      * @param stream InputStream containing KML file
+     * @param directoryName the fully qualified directory name to look in (in the android file
+     *                      system) for any relative-path images, or null to only look online.
      * @throws XmlPullParserException if file cannot be parsed
      */
-    public KmlLayer(GoogleMap map, InputStream stream, Context context)
+    public KmlLayer(GoogleMap map, InputStream stream, Context context, String directoryName)
             throws XmlPullParserException, IOException {
         if (stream == null) {
             throw new IllegalArgumentException("KML InputStream cannot be null");

--- a/library/src/com/google/maps/android/data/kml/KmlLayer.java
+++ b/library/src/com/google/maps/android/data/kml/KmlLayer.java
@@ -64,7 +64,7 @@ public class KmlLayer extends Layer {
         if (stream == null) {
             throw new IllegalArgumentException("KML InputStream cannot be null");
         }
-        KmlRenderer mRenderer = new KmlRenderer(map, context);
+        KmlRenderer mRenderer = new KmlRenderer(map, context, directoryName);
         XmlPullParser xmlPullParser = createXmlParser(stream);
         KmlParser parser = new KmlParser(xmlPullParser);
         parser.parseKml();

--- a/library/src/com/google/maps/android/data/kml/KmlRenderer.java
+++ b/library/src/com/google/maps/android/data/kml/KmlRenderer.java
@@ -559,12 +559,12 @@ public class KmlRenderer  extends Renderer {
 
     /**
      * @param fileName the name of the file to look for within {@link KmlRenderer#mDirectoryName}.
-     * @return the bitmap in the directory {@link KmlRenderer#mDirectoryName} and name fileName,
-     * or null if {@link KmlRenderer#mDirectoryName} is null.
+     * @return the bitmap in the directory {@link KmlRenderer#mDirectoryName} and name fileName;
+     * or the bitmap found at fileName (treated as an absolute path) if {@link KmlRenderer#mDirectoryName} is null.
      */
     private Bitmap getBitmapFromFile(String fileName) {
         if (mDirectoryName == null) {
-            return null;
+            return BitmapFactory.decodeFile(fileName);
         }
         return BitmapFactory.decodeFile(new File(mDirectoryName, fileName).getPath());
     }

--- a/library/src/com/google/maps/android/data/kml/KmlRenderer.java
+++ b/library/src/com/google/maps/android/data/kml/KmlRenderer.java
@@ -44,20 +44,17 @@ public class KmlRenderer  extends Renderer {
     private ArrayList<KmlContainer> mContainers;
 
     /**
-     * The fully qualified directory name to look in (in the android file system) for any relative-path images.
+     * The fully qualified directory name to look in (in the android file system) for any relative-path images,
+     * or null if we should only look online.
      */
     private String mDirectoryName;
 
     /* package */ KmlRenderer(GoogleMap map, Context context) {
-        super(map, context);
-        mGroundOverlayUrls = new ArrayList<>();
-        mMarkerIconsDownloaded = false;
-        mGroundOverlayImagesDownloaded = false;
+        this(map, context, null);
     }
 
     /**
-     * @param directoryName the fully qualified directory name to look in (in the android external file
-     * system) for any relative-path images.
+     * @param directoryName See {@link KmlRenderer#mDirectoryName}, or null to only look online.
      */
     KmlRenderer(GoogleMap map, Context context, String directoryName) {
         super(map, context);
@@ -463,6 +460,8 @@ public class KmlRenderer  extends Renderer {
          */
         @Override
         protected Bitmap doInBackground(String... params) {
+            //Note: Doing this "URI uri = new URI(mGroundOverlayUrl);" doesn't work because it will always throw a syntax exception if there are spaces.
+            //Should always check online first, then check in the filesystem.
             try {
                 return getBitmapFromUrl(mIconUrl);
             } catch (MalformedURLException e) {
@@ -516,7 +515,7 @@ public class KmlRenderer  extends Renderer {
         @Override
         protected Bitmap doInBackground(String... params) {
             //Note: Doing this "URI uri = new URI(mGroundOverlayUrl);" doesn't work because it will always throw a syntax exception if there are spaces.
-            //If it's not a relative URL, then try to load from the world wide web.
+            //Should always check online first, then check in the filesystem.
             try {
                 return getBitmapFromUrl(mGroundOverlayUrl);
             } catch (MalformedURLException e) {
@@ -560,9 +559,13 @@ public class KmlRenderer  extends Renderer {
 
     /**
      * @param fileName the name of the file to look for within {@link KmlRenderer#mDirectoryName}.
-     * @return the bitmap in the directory {@link KmlRenderer#mDirectoryName} and name fileName, scaled according to screen density.
+     * @return the bitmap in the directory {@link KmlRenderer#mDirectoryName} and name fileName,
+     * or null if {@link KmlRenderer#mDirectoryName} is null.
      */
     private Bitmap getBitmapFromFile(String fileName) {
+        if (mDirectoryName == null) {
+            return null;
+        }
         return BitmapFactory.decodeFile(new File(mDirectoryName, fileName).getPath());
     }
 


### PR DESCRIPTION
Allows you to configure a directory to look for relative image URLs if the KML file has relative image paths. (This helps the library be compatible with KMZs which have the images in the same folder as the KML file, and not all images are simply online).