### PR TITLE
Handle 3xx redirects from HTTP to HTTPS

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -6,13 +6,13 @@ archivesBaseName = 'android-maps-utils'
 group = 'com.google.maps.android'
 
 dependencies {
-    compile 'com.google.android.gms:play-services-maps:9.6.1'
+    compile 'com.google.android.gms:play-services-maps:10.2.1'
 }
 
 android {
     compileSdkVersion 24
 
-    buildToolsVersion "23.0.3"
+    buildToolsVersion '25.0.2'
 
     resourcePrefix 'amu_'
 

--- a/library/src/com/google/maps/android/data/kml/KmlRenderer.java
+++ b/library/src/com/google/maps/android/data/kml/KmlRenderer.java
@@ -18,8 +18,10 @@ import com.google.maps.android.data.Geometry;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -445,7 +447,7 @@ public class KmlRenderer  extends Renderer {
         @Override
         protected Bitmap doInBackground(String... params) {
             try {
-                return BitmapFactory.decodeStream((InputStream) new URL(mIconUrl).getContent());
+                return getBitmapFromUrl(mIconUrl);
             } catch (MalformedURLException e) {
                 return BitmapFactory.decodeFile(mIconUrl);
             } catch (IOException e) {
@@ -493,8 +495,7 @@ public class KmlRenderer  extends Renderer {
         @Override
         protected Bitmap doInBackground(String... params) {
             try {
-                return BitmapFactory
-                        .decodeStream((InputStream) new URL(mGroundOverlayUrl).getContent());
+                return getBitmapFromUrl(mGroundOverlayUrl);
             } catch (MalformedURLException e) {
                 return BitmapFactory.decodeFile(mGroundOverlayUrl);
             } catch (IOException e) {
@@ -520,5 +521,56 @@ public class KmlRenderer  extends Renderer {
                 }
             }
         }
+    }
+
+    /**
+     * @param url internet address of the image.
+     * @return the bitmap of that image, scaled according to screen density.
+     */
+    private Bitmap getBitmapFromUrl(String url) throws MalformedURLException, IOException {
+        return BitmapFactory.decodeStream(openConnectionCheckRedirects(new URL(url).openConnection()));
+    }
+
+    /**
+     * opens a stream allowing redirects.
+     */
+    private InputStream openConnectionCheckRedirects(URLConnection c) throws IOException {
+        boolean redir;
+        int redirects = 0;
+        InputStream in;
+        do {
+            if (c instanceof HttpURLConnection) {
+                ((HttpURLConnection) c).setInstanceFollowRedirects(false);
+            }
+            // We want to open the input stream before getting headers
+            // because getHeaderField() et al swallow IOExceptions.
+            in = c.getInputStream();
+            redir = false;
+            if (c instanceof HttpURLConnection) {
+                HttpURLConnection http = (HttpURLConnection) c;
+                int stat = http.getResponseCode();
+                if (stat >= 300 && stat <= 307 && stat != 306 &&
+                        stat != HttpURLConnection.HTTP_NOT_MODIFIED) {
+                    URL base = http.getURL();
+                    String loc = http.getHeaderField("Location");
+                    URL target = null;
+                    if (loc != null) {
+                        target = new URL(base, loc);
+                    }
+                    http.disconnect();
+                    // Redirection should be allowed only for HTTP and HTTPS
+                    // and should be limited to 5 redirections at most.
+                    if (target == null || !(target.getProtocol().equals("http")
+                            || target.getProtocol().equals("https"))
+                            || redirects >= 5) {
+                        throw new SecurityException("illegal URL redirect");
+                    }
+                    redir = true;
+                    c = target.openConnection();
+                    redirects++;
+                }
+            }
+        } while (redir);
+        return in;
     }
 }


### PR DESCRIPTION
and vice versa. HttpURLConnection does not follow these redirects natively (https://bugs.openjdk.java.net/browse/JDK-4620571). KMLs with image assets that redirect are unable to download.