### PR TITLE
Fix issue #530:  Crash loading KML File if hotspot tag is empty

### DIFF
--- a/library/src/com/google/maps/android/data/kml/KmlStyleParser.java
+++ b/library/src/com/google/maps/android/data/kml/KmlStyleParser.java
@@ -171,10 +171,16 @@ import static org.xmlpull.v1.XmlPullParser.START_TAG;
      * @param style Style object to apply hotspot properties to
      */
     private static void setIconHotSpot(XmlPullParser parser, KmlStyle style) {
+        String xValStr=parser.getAttributeValue(null, "x");
+        String yValStr=parser.getAttributeValue(null, "y");
+        // if x or y tags are not available in hotspot tag or hotspot tag is empty then return 
+        if(xValStr==null||yValStr==null)
+            return;
+
         Float xValue, yValue;
         String xUnits, yUnits;
-        xValue = Float.parseFloat(parser.getAttributeValue(null, "x"));
-        yValue = Float.parseFloat(parser.getAttributeValue(null, "y"));
+        xValue = Float.parseFloat(xValStr);
+        yValue = Float.parseFloat(yValStr);
         xUnits = parser.getAttributeValue(null, "xunits");
         yUnits = parser.getAttributeValue(null, "yunits");
         style.setHotSpot(xValue, yValue, xUnits, yUnits);


### PR DESCRIPTION
Solve Crash if no x,y tags under hotspot

Exception : 
java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String java.lang.String.trim()' on a null object reference
        at sun.misc.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:1838)
        at sun.misc.FloatingDecimal.parseFloat(FloatingDecimal.java:122)
        at java.lang.Float.parseFloat(Float.java:451)
        at com.google.maps.android.data.kml.KmlStyleParser.setIconHotSpot(KmlStyleParser.java:176)
        at com.google.maps.android.data.kml.KmlStyleParser.createIconStyle(KmlStyleParser.java:95)
        at com.google.maps.android.data.kml.KmlStyleParser.createStyle(KmlStyleParser.java:53)
        at com.google.maps.android.data.kml.KmlContainerParser.setContainerStyle(KmlContainerParser.java:148)
        at com.google.maps.android.data.kml.KmlContainerParser.assignPropertiesToContainer(KmlContainerParser.java:91)
        at com.google.maps.android.data.kml.KmlContainerParser.createContainer(KmlContainerParser.java:52)
        at com.google.maps.android.data.kml.KmlParser.parseKml(KmlParser.java:74)
        at com.google.maps.android.data.kml.KmlLayer.<init>(KmlLayer.java:47)
        at com.google.maps.android.data.kml.KmlLayer.<init>(KmlLayer.java:29)