### PR TITLE
Method to get StyleId's from mStyleMap KmlContainer

### DIFF
--- a/library/src/com/google/maps/android/data/kml/KmlContainer.java
+++ b/library/src/com/google/maps/android/data/kml/KmlContainer.java
@@ -86,6 +86,14 @@ public class KmlContainer {
     public KmlStyle getStyle(String styleID) {
         return mStyles.get(styleID);
     }
+    
+     /**
+     * Gets a style Id from map based on an ID
+     */
+    public String getStyleIdFromMap(String styleID) {
+        return mStyleMap.get(styleID);
+    }
+
 
     /**
      * @return HashMap of containers


### PR DESCRIPTION
Because KmlPlacemarks returns StyleId's that are inside mStyleMap but containers only returns styles inside mStyles it is impossible to get all Styles. 

Add a method (getStyleIdFromMap) to get true style id from map.