### PR TITLE
 Added Zindex in PointStyle and LinePattern in LineStringStyle of GeoJson

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -6,7 +6,7 @@ archivesBaseName = 'android-maps-utils'
 group = 'com.google.maps.android'
 
 dependencies {
-    compile 'com.google.android.gms:play-services-maps:9.6.1'
+    compile 'com.google.android.gms:play-services-maps:11.0.4'
 }
 
 android {

--- a/library/src/com/google/maps/android/data/geojson/GeoJsonLineStringStyle.java
+++ b/library/src/com/google/maps/android/data/geojson/GeoJsonLineStringStyle.java
@@ -1,9 +1,14 @@
 package com.google.maps.android.data.geojson;
 
+import android.graphics.Color;
+
+import com.google.android.gms.maps.model.Dot;
+import com.google.android.gms.maps.model.PatternItem;
 import com.google.android.gms.maps.model.PolylineOptions;
 import com.google.maps.android.data.Style;
 
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * A class that allows for GeoJsonLineString objects to be styled and for these styles to be
@@ -167,6 +172,7 @@ public class GeoJsonLineStringStyle extends Style implements GeoJsonStyle {
         polylineOptions.visible(mPolylineOptions.isVisible());
         polylineOptions.width(mPolylineOptions.getWidth());
         polylineOptions.zIndex(mPolylineOptions.getZIndex());
+        polylineOptions.pattern(getPattern());
         return polylineOptions;
     }
 
@@ -180,7 +186,28 @@ public class GeoJsonLineStringStyle extends Style implements GeoJsonStyle {
         sb.append(",\n visible=").append(isVisible());
         sb.append(",\n width=").append(getWidth());
         sb.append(",\n z index=").append(getZIndex());
+        sb.append(",\n pattern=").append(getPattern());
         sb.append("\n}\n");
         return sb.toString();
     }
+
+    /**
+     * Sets the z index of the GeoJsonLineString
+     *
+     * @return  line style of GeoJsonLineString
+     */
+    public List<PatternItem> getPattern() {
+        return mPolylineOptions.getPattern();
+    }
+
+    /**
+     * Sets the z index of the GeoJsonLineString
+     *
+     * @param pattern line style of GeoJsonLineString
+     */
+    public void setPattern(List<PatternItem> pattern) {
+        mPolylineOptions.pattern(pattern);
+        styleChanged();
+    }
+
 }

--- a/library/src/com/google/maps/android/data/geojson/GeoJsonPointStyle.java
+++ b/library/src/com/google/maps/android/data/geojson/GeoJsonPointStyle.java
@@ -287,6 +287,7 @@ public class GeoJsonPointStyle extends Style implements GeoJsonStyle {
         markerOptions.snippet(mMarkerOptions.getSnippet());
         markerOptions.title(mMarkerOptions.getTitle());
         markerOptions.visible(mMarkerOptions.isVisible());
+        markerOptions.zIndex(mMarkerOptions.getZIndex());
         return markerOptions;
     }
 
@@ -305,7 +306,28 @@ public class GeoJsonPointStyle extends Style implements GeoJsonStyle {
         sb.append(",\n snippet=").append(getSnippet());
         sb.append(",\n title=").append(getTitle());
         sb.append(",\n visible=").append(isVisible());
+        sb.append(",\n z index=").append(getZIndex());
         sb.append("\n}\n");
         return sb.toString();
     }
+
+    /**
+     * Gets the z index of the GeoJsonLineString
+     *
+     * @return z index of the GeoJsonLineString
+     */
+    public float getZIndex() {
+        return mMarkerOptions.getZIndex();
+    }
+
+    /**
+     * Sets the z index of the GeoJsonLineString
+     *
+     * @param zIndex z index value of the GeoJsonPoint
+     */
+    public void setZIndex(float zIndex) {
+        mMarkerOptions.zIndex(zIndex);
+        styleChanged();
+    }
+
 }


### PR DESCRIPTION
## Improvements Made

1. **Zindex** feature is added to **PointStyle of GeoJson** to facilitate placement of a point above or below
among multiple points
2. **LinePattern** feature is **added to LineStringStyle** to facilitate creation of dotted, dashed and other line style

Following screen shot displays uses of these features 

![screenshot_20171028-115834](https://user-images.githubusercontent.com/29140664/32655616-57d6b51a-c634-11e7-8185-ae123258bf13.png)
