### PR TITLE
Gradle update to v3.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,17 +3,24 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
 allprojects {
     repositories {
-        mavenLocal()
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }
 

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 14

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Apr 29 17:27:18 CEST 2017
+#Mon Dec 10 16:14:53 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 android {
     compileSdkVersion 25
 
-    buildToolsVersion '25.0.2'
+    buildToolsVersion '28.0.3'
 
     resourcePrefix 'amu_'
 


### PR DESCRIPTION
To prevent build issues like "Could not find com.android.tools.build:gradle:2.3.1" in common CI system like Travis or Jitpack the gradle version and build tools need to be updated.