### PR TITLE
Use HTTPS for demo KML Url

### DIFF
--- a/demo/res/values/strings.xml
+++ b/demo/res/values/strings.xml
@@ -8,7 +8,7 @@
     <string name="attrib_format">Data from &lt;a href = "%s">data.gov.au&lt;/a>, modified under &lt;a href = \"http://creativecommons.org/licenses/by/3.0/au/\">CC BY 3.0 AU&lt;/a></string>
     <string name="police_stations_url">http://data.gov.au/dataset/police-station-locations/resource/76110b24-0f0a-4c29-9583-3f99eaba486c</string>
     <string name="medicare_url">http://data.gov.au/dataset/location-of-medicare-offices/resource/5d38e1be-4011-49c4-8b8b-75405eeb1088</string>
-    <string name="kml_url">http://googlemaps.github.io/kml-samples/morekml/Polygons/Polygons.Google_Campus.kml</string>
+    <string name="kml_url">https://googlemaps.github.io/kml-samples/morekml/Polygons/Polygons.Google_Campus.kml</string>
     <string name="geojson_url">https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_day.geojson</string>
     <string-array name="heatmaps_datasets_array">
         <item>@string/police_stations</item>


### PR DESCRIPTION
Solves the following error:

java.io.IOException: Cleartext HTTP traffic to googlemaps.github.io not permitted
    at com.android.okhttp.HttpHandler$CleartextURLFilter.checkURLPermitted(HttpHandler.java:115)
    at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:458)
    at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponse(HttpURLConnectionImpl.java:407)
    at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getInputStream(HttpURLConnectionImpl.java:244)
    at java.net.URL.openStream(URL.java:1072)
    at com.google.maps.android.utils.demo.KmlDemoActivity$DownloadKmlFile.doInBackground(KmlDemoActivity.java:88)
    at com.google.maps.android.utils.demo.KmlDemoActivity$DownloadKmlFile.doInBackground(KmlDemoActivity.java:79)
    at android.os.AsyncTask$2.call(AsyncTask.java:333)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:245)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
    at java.lang.Thread.run(Thread.java:764)