### PR TITLE
Storing Collection objects in BiMultiMap

### DIFF
--- a/library/src/com/google/maps/android/data/geojson/BiMultiMap.java
+++ b/library/src/com/google/maps/android/data/geojson/BiMultiMap.java
@@ -30,8 +30,12 @@ public class BiMultiMap<K> extends HashMap<K, Object> {
     @Override
     public Object put(K key, Object value) {
         // Store value/key in the reverse map.
-        mValuesToKeys.put(value, key);
-        return super.put(key, value);
+        if (value instanceof Collection) {
+            return put(key, (Collection) value);
+        } else {
+            mValuesToKeys.put(value, key);
+            return super.put(key, value);
+        }
     }
 
     public Object put(K key, Collection values) {

--- a/library/tests/src/com/google/maps/android/data/geojson/BiMultiMapTest.java
+++ b/library/tests/src/com/google/maps/android/data/geojson/BiMultiMapTest.java
@@ -39,4 +39,20 @@ public class BiMultiMapTest extends TestCase {
         }
     }
 
+    public void testCollection() {
+        BiMultiMap<String> map = new BiMultiMap<>();
+        String key = "foo";
+        Object values = Arrays.asList("bar", "baz");
+        map.put(key, values);
+        assertEquals(1, map.size());
+        assertEquals(values, map.get(key));
+        for (String value : (List<String>) values) {
+            assertEquals(key, map.getKey(value));
+        }
+        map.remove(key);
+        assertEquals(0, map.size());
+        for (String value : (List<String>) values) {
+            assertEquals(null, map.getKey(value));
+        }
+    }
 }


### PR DESCRIPTION
**Changes**
- Explicitly call the Collection version of `put(key, value)` to correctly store the reverse relationship

The method `Renderer#addFeature(Feature feature)` calls the method `BiMultiMap#put` with an `Object` parameter. Java dynamic method dispatch does not work when passing objects as parameters, so the generic method `BiMultiMap#put(K key, Object object)` is always called, even when the created `mapObject` object is of type `Collection`.