### PR TITLE
Fix deprecated API usage warnings

### DIFF
--- a/library/src/com/google/maps/android/clustering/ClusterManager.java
+++ b/library/src/com/google/maps/android/clustering/ClusterManager.java
@@ -75,8 +75,8 @@ public class ClusterManager<T extends ClusterItem> implements
         mMarkerManager = markerManager;
         mClusterMarkers = markerManager.newCollection();
         mMarkers = markerManager.newCollection();
-        mRenderer = new DefaultClusterRenderer<T>(context, map, this);
-        mAlgorithm = new ScreenBasedAlgorithmAdapter<T>(new PreCachingAlgorithmDecorator<T>(
+        mRenderer = new DefaultClusterRenderer<>(context, map, this);
+        mAlgorithm = new ScreenBasedAlgorithmAdapter<>(new PreCachingAlgorithmDecorator<>(
                 new NonHierarchicalDistanceBasedAlgorithm<T>()));
 
         mClusterTask = new ClusterTask();
@@ -112,9 +112,9 @@ public class ClusterManager<T extends ClusterItem> implements
 
     public void setAlgorithm(Algorithm<T> algorithm) {
         if (algorithm instanceof ScreenBasedAlgorithm) {
-            setAlgorithm((ScreenBasedAlgorithm) algorithm);
+            setAlgorithm((ScreenBasedAlgorithm<T>) algorithm);
         } else {
-            setAlgorithm(new ScreenBasedAlgorithmAdapter<T>(algorithm));
+            setAlgorithm(new ScreenBasedAlgorithmAdapter<>(algorithm));
         }
     }
 
@@ -301,28 +301,28 @@ public class ClusterManager<T extends ClusterItem> implements
          * Called when cluster is clicked. 
          * Return true if click has been handled
          * Return false and the click will dispatched to the next listener
-         */ 
-        public boolean onClusterClick(Cluster<T> cluster);
+         */
+        boolean onClusterClick(Cluster<T> cluster);
     }
 
     /**
      * Called when a Cluster's Info Window is clicked.
      */
     public interface OnClusterInfoWindowClickListener<T extends ClusterItem> {
-        public void onClusterInfoWindowClick(Cluster<T> cluster);
+        void onClusterInfoWindowClick(Cluster<T> cluster);
     }
 
     /**
      * Called when an individual ClusterItem is clicked.
      */
     public interface OnClusterItemClickListener<T extends ClusterItem> {
-        public boolean onClusterItemClick(T item);
+        boolean onClusterItemClick(T item);
     }
 
     /**
      * Called when an individual ClusterItem's Info Window is clicked.
      */
     public interface OnClusterItemInfoWindowClickListener<T extends ClusterItem> {
-        public void onClusterItemInfoWindowClick(T item);
+        void onClusterItemInfoWindowClick(T item);
     }
 }

--- a/library/src/com/google/maps/android/clustering/algo/NonHierarchicalViewBasedAlgorithm.java
+++ b/library/src/com/google/maps/android/clustering/algo/NonHierarchicalViewBasedAlgorithm.java
@@ -20,7 +20,7 @@ import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.maps.android.clustering.ClusterItem;
 import com.google.maps.android.geometry.Bounds;
-import com.google.maps.android.projection.Point;
+import com.google.maps.android.geometry.Point;
 import com.google.maps.android.projection.SphericalMercatorProjection;
 import com.google.maps.android.quadtree.PointQuadTree;
 

--- a/library/src/com/google/maps/android/clustering/algo/ScreenBasedAlgorithm.java
+++ b/library/src/com/google/maps/android/clustering/algo/ScreenBasedAlgorithm.java
@@ -16,7 +16,7 @@
 
 package com.google.maps.android.clustering.algo;
 
-import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.CameraPosition;
 import com.google.maps.android.clustering.ClusterItem;
 
 /**
@@ -25,7 +25,9 @@ import com.google.maps.android.clustering.ClusterItem;
  * @param <T>
  */
 
-public interface ScreenBasedAlgorithm<T extends ClusterItem> extends Algorithm<T>, GoogleMap.OnCameraChangeListener {
+public interface ScreenBasedAlgorithm<T extends ClusterItem> extends Algorithm<T> {
 
     boolean shouldReclusterOnMapMovement();
+
+    void onCameraChange(CameraPosition position);
 }


### PR DESCRIPTION
Since ScreenBasedAlgorithm's GoogleMap.OnCameraChangeListener onCameraChange() method is only used within ClusterManager, it doesn't need to extend the deprecated listener.