### PR TITLE
Fix Geometry NPE

### DIFF
--- a/library/src/com/google/maps/android/data/kml/KmlRenderer.java
+++ b/library/src/com/google/maps/android/data/kml/KmlRenderer.java
@@ -287,7 +287,7 @@ public class KmlRenderer  extends Renderer {
         for (Feature placemark : placemarks.keySet()) {
             KmlStyle urlStyle = getStylesRenderer().get(placemark.getId());
             KmlStyle inlineStyle = ((KmlPlacemark) placemark).getInlineStyle();
-            if ("Point".equals(placemark.getGeometry().getGeometryType())) {
+            if (placemark.getGeometry() != null && "Point".equals(placemark.getGeometry().getGeometryType())) {
                 boolean isInlineStyleIcon = inlineStyle != null && iconUrl
                         .equals(inlineStyle.getIconUrl());
                 boolean isPlacemarkStyleIcon = urlStyle != null && iconUrl


### PR DESCRIPTION
`placemark.getGeometry().getGeometryType()` was generating a null pointer exception and crashing the app because Geometry was null, so I added a simple null check.