### PR TITLE
Don't run unit tests on Travis - just build the project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ env:
   global:
     - ANDROID_API_LEVEL=24
     - ANDROID_BUILD_TOOLS_VERSION=23.0.3
-    - ANDROID_ABI=armeabi-v7a
-    - ANDROID_TAG=google_apis
-    - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)
 
 android:
   components:
@@ -32,14 +29,6 @@ android:
     # Latest artifacts in local repository
     - extra-google-m2repository
     - extra-android-m2repository
-    # Specify at least one system image
-    - sys-img-armeabi-v7a-google_apis-$ANDROID_API_LEVEL
-
-before_script:
-  # Create and start emulator
-  - echo no | android create avd --force -n test -t "android-"$ANDROID_API_LEVEL --abi $ANDROID_ABI --tag $ANDROID_TAG
-  - emulator -avd test -no-skin -no-window &
-  - android-wait-for-emulator
 
 script:
-  - ./gradlew clean check connectedCheck -x library:signArchives -PdisablePreDex
+  - ./gradlew clean assembleDebug -x library:signArchives -PdisablePreDex


### PR DESCRIPTION
It seems emulator-based unit testing is currently horribly broken due to issues with the API Level 23-25 emulators/SDK:
* API Level 23 - https://code.google.com/p/android/issues/detail?id=228113
* API Level 24/25 - https://code.google.com/p/android/issues/detail?id=230083 

...so for now change to just building the project on Travis (via `./gradlew clean assembleDebug`).

I'll keep tabs on the emulator testing and hopefully we can restore unit tests at some point in the future.  In the mean time we'll need to run tests locally.