### PR TITLE
Fix #384 - Show clustered markers in exact same location

### DIFF
--- a/demo/AndroidManifest.xml
+++ b/demo/AndroidManifest.xml
@@ -56,6 +56,7 @@
         <activity android:name=".HeatmapsPlacesDemoActivity"/>
         <activity android:name=".GeoJsonDemoActivity"/>
         <activity android:name=".KmlDemoActivity"/>
+        <activity android:name=".ClusteringSameLocationActivity"/>
 
     </application>
 

--- a/demo/res/raw/markers_same_location.json
+++ b/demo/res/raw/markers_same_location.json
@@ -1,0 +1,7 @@
+[
+{ "lat" : 51.503186, "lng" : -0.126446, "title" : "Marker 1", "snippet": "Marker 1"},
+{ "lat" : 51.503186, "lng" : -0.126446, "title" : "Marker 2", "snippet" : "Marker 2"},
+{ "lat" : 51.503186, "lng" : -0.126446, "title" : "Marker 3", "snippet": "Marker 3"},
+{ "lat" : 51.503186, "lng" : -0.126446, "title" : "Marker 4", "snippet": "Marker 4" },
+{ "lat" : 51.503186, "lng" : -0.126446, "title" : "Marker 5", "snippet": "Marker 5"}
+]

--- a/demo/src/com/google/maps/android/utils/demo/ClusteringSameLocationActivity.java
+++ b/demo/src/com/google/maps/android/utils/demo/ClusteringSameLocationActivity.java
@@ -1,16 +1,17 @@
 package com.google.maps.android.utils.demo;
 
 import android.content.Context;
-import android.util.Log;
 import android.widget.Toast;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.Marker;
 import com.google.maps.android.MarkerManager;
 import com.google.maps.android.clustering.Cluster;
 import com.google.maps.android.clustering.ClusterItem;
 import com.google.maps.android.clustering.ClusterManager;
+import com.google.maps.android.clustering.view.DefaultClusterRenderer;
 import com.google.maps.android.utils.demo.model.MyItem;
 
 import org.json.JSONException;
@@ -47,7 +48,9 @@ public class ClusteringSameLocationActivity extends BaseDemoActivity {
                     return false;
                 }
 
-                // TODO: show markers included in cluster with the same location
+                Marker marker = ((DefaultClusterRenderer<MyItem>) mClusterManager.getRenderer()).getMarker(cluster);
+                marker.setTitle("Cluster with " + cluster.getItems().size() + " items");
+                marker.showInfoWindow();
 
                 return true;
             }
@@ -68,9 +71,9 @@ public class ClusteringSameLocationActivity extends BaseDemoActivity {
         mClusterManager.addItems(items);
     }
 
