### PR TITLE
Update Android Gradle plugin to 3.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.1'
     }
 }
 


### PR DESCRIPTION
Android Studio 3.5.1 is now available:

https://androidstudio.googleblog.com/2019/10/android-studio-351-available.html