### PR TITLE
Set polygon clickable option with style instead of forced true.

### DIFF
--- a/library/src/com/google/maps/android/data/Renderer.java
+++ b/library/src/com/google/maps/android/data/Renderer.java
@@ -423,11 +423,11 @@ public class Renderer {
      *
      * @param feature feature to add to the map
      */
-     public void addFeature(Feature feature) {
+    public void addFeature(Feature feature) {
         Object mapObject = FEATURE_NOT_ON_MAP;
-         if (feature instanceof GeoJsonFeature) {
-             setFeatureDefaultStyles((GeoJsonFeature) feature);
-         }
+        if (feature instanceof GeoJsonFeature) {
+            setFeatureDefaultStyles((GeoJsonFeature) feature);
+        }
         if (mLayerOnMap) {
             if (mFeatures.containsKey(feature)) {
                 // Remove current map objects before adding new ones
@@ -637,7 +637,7 @@ public class Renderer {
      * @return Polyline object created from given LineString
      */
     protected Polyline addLineStringToMap(PolylineOptions polylineOptions,
-                                       LineString lineString) {
+                                          LineString lineString) {
         // Add coordinates
         polylineOptions.addAll(lineString.getGeometryObject());
         Polyline addedPolyline = mMap.addPolyline(polylineOptions);
@@ -680,7 +680,7 @@ public class Renderer {
             polygonOptions.addHole(innerBoundary);
         }
         Polygon addedPolygon = mMap.addPolygon(polygonOptions);
-        addedPolygon.setClickable(true);
+        addedPolygon.setClickable(polygonOptions.isClickable());
         return addedPolygon;
     }
 

--- a/library/src/com/google/maps/android/data/geojson/GeoJsonPolygonStyle.java
+++ b/library/src/com/google/maps/android/data/geojson/GeoJsonPolygonStyle.java
@@ -166,6 +166,7 @@ public class GeoJsonPolygonStyle extends Style implements GeoJsonStyle {
         polygonOptions.strokeWidth(mPolygonOptions.getStrokeWidth());
         polygonOptions.visible(mPolygonOptions.isVisible());
         polygonOptions.zIndex(mPolygonOptions.getZIndex());
+        polygonOptions.clickable(mPolygonOptions.isClickable());
         return polygonOptions;
     }
 
@@ -181,5 +182,9 @@ public class GeoJsonPolygonStyle extends Style implements GeoJsonStyle {
         sb.append(",\n z index=").append(getZIndex());
         sb.append("\n}\n");
         return sb.toString();
+    }
+
+    public void setClickable(boolean clickable) {
+        mPolygonOptions.clickable(clickable);
     }
 }


### PR DESCRIPTION
setOnMapClickListener not called when clicking on map area with GeoJson polygon added. Polygon clickable option was set to true. Allow the user to set the clickable option.

Patch file with modified GeoJsonDemoActivity.java to test setting clickable style
[Demo_of_clickable_polygon_or_clicking_through.zip](https://github.com/googlemaps/android-maps-utils/files/1951404/Demo_of_clickable_polygon_or_clicking_through.zip)