-    class CustomClusterManager<T extends ClusterItem> extends ClusterManager<T> {
+    private class CustomClusterManager<T extends ClusterItem> extends ClusterManager<T> {
 
-        public CustomClusterManager(Context context, GoogleMap map) {
+        CustomClusterManager(Context context, GoogleMap map) {
             super(context, map);
         }
 
@@ -78,7 +81,7 @@ public class ClusteringSameLocationActivity extends BaseDemoActivity {
             super(context, map, markerManager);
         }
 
-        public boolean hasMarkersSameLocation(Cluster<T> cluster) {
+        boolean hasMarkersSameLocation(Cluster<T> cluster) {
             LinkedList<T> items = new LinkedList<>(cluster.getItems());
             T item = items.remove(0);
 

--- a/demo/src/com/google/maps/android/utils/demo/ClusteringSameLocationActivity.java
+++ b/demo/src/com/google/maps/android/utils/demo/ClusteringSameLocationActivity.java
@@ -1,0 +1,38 @@
+package com.google.maps.android.utils.demo;
+
+import android.widget.Toast;
+
+import com.google.android.gms.maps.CameraUpdateFactory;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.maps.android.clustering.ClusterManager;
+import com.google.maps.android.utils.demo.model.MyItem;
+
+import org.json.JSONException;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ClusteringSameLocationActivity extends BaseDemoActivity {
+    private ClusterManager<MyItem> mClusterManager;
+
+    @Override
+    protected void startDemo() {
+        getMap().moveCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(51.503186, -0.126446), 10));
+
+        mClusterManager = new ClusterManager<MyItem>(this, getMap());
+        getMap().setOnCameraIdleListener(mClusterManager);
+
+        try {
+            readItems();
+        } catch (JSONException e) {
+            Toast.makeText(this, "Problem reading list of markers.", Toast.LENGTH_LONG).show();
+        }
+    }
+
+    private void readItems() throws JSONException {
+        InputStream inputStream = getResources().openRawResource(R.raw.markers_same_location);
+        List<MyItem> items = new MyItemReader().read(inputStream);
+        mClusterManager.addItems(items);
+    }
+}

--- a/demo/src/com/google/maps/android/utils/demo/ClusteringSameLocationActivity.java
+++ b/demo/src/com/google/maps/android/utils/demo/ClusteringSameLocationActivity.java
@@ -1,26 +1,33 @@
 package com.google.maps.android.utils.demo;
 
+import android.content.Context;
+import android.util.Log;
 import android.widget.Toast;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
+import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.LatLng;
+import com.google.maps.android.MarkerManager;
 import com.google.maps.android.clustering.Cluster;
+import com.google.maps.android.clustering.ClusterItem;
 import com.google.maps.android.clustering.ClusterManager;
 import com.google.maps.android.utils.demo.model.MyItem;
 
 import org.json.JSONException;
 
 import java.io.InputStream;
+import java.util.LinkedList;
 import java.util.List;
 
 public class ClusteringSameLocationActivity extends BaseDemoActivity {
-    private ClusterManager<MyItem> mClusterManager;
+
+    private CustomClusterManager<MyItem> mClusterManager;
 
     @Override
     protected void startDemo() {
         getMap().moveCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(51.503186, -0.126446), 10));
 
-        mClusterManager = new ClusterManager<>(this, getMap());
+        mClusterManager = new CustomClusterManager<>(this, getMap());
 
         getMap().setOnMarkerClickListener(mClusterManager);
 
@@ -28,8 +35,21 @@ public class ClusteringSameLocationActivity extends BaseDemoActivity {
 
             @Override
             public boolean onClusterClick(Cluster<MyItem> cluster) {
+                float maxZoomLevel = getMap().getMaxZoomLevel();
+                float currentZoomLevel = getMap().getCameraPosition().zoom;
 
-                return false;
+                // only show markers if users is in the max zoom level
+                if (currentZoomLevel != maxZoomLevel) {
+                    return false;
+                }
+
+                if (!mClusterManager.hasMarkersSameLocation(cluster)) {
+                    return false;
+                }
+
+                // TODO: show markers included in cluster with the same location
+
+                return true;
             }
         });
 
@@ -46,5 +66,32 @@ public class ClusteringSameLocationActivity extends BaseDemoActivity {
         InputStream inputStream = getResources().openRawResource(R.raw.markers_same_location);
         List<MyItem> items = new MyItemReader().read(inputStream);
         mClusterManager.addItems(items);
+    }
+
+    class CustomClusterManager<T extends ClusterItem> extends ClusterManager<T> {
+
+        public CustomClusterManager(Context context, GoogleMap map) {
+            super(context, map);
+        }
+
+        public CustomClusterManager(Context context, GoogleMap map, MarkerManager markerManager) {
+            super(context, map, markerManager);
+        }
+
+        public boolean hasMarkersSameLocation(Cluster<T> cluster) {
+            LinkedList<T> items = new LinkedList<>(cluster.getItems());
+            T item = items.remove(0);
+
+            double longitude = item.getPosition().longitude;
+            double latitude = item.getPosition().latitude;
+
+            for (T t : items) {
+                if (longitude != t.getPosition().longitude && latitude != t.getPosition().latitude) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 }

--- a/demo/src/com/google/maps/android/utils/demo/ClusteringSameLocationActivity.java
+++ b/demo/src/com/google/maps/android/utils/demo/ClusteringSameLocationActivity.java
@@ -51,6 +51,7 @@ public class ClusteringSameLocationActivity extends BaseDemoActivity {
             @Override
             public void onCameraMove() {
 
+                // get markesr back to the original position if they were relocated
                 if (getMap().getCameraPosition().zoom < getMap().getMaxZoomLevel()) {
                     mClusterManager.removeItems(mItemsCache.get(DEFAULT_ADDED_LIST));
                     mClusterManager.addItems(mItemsCache.get(DEFAULT_DELETE_LIST));
@@ -74,11 +75,11 @@ public class ClusteringSameLocationActivity extends BaseDemoActivity {
                     return false;
                 }
 
-                if (!mClusterManager.hasMarkersSameLocation(cluster)) {
+                if (!mClusterManager.itemsInSameLocation(cluster)) {
                     return false;
                 }
 
-                // distribute the markers around the center
+                // relocate the markers around the current markers position
                 int counter = 0;
                 float rotateFactor = (360 / cluster.getItems().size());
                 for (MyItem item : cluster.getItems()) {
@@ -110,6 +111,7 @@ public class ClusteringSameLocationActivity extends BaseDemoActivity {
     private void readItems() throws JSONException {
         InputStream inputStream = getResources().openRawResource(R.raw.markers_same_location);
         List<MyItem> items = new MyItemReader().read(inputStream);
+
         mClusterManager.addItems(items);
     }
 
@@ -119,11 +121,7 @@ public class ClusteringSameLocationActivity extends BaseDemoActivity {
             super(context, map);
         }
 
-        public CustomClusterManager(Context context, GoogleMap map, MarkerManager markerManager) {
-            super(context, map, markerManager);
-        }
-
-        boolean hasMarkersSameLocation(Cluster<T> cluster) {
+        boolean itemsInSameLocation(Cluster<T> cluster) {
             LinkedList<T> items = new LinkedList<>(cluster.getItems());
             T item = items.remove(0);
 

--- a/demo/src/com/google/maps/android/utils/demo/ClusteringSameLocationActivity.java
+++ b/demo/src/com/google/maps/android/utils/demo/ClusteringSameLocationActivity.java
@@ -4,13 +4,13 @@ import android.widget.Toast;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.model.LatLng;
+import com.google.maps.android.clustering.Cluster;
 import com.google.maps.android.clustering.ClusterManager;
 import com.google.maps.android.utils.demo.model.MyItem;
 
 import org.json.JSONException;
 
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.List;
 
 public class ClusteringSameLocationActivity extends BaseDemoActivity {
@@ -20,11 +20,23 @@ public class ClusteringSameLocationActivity extends BaseDemoActivity {
     protected void startDemo() {
         getMap().moveCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(51.503186, -0.126446), 10));
 
-        mClusterManager = new ClusterManager<MyItem>(this, getMap());
-        getMap().setOnCameraIdleListener(mClusterManager);
+        mClusterManager = new ClusterManager<>(this, getMap());
+
+        getMap().setOnMarkerClickListener(mClusterManager);
+
+        mClusterManager.setOnClusterClickListener(new ClusterManager.OnClusterClickListener<MyItem>() {
+
+            @Override
+            public boolean onClusterClick(Cluster<MyItem> cluster) {
+
+                return false;
+            }
+        });
 
         try {
             readItems();
+
+            mClusterManager.cluster();
         } catch (JSONException e) {
             Toast.makeText(this, "Problem reading list of markers.", Toast.LENGTH_LONG).show();
         }

--- a/demo/src/com/google/maps/android/utils/demo/ClusteringSameLocationActivity.java
+++ b/demo/src/com/google/maps/android/utils/demo/ClusteringSameLocationActivity.java
@@ -121,22 +121,6 @@ public class ClusteringSameLocationActivity extends BaseDemoActivity {
             super(context, map);
         }
 
-        boolean itemsInSameLocation(Cluster<T> cluster) {
-            LinkedList<T> items = new LinkedList<>(cluster.getItems());
-            T item = items.remove(0);
-
-            double longitude = item.getPosition().longitude;
-            double latitude = item.getPosition().latitude;
-
-            for (T t : items) {
-                if (Double.compare(longitude, t.getPosition().longitude) != 0 && Double.compare(latitude, t.getPosition().latitude) != 0) {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
         void removeItems(List<T> items) {
 
             for (T item : items) {

--- a/demo/src/com/google/maps/android/utils/demo/ClusteringSameLocationActivity.java
+++ b/demo/src/com/google/maps/android/utils/demo/ClusteringSameLocationActivity.java
@@ -129,7 +129,7 @@ public class ClusteringSameLocationActivity extends BaseDemoActivity {
             double latitude = item.getPosition().latitude;
 
             for (T t : items) {
-                if (longitude != t.getPosition().longitude && latitude != t.getPosition().latitude) {
+                if (Double.compare(longitude, t.getPosition().longitude) != 0 && Double.compare(latitude, t.getPosition().latitude) != 0) {
                     return false;
                 }
             }

--- a/demo/src/com/google/maps/android/utils/demo/MainActivity.java
+++ b/demo/src/com/google/maps/android/utils/demo/MainActivity.java
@@ -38,6 +38,7 @@ public class MainActivity extends Activity implements View.OnClickListener {
         addDemo("Clustering", ClusteringDemoActivity.class);
         addDemo("Clustering: Custom Look", CustomMarkerClusteringDemoActivity.class);
         addDemo("Clustering: 2K markers", BigClusteringDemoActivity.class);
+        addDemo("Clustering: Markers in same location", ClusteringSameLocationActivity.class);
         addDemo("PolyUtil.decode", PolyDecodeDemoActivity.class);
         addDemo("PolyUtil.simplify", PolySimplifyDemoActivity.class);
         addDemo("IconGenerator", IconGeneratorDemoActivity.class);

--- a/demo/src/com/google/maps/android/utils/demo/model/MyItem.java
+++ b/demo/src/com/google/maps/android/utils/demo/model/MyItem.java
@@ -47,6 +47,15 @@ public class MyItem implements ClusterItem {
     @Override
     public String getSnippet() { return mSnippet; }
 
+    @Override
+    public ClusterItem copy(double lat, double lng) {
+        MyItem item = new MyItem(lat, lng);
+        item.setSnippet(getSnippet());
+        item.setTitle(getTitle());
+
+        return item;
+    }
+
     /**
      * Set the title of the marker
      * @param title string to be set as title

--- a/demo/src/com/google/maps/android/utils/demo/model/Person.java
+++ b/demo/src/com/google/maps/android/utils/demo/model/Person.java
@@ -44,4 +44,9 @@ public class Person implements ClusterItem {
     public String getSnippet() {
         return null;
     }
+
+    @Override
+    public ClusterItem copy(double lat, double lng) {
+        return new Person(new LatLng(lat, lng), name, profilePhoto);
+    }
 }

--- a/library/src/com/google/maps/android/clustering/ClusterItem.java
+++ b/library/src/com/google/maps/android/clustering/ClusterItem.java
@@ -37,4 +37,11 @@ public interface ClusterItem {
      * The description of this marker.
      */
     String getSnippet();
+
+    /**
+     * Produces a copy of the same object but setting the given location.
+     *
+     * @return The new object copied.
+     */
+    ClusterItem copy(double lat, double lng);
 }

--- a/library/src/com/google/maps/android/clustering/ClusterManager.java
+++ b/library/src/com/google/maps/android/clustering/ClusterManager.java
@@ -58,7 +58,7 @@ public class ClusterManager<T extends ClusterItem> implements
     private Algorithm<T> mAlgorithm;
     private final ReadWriteLock mAlgorithmLock = new ReentrantReadWriteLock();
     private ClusterRenderer<T> mRenderer;
-    private ClusterItemsDistributor mClusterItemsDistributor;
+    private ClusterItemsDistributor<T> mClusterItemsDistributor;
 
     private GoogleMap mMap;
     private CameraPosition mPreviousCameraPosition;
@@ -82,7 +82,7 @@ public class ClusterManager<T extends ClusterItem> implements
         mRenderer = new DefaultClusterRenderer<T>(context, map, this);
         mAlgorithm = new PreCachingAlgorithmDecorator<T>(new NonHierarchicalDistanceBasedAlgorithm<T>());
         mClusterTask = new ClusterTask();
-        mClusterItemsDistributor = new DefaultClusterItemsDistributor(this);
+        mClusterItemsDistributor = new DefaultClusterItemsDistributor<>(this);
         mRenderer.onAdd();
 
         setOnClusterClickListener(new ClusterManager.OnClusterClickListener<T>() {
@@ -138,7 +138,7 @@ public class ClusterManager<T extends ClusterItem> implements
         mRenderer.setAnimation(animate);
     }
 
-    public void setClusterItemsDistributor(ClusterItemsDistributor clusterItemsDistributor) {
+    public void setClusterItemsDistributor(ClusterItemsDistributor<T> clusterItemsDistributor) {
         this.mClusterItemsDistributor = clusterItemsDistributor;
     }
 
@@ -275,7 +275,7 @@ public class ClusterManager<T extends ClusterItem> implements
         return true;
     }
 
-    public boolean handleClusterClick(Cluster cluster) {
+    public boolean handleClusterClick(Cluster<T> cluster) {
         float maxZoomLevel = mMap.getMaxZoomLevel();
         float currentZoomLevel = mMap.getCameraPosition().zoom;
 

--- a/library/src/com/google/maps/android/clustering/ClusterManager.java
+++ b/library/src/com/google/maps/android/clustering/ClusterManager.java
@@ -89,22 +89,7 @@ public class ClusterManager<T extends ClusterItem> implements
 
             @Override
             public boolean onClusterClick(Cluster<T> cluster) {
-                float maxZoomLevel = mMap.getMaxZoomLevel();
-                float currentZoomLevel = mMap.getCameraPosition().zoom;
-
-                // only show markers if users is in the max zoom level
-                if (currentZoomLevel != maxZoomLevel) {
-                    return false;
-                }
-
-                if (!itemsInSameLocation(cluster)) {
-                    return false;
-                }
-
-                // relocate the markers as defined in the distributor
-                mClusterItemsDistributor.distribute(cluster);
-
-                return true;
+                return handleClusterClick(cluster);
             }
         });
     }
@@ -286,6 +271,25 @@ public class ClusterManager<T extends ClusterItem> implements
                 return false;
             }
         }
+
+        return true;
+    }
+
+    public boolean handleClusterClick(Cluster cluster) {
+        float maxZoomLevel = mMap.getMaxZoomLevel();
+        float currentZoomLevel = mMap.getCameraPosition().zoom;
+
+        // only show markers if users is in the max zoom level
+        if (currentZoomLevel != maxZoomLevel) {
+            return false;
+        }
+
+        if (!itemsInSameLocation(cluster)) {
+            return false;
+        }
+
+        // relocate the markers as defined in the distributor
+        mClusterItemsDistributor.distribute(cluster);
 
         return true;
     }

--- a/library/src/com/google/maps/android/clustering/ClusterManager.java
+++ b/library/src/com/google/maps/android/clustering/ClusterManager.java
@@ -31,6 +31,7 @@ import com.google.maps.android.clustering.view.ClusterRenderer;
 import com.google.maps.android.clustering.view.DefaultClusterRenderer;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -214,6 +215,30 @@ public class ClusterManager<T extends ClusterItem> implements
     @Override
     public void onInfoWindowClick(Marker marker) {
         getMarkerManager().onInfoWindowClick(marker);
+    }
+
+    public boolean itemsInSameLocation(Cluster<T> cluster) {
+        Collection<T> items = cluster.getItems();
+
+        if (items.size() < 2) {
+            return false;
+        }
+
+        Iterator<T> iterator = items.iterator();
+        T item = iterator.next();
+
+        double longitude = item.getPosition().longitude;
+        double latitude = item.getPosition().latitude;
+
+        while (iterator.hasNext()) {
+            T t = iterator.next();
+
+            if (Double.compare(longitude, t.getPosition().longitude) != 0 && Double.compare(latitude, t.getPosition().latitude) != 0) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/library/src/com/google/maps/android/clustering/view/ClusterItemsDistributor.java
+++ b/library/src/com/google/maps/android/clustering/view/ClusterItemsDistributor.java
@@ -1,0 +1,20 @@
+package com.google.maps.android.clustering.view;
+
+import com.google.maps.android.clustering.Cluster;
+import com.google.maps.android.clustering.ClusterItem;
+
+/**
+ * It distributes the items in a cluster.
+ */
+public interface ClusterItemsDistributor<T extends ClusterItem> {
+
+    /**
+     * Proceed with the distribution of the items in a cluster.
+     */
+    void distribute(Cluster<T> cluster);
+
+    /**
+     * Proceed to collect the items back to their previous state.
+     */
+    void collect();
+}

--- a/library/src/com/google/maps/android/clustering/view/DefaultClusterItemsDistributor.java
+++ b/library/src/com/google/maps/android/clustering/view/DefaultClusterItemsDistributor.java
@@ -1,0 +1,65 @@
+package com.google.maps.android.clustering.view;
+
+import com.google.maps.android.clustering.Cluster;
+import com.google.maps.android.clustering.ClusterItem;
+import com.google.maps.android.clustering.ClusterManager;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The default distributor of items included in a cluster. It distributes the items around the original lat/lng in a given radius.
+ *
+ * @param <T> Cluster item type.
+ */
+public class DefaultClusterItemsDistributor<T extends ClusterItem> implements ClusterItemsDistributor<T> {
+
+    private static final double DEFAULT_RADIUS = 0.00003;
+
+    private static final String DEFAULT_DELETE_LIST = "itemsDeleted";
+
+    private static final String DEFAULT_ADDED_LIST = "itemsAdded";
+
+    private ClusterManager<T> mClusterManager;
+
+    private Map<String, List<T>> mItemsCache;
+
+    public DefaultClusterItemsDistributor(ClusterManager<T> clusterManager) {
+        mClusterManager = clusterManager;
+        mItemsCache = new HashMap<>();
+        mItemsCache.put(DEFAULT_ADDED_LIST, new ArrayList<T>());
+        mItemsCache.put(DEFAULT_DELETE_LIST, new ArrayList<T>());
+    }
+
+    @Override
+    public void distribute(Cluster<T> cluster) {
+        // relocate the markers around the original markers position
+        int counter = 0;
+        float rotateFactor = (360 / cluster.getItems().size());
+
+        for (T item : cluster.getItems()) {
+            double lat = item.getPosition().latitude + (DEFAULT_RADIUS * Math.cos(++counter * rotateFactor));
+            double lng = item.getPosition().longitude + (DEFAULT_RADIUS * Math.sin(counter * rotateFactor));
+            T copy = (T) item.copy(lat, lng);
+
+            mClusterManager.removeItem(item);
+            mClusterManager.addItem(copy);
+            mClusterManager.cluster();
+
+            mItemsCache.get(DEFAULT_ADDED_LIST).add(copy);
+            mItemsCache.get(DEFAULT_DELETE_LIST).add(item);
+        }
+    }
+
+    public void collect() {
+        // collect the items
+        mClusterManager.removeItems(mItemsCache.get(DEFAULT_ADDED_LIST));
+        mClusterManager.addItems(mItemsCache.get(DEFAULT_DELETE_LIST));
+        mClusterManager.cluster();
+
+        mItemsCache.get(DEFAULT_ADDED_LIST).clear();
+        mItemsCache.get(DEFAULT_DELETE_LIST).clear();
+    }
+}

--- a/library/src/com/google/maps/android/clustering/view/DefaultClusterItemsDistributor.java
+++ b/library/src/com/google/maps/android/clustering/view/DefaultClusterItemsDistributor.java
@@ -22,12 +22,19 @@ public class DefaultClusterItemsDistributor<T extends ClusterItem> implements Cl
 
     private static final String DEFAULT_ADDED_LIST = "itemsAdded";
 
+    private double mDistributionRadius;
+
     private ClusterManager<T> mClusterManager;
 
     private Map<String, List<T>> mItemsCache;
 
     public DefaultClusterItemsDistributor(ClusterManager<T> clusterManager) {
+        this(clusterManager, DEFAULT_RADIUS);
+    }
+
+    public DefaultClusterItemsDistributor(ClusterManager<T> clusterManager, double distributionRadius) {
         mClusterManager = clusterManager;
+        mDistributionRadius = distributionRadius;
         mItemsCache = new HashMap<>();
         mItemsCache.put(DEFAULT_ADDED_LIST, new ArrayList<T>());
         mItemsCache.put(DEFAULT_DELETE_LIST, new ArrayList<T>());
@@ -40,8 +47,8 @@ public class DefaultClusterItemsDistributor<T extends ClusterItem> implements Cl
         float rotateFactor = (360 / cluster.getItems().size());
 
         for (T item : cluster.getItems()) {
-            double lat = item.getPosition().latitude + (DEFAULT_RADIUS * Math.cos(++counter * rotateFactor));
-            double lng = item.getPosition().longitude + (DEFAULT_RADIUS * Math.sin(counter * rotateFactor));
+            double lat = item.getPosition().latitude + (mDistributionRadius * Math.cos(++counter * rotateFactor));
+            double lng = item.getPosition().longitude + (mDistributionRadius * Math.sin(counter * rotateFactor));
             T copy = (T) item.copy(lat, lng);
 
             mClusterManager.removeItem(item);

--- a/library/tests/src/com/google/maps/android/clustering/QuadItemTest.java
+++ b/library/tests/src/com/google/maps/android/clustering/QuadItemTest.java
@@ -44,6 +44,11 @@ public class QuadItemTest extends TestCase {
         public String getSnippet() {
             return null;
         }
+
+        @Override
+        public TestingItem copy(double lat, double lng) {
+            return new TestingItem(lat, lng);
+        }
     }
 
     public void setUp() {


### PR DESCRIPTION
This pull request implements a solution for a situation where more than one marker have the exact same location (lat and lng), an issue reported in #384.

The activity ClusteringSameLocationActivity shows 5 markers in the exact same location and use this new implementation. Basically, if the user does zoom in till the maximum zoom value and touch the cluster with the markers in the same location, markers are distributed in new locations based in the default implementation of ClusterItemsDistributor interface. A new distributor can be implemented and used calling ClusterManager.setClusterItemsDistributor.

There is a potential backward compatibility break as ClusterItem interface requires now a copy method to copy the cluster item with a new location to be used to distribute the markers. It is important to keep BC compatibility I could make changes to this feature or function.

This implementation requires to implement OnClusterClickListener and OnCameraMoveListener, this means if the library consumer needs to implement those listeners, it is a requirement to call to ClusterManager.handleClickListener or ClusterManager.OnCameraMove to keep the feature working well. This could be improved also if it is required.