### PR TITLE
Relative URLs & ability to optionally not set an info window adapter

### DIFF
--- a/REALEASENOTES.md
+++ b/REALEASENOTES.md
@@ -1,0 +1,47 @@
+# Google Maps Android API Utility Library Release Notes
+
+### Version 0.5
+
+#### New Features:
+
+  * Click handling was previously only available for GeoJSON, but is now available for KML layers as well
+    - Also works for multipolygons, multilinestring and multipoints
+  * Info windows can be added to clustered markers
+
+
+#### Modifications from previous version:
+ 
+ *  OnFeatureClickListener changed from accepting a GeoJsonFeature to a Feature, which is supported for KML as well.
+ 
+    Previous version:
+    ```java
+	public interface GeoJsonOnFeatureClickListener {
+        void onFeatureClick(GeoJsonFeature feature);
+    }
+	```
+    New version:
+    
+    ```java
+	public interface GeoJsonOnFeatureClickListener {
+        void onFeatureClick(Feature feature);
+    }
+	```
+ * GeoJsonGeometry and KmlGeometry interfaces replaced by common Geometry interface
+ * ClusterItem interface has two new methods:
+ 	`getTitle()` and
+    `getSnippet()`
+
+
+#### Issues resolved:
+
+ * [NullPointerException with markers that have snippets but no title (Issue #327)](https://github.com/googlemaps/android-maps-utils/issues/327)
+   * [Issue #218](https://github.com/googlemaps/android-maps-utils/issues/218)
+   * [Issue #317](https://github.com/googlemaps/android-maps-utils/issues/317)
+   
+ * [Multipolygon not supported by OnFeatureClickListener (Issue #320)](https://github.com/googlemaps/android-maps-utils/issues/320)
+ * [KmlStyle class not public (Issue #311)](https://github.com/googlemaps/android-maps-utils/issues/311)
+ * [Info Windows on clustered markers (Issue #188)](https://github.com/googlemaps/android-maps-utils/issues/188#issuecomment-262714692)
+ * [Disable animations for clustered markers (Issue #306)](https://github.com/googlemaps/android-maps-utils/issues/306)
+
+
+

--- a/library/src/com/google/maps/android/data/Renderer.java
+++ b/library/src/com/google/maps/android/data/Renderer.java
@@ -103,12 +103,24 @@ public class Renderer {
     private final GeoJsonPolygonStyle mDefaultPolygonStyle;
 
     /**
-     * Creates a new Renderer object
+     * Creates a new Renderer object with the default info window adapter.
      *
      * @param map map to place objects on
      * @param context context needed to add info windows
      */
     public Renderer(GoogleMap map, Context context) {
+        //This constructor is left for backwards compatibility.
+        this(map, context, true);
+    }
+    /**
+     * Creates a new Renderer object, and optionally sets the default info window adapter.
+     *
+     * @param map map to place objects on
+     * @param context context needed to add info windows
+     * @param setDefaultInfoWindowAdapter true to set the given map's info window adapter to one that displays a title and snippet,
+     *                                  or false to not set it (used to prevent this class from overriding your own custom adapter).
+     */
+    public Renderer(GoogleMap map, Context context, boolean setDefaultInfoWindowAdapter) {
         mMap = map;
         mContext = context;
         mLayerOnMap = false;
@@ -119,6 +131,10 @@ public class Renderer {
         mDefaultLineStringStyle = null;
         mDefaultPolygonStyle = null;
         mContainerFeatures = new BiMultiMap<>();
+
+        if (setDefaultInfoWindowAdapter) {
+            setDefaultInfoWindowAdapter();
+        }
     }
 
     /**
@@ -871,28 +887,23 @@ public class Renderer {
         boolean hasBalloonText = style.getBalloonOptions().containsKey("text");
         if (hasBalloonOptions && hasBalloonText) {
             marker.setTitle(style.getBalloonOptions().get("text"));
-            createInfoWindow();
         } else if (hasBalloonOptions && hasName) {
             marker.setTitle(placemark.getProperty("name"));
-            createInfoWindow();
         } else if (hasName && hasDescription) {
             marker.setTitle(placemark.getProperty("name"));
             marker.setSnippet(placemark.getProperty("description"));
-            createInfoWindow();
         } else if (hasDescription) {
             marker.setTitle(placemark.getProperty("description"));
-            createInfoWindow();
         } else if (hasName) {
             marker.setTitle(placemark.getProperty("name"));
-            createInfoWindow();
         }
     }
 
     /**
-     * Creates a new InfoWindowAdapter and sets text if marker snippet or title is set. This allows
+     * Sets a default InfoWindowAdapter on the map that sets text if marker snippet or title is set. This allows
      * the info window to have custom HTML.
      */
-    private void createInfoWindow() {
+    private void setDefaultInfoWindowAdapter() {
         mMap.setInfoWindowAdapter(new GoogleMap.InfoWindowAdapter() {
 
             public View getInfoWindow(Marker arg0) {

--- a/library/src/com/google/maps/android/data/kml/KmlLayer.java
+++ b/library/src/com/google/maps/android/data/kml/KmlLayer.java
@@ -16,17 +16,38 @@ import java.io.InputStream;
  */
 public class KmlLayer extends Layer {
 
+
+    /**
+     * Same as {@link KmlLayer#KmlLayer(GoogleMap, int, Context, String)} but with a null directoryName.
+     */
+     public KmlLayer(GoogleMap map, int resourceId, Context context)
+             throws XmlPullParserException, IOException {
+         this(map, resourceId, context, null);
+     }
+
+
+    /**
+     * Same as {@link KmlLayer#KmlLayer(GoogleMap, InputStream, Context, String)} but with a null directoryName.
+     */
+     public KmlLayer(GoogleMap map, InputStream stream, Context context)
+             throws XmlPullParserException, IOException {
+         this(map, stream, context, null);
+     }
+
+
     /**
      * Creates a new KmlLayer object - addLayerToMap() must be called to trigger rendering onto a map.
      *
      * @param map        GoogleMap object
      * @param resourceId Raw resource KML file
      * @param context    Context object
+     * @param directoryName the fully qualified directory name to look in (in the android file
+     *                      system) for any relative-path images, or null to only look online.
      * @throws XmlPullParserException if file cannot be parsed
      */
-    public KmlLayer(GoogleMap map, int resourceId, Context context)
+    public KmlLayer(GoogleMap map, int resourceId, Context context, String directoryName)
             throws XmlPullParserException, IOException {
-        this(map, context.getResources().openRawResource(resourceId), context);
+        this(map, context.getResources().openRawResource(resourceId), context, directoryName);
     }
 
     /**
@@ -34,9 +55,11 @@ public class KmlLayer extends Layer {
      *
      * @param map    GoogleMap object
      * @param stream InputStream containing KML file
+     * @param directoryName the fully qualified directory name to look in (in the android file
+     *                      system) for any relative-path images, or null to only look online.
      * @throws XmlPullParserException if file cannot be parsed
      */
-    public KmlLayer(GoogleMap map, InputStream stream, Context context)
+    public KmlLayer(GoogleMap map, InputStream stream, Context context, String directoryName)
             throws XmlPullParserException, IOException {
         if (stream == null) {
             throw new IllegalArgumentException("KML InputStream cannot be null");

--- a/library/src/com/google/maps/android/data/kml/KmlLayer.java
+++ b/library/src/com/google/maps/android/data/kml/KmlLayer.java
@@ -2,6 +2,8 @@ package com.google.maps.android.data.kml;
 
 import com.google.android.gms.maps.GoogleMap;
 import com.google.maps.android.data.Layer;
+import com.google.maps.android.data.Renderer;
+
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
@@ -18,20 +20,22 @@ public class KmlLayer extends Layer {
 
 
     /**
-     * Same as {@link KmlLayer#KmlLayer(GoogleMap, int, Context, String)} but with a null directoryName.
+     * Same as {@link KmlLayer#KmlLayer(GoogleMap, int, Context, String, boolean)} but with a null directoryName
+     * and and will use the default info window adapter.
      */
      public KmlLayer(GoogleMap map, int resourceId, Context context)
              throws XmlPullParserException, IOException {
-         this(map, resourceId, context, null);
+         this(map, resourceId, context, null, true);
      }
 
 
     /**
-     * Same as {@link KmlLayer#KmlLayer(GoogleMap, InputStream, Context, String)} but with a null directoryName.
+     * Same as {@link KmlLayer#KmlLayer(GoogleMap, InputStream, Context, String, boolean)} but with a null directoryName
+     * and will use the default info window adapter.
      */
      public KmlLayer(GoogleMap map, InputStream stream, Context context)
              throws XmlPullParserException, IOException {
-         this(map, stream, context, null);
+         this(map, stream, context, null, true);
      }
 
 
@@ -43,11 +47,12 @@ public class KmlLayer extends Layer {
      * @param context    Context object
      * @param directoryName the fully qualified directory name to look in (in the android file
      *                      system) for any relative-path images, or null to only look online.
+     * @param setDefaultInfoWindowAdapter See {@link Renderer#Renderer(GoogleMap, Context, boolean)} docs.
      * @throws XmlPullParserException if file cannot be parsed
      */
-    public KmlLayer(GoogleMap map, int resourceId, Context context, String directoryName)
+    public KmlLayer(GoogleMap map, int resourceId, Context context, String directoryName, boolean setDefaultInfoWindowAdapter)
             throws XmlPullParserException, IOException {
-        this(map, context.getResources().openRawResource(resourceId), context, directoryName);
+        this(map, context.getResources().openRawResource(resourceId), context, directoryName, setDefaultInfoWindowAdapter);
     }
 
     /**
@@ -57,14 +62,15 @@ public class KmlLayer extends Layer {
      * @param stream InputStream containing KML file
      * @param directoryName the fully qualified directory name to look in (in the android file
      *                      system) for any relative-path images, or null to only look online.
+     * @param setDefaultInfoWindowAdapter See {@link Renderer#Renderer(GoogleMap, Context, boolean)} docs.
      * @throws XmlPullParserException if file cannot be parsed
      */
-    public KmlLayer(GoogleMap map, InputStream stream, Context context, String directoryName)
+    public KmlLayer(GoogleMap map, InputStream stream, Context context, String directoryName, boolean setDefaultInfoWindowAdapter)
             throws XmlPullParserException, IOException {
         if (stream == null) {
             throw new IllegalArgumentException("KML InputStream cannot be null");
         }
-        KmlRenderer mRenderer = new KmlRenderer(map, context, directoryName);
+        KmlRenderer mRenderer = new KmlRenderer(map, context, directoryName, setDefaultInfoWindowAdapter);
         XmlPullParser xmlPullParser = createXmlParser(stream);
         KmlParser parser = new KmlParser(xmlPullParser);
         parser.parseKml();

--- a/library/src/com/google/maps/android/data/kml/KmlLayer.java
+++ b/library/src/com/google/maps/android/data/kml/KmlLayer.java
@@ -64,7 +64,7 @@ public class KmlLayer extends Layer {
         if (stream == null) {
             throw new IllegalArgumentException("KML InputStream cannot be null");
         }
-        KmlRenderer mRenderer = new KmlRenderer(map, context);
+        KmlRenderer mRenderer = new KmlRenderer(map, context, directoryName);
         XmlPullParser xmlPullParser = createXmlParser(stream);
         KmlParser parser = new KmlParser(xmlPullParser);
         parser.parseKml();

--- a/library/src/com/google/maps/android/data/kml/KmlRenderer.java
+++ b/library/src/com/google/maps/android/data/kml/KmlRenderer.java
@@ -559,12 +559,12 @@ public class KmlRenderer  extends Renderer {
 
     /**
      * @param fileName the name of the file to look for within {@link KmlRenderer#mDirectoryName}.
-     * @return the bitmap in the directory {@link KmlRenderer#mDirectoryName} and name fileName,
-     * or null if {@link KmlRenderer#mDirectoryName} is null.
+     * @return the bitmap in the directory {@link KmlRenderer#mDirectoryName} and name fileName;
+     * or the bitmap found at fileName (treated as an absolute path) if {@link KmlRenderer#mDirectoryName} is null.
      */
     private Bitmap getBitmapFromFile(String fileName) {
         if (mDirectoryName == null) {
-            return null;
+            return BitmapFactory.decodeFile(fileName);
         }
         return BitmapFactory.decodeFile(new File(mDirectoryName, fileName).getPath());
     }

--- a/library/src/com/google/maps/android/data/kml/KmlRenderer.java
+++ b/library/src/com/google/maps/android/data/kml/KmlRenderer.java
@@ -44,20 +44,17 @@ public class KmlRenderer  extends Renderer {
     private ArrayList<KmlContainer> mContainers;
 
     /**
-     * The fully qualified directory name to look in (in the android file system) for any relative-path images.
+     * The fully qualified directory name to look in (in the android file system) for any relative-path images,
+     * or null if we should only look online.
      */
     private String mDirectoryName;
 
     /* package */ KmlRenderer(GoogleMap map, Context context) {
-        super(map, context);
-        mGroundOverlayUrls = new ArrayList<>();
-        mMarkerIconsDownloaded = false;
-        mGroundOverlayImagesDownloaded = false;
+        this(map, context, null);
     }
 
     /**
-     * @param directoryName the fully qualified directory name to look in (in the android external file
-     * system) for any relative-path images.
+     * @param directoryName See {@link KmlRenderer#mDirectoryName}, or null to only look online.
      */
     KmlRenderer(GoogleMap map, Context context, String directoryName) {
         super(map, context);
@@ -463,6 +460,8 @@ public class KmlRenderer  extends Renderer {
          */
         @Override
         protected Bitmap doInBackground(String... params) {
+            //Note: Doing this "URI uri = new URI(mGroundOverlayUrl);" doesn't work because it will always throw a syntax exception if there are spaces.
+            //Should always check online first, then check in the filesystem.
             try {
                 return getBitmapFromUrl(mIconUrl);
             } catch (MalformedURLException e) {
@@ -516,7 +515,7 @@ public class KmlRenderer  extends Renderer {
         @Override
         protected Bitmap doInBackground(String... params) {
             //Note: Doing this "URI uri = new URI(mGroundOverlayUrl);" doesn't work because it will always throw a syntax exception if there are spaces.
-            //If it's not a relative URL, then try to load from the world wide web.
+            //Should always check online first, then check in the filesystem.
             try {
                 return getBitmapFromUrl(mGroundOverlayUrl);
             } catch (MalformedURLException e) {
@@ -560,9 +559,13 @@ public class KmlRenderer  extends Renderer {
 
     /**
      * @param fileName the name of the file to look for within {@link KmlRenderer#mDirectoryName}.
-     * @return the bitmap in the directory {@link KmlRenderer#mDirectoryName} and name fileName, scaled according to screen density.
+     * @return the bitmap in the directory {@link KmlRenderer#mDirectoryName} and name fileName,
+     * or null if {@link KmlRenderer#mDirectoryName} is null.
      */
     private Bitmap getBitmapFromFile(String fileName) {
+        if (mDirectoryName == null) {
+            return null;
+        }
         return BitmapFactory.decodeFile(new File(mDirectoryName, fileName).getPath());
     }
 

--- a/library/src/com/google/maps/android/data/kml/KmlRenderer.java
+++ b/library/src/com/google/maps/android/data/kml/KmlRenderer.java
@@ -56,14 +56,16 @@ public class KmlRenderer  extends Renderer {
     private String mDirectoryName;
 
     /* package */ KmlRenderer(GoogleMap map, Context context) {
-        this(map, context, null);
+        this(map, context, null, true);
+        //For backwards compatibility, will use a default info window adapter by default.
     }
 
     /**
-     * @param directoryName See {@link KmlRenderer#mDirectoryName}, or null to only look online.
+     * @param directoryName See {@link KmlRenderer#mDirectoryName}.
+     * @param setDefaultInfoWindowAdapter See {@link Renderer#Renderer(GoogleMap, Context, boolean)} docs.
      */
-    KmlRenderer(GoogleMap map, Context context, String directoryName) {
-        super(map, context);
+    public KmlRenderer(GoogleMap map, Context context, String directoryName, boolean setDefaultInfoWindowAdapter) {
+        super(map, context, setDefaultInfoWindowAdapter);
         mDirectoryName = directoryName;
         mGroundOverlayUrls = new ArrayList<>();
         mMarkerIconsDownloaded = false;
@@ -128,7 +130,10 @@ public class KmlRenderer  extends Renderer {
      */
     private void removeGroundOverlays(HashMap<KmlGroundOverlay, GroundOverlay> groundOverlays) {
         for (GroundOverlay groundOverlay : groundOverlays.values()) {
-            groundOverlay.remove();
+            //For some reason, it was getting null overlays. This fixed the problem. I guess it's from malformed KML files.
+            if (groundOverlay != null) {
+                groundOverlay.remove();
+            }
         }
     }
 
@@ -316,7 +321,7 @@ public class KmlRenderer  extends Renderer {
         for (Feature placemark : placemarks.keySet()) {
             KmlStyle urlStyle = getStylesRenderer().get(placemark.getId());
             KmlStyle inlineStyle = ((KmlPlacemark) placemark).getInlineStyle();
-            if ("Point".equals(placemark.getGeometry().getGeometryType())) {
+            if (placemark.getGeometry() != null && "Point".equals(placemark.getGeometry().getGeometryType())) {
                 boolean isInlineStyleIcon = inlineStyle != null && iconUrl
                         .equals(inlineStyle.getIconUrl());
                 boolean isPlacemarkStyleIcon = urlStyle != null && iconUrl


### PR DESCRIPTION
`Renderer.createInfoWindow()` was calling `mMap.setInfoWindowAdapter`, overriding any custom info window adapter that the user might have set. I added the ability to construct a KmlLayer with a boolean parameter that will tell the library to not set that default info window adapter.

Also, I have the Relative URLs feature in this pull request so we do not need so many telescoping constructors. So the new KmlLayer constructor also accepts a string for a directory name. The library was modified to first look online for the image, and if it was not found, then it looks in the directory for the image.  If it is null, it will behave as before (only looking online). This feature allows users to open KMZ (zipped) folders that have offline images.

Everything was made backwards compatible by leaving the original constructors intact.

Other small fixes included in this pull request:
- `placemark.getGeometry().getGeometryType()` was generating a null pointer exception and crashing the app because Geometry was null, so I added a simple null check.
- Fix null overlays NPE in `KmlRenderer.removeGroundOverlays` method.
- adds auto-scaling of bitmaps according to screen density (see usages of `mBitmapOptions` in `KmlRenderer.java` for more info).