### PR TITLE
Fix test setup

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -8,8 +8,8 @@ dependencies {
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
 }
 
 android {
@@ -19,6 +19,7 @@ android {
 
     defaultConfig {
         minSdkVersion 14
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     sourceSets {

--- a/library/tests/src/com/google/maps/android/clustering/StaticClusterTest.java
+++ b/library/tests/src/com/google/maps/android/clustering/StaticClusterTest.java
@@ -19,6 +19,7 @@ package com.google.maps.android.clustering;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.maps.android.clustering.algo.StaticCluster;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.Assert;
 
@@ -26,6 +27,7 @@ public class StaticClusterTest {
 
     private StaticCluster<ClusterItem> mCluster;
 
+    @Before
     public void setUp() {
         mCluster = new StaticCluster<ClusterItem>(new LatLng(0.1, 0.5));
     }

--- a/library/tests/src/com/google/maps/android/data/LineStringTest.java
+++ b/library/tests/src/com/google/maps/android/data/LineStringTest.java
@@ -48,19 +48,19 @@ public class LineStringTest {
         Assert.assertNotNull(lineString);
         Assert.assertNotNull(lineString.getGeometryObject());
         Assert.assertEquals(lineString.getGeometryObject().size(), 6);
-        Assert.assertEquals(lineString.getGeometryObject().get(0).latitude, 90.0);
-        Assert.assertEquals(lineString.getGeometryObject().get(1).latitude, 90.0);
-        Assert.assertEquals(lineString.getGeometryObject().get(2).latitude, 90.0);
-        Assert.assertEquals(lineString.getGeometryObject().get(3).longitude, 53.0);
-        Assert.assertEquals(lineString.getGeometryObject().get(4).longitude, 54.0);
+        Assert.assertEquals(lineString.getGeometryObject().get(0).latitude, 90.0, 0);
+        Assert.assertEquals(lineString.getGeometryObject().get(1).latitude, 90.0, 0);
+        Assert.assertEquals(lineString.getGeometryObject().get(2).latitude, 90.0, 0);
+        Assert.assertEquals(lineString.getGeometryObject().get(3).longitude, 53.0, 0);
+        Assert.assertEquals(lineString.getGeometryObject().get(4).longitude, 54.0, 0);
         lineString = createLoopedLineString();
         Assert.assertNotNull(lineString);
         Assert.assertNotNull(lineString.getGeometryObject());
         Assert.assertEquals(lineString.getGeometryObject().size(), 4);
-        Assert.assertEquals(lineString.getGeometryObject().get(0).latitude, 90.0);
-        Assert.assertEquals(lineString.getGeometryObject().get(1).latitude, 89.0);
-        Assert.assertEquals(lineString.getGeometryObject().get(2).longitude, 62.0);
-        Assert.assertEquals(lineString.getGeometryObject().get(3).longitude, 66.0);
+        Assert.assertEquals(lineString.getGeometryObject().get(0).latitude, 90.0, 0);
+        Assert.assertEquals(lineString.getGeometryObject().get(1).latitude, 89.0, 0);
+        Assert.assertEquals(lineString.getGeometryObject().get(2).longitude, 62.0, 0);
+        Assert.assertEquals(lineString.getGeometryObject().get(3).longitude, 66.0, 0);
 
     }
 

--- a/library/tests/src/com/google/maps/android/data/geojson/GeoJsonLineStringStyleTest.java
+++ b/library/tests/src/com/google/maps/android/data/geojson/GeoJsonLineStringStyleTest.java
@@ -57,15 +57,15 @@ public class GeoJsonLineStringStyleTest {
     @Test
     public void testWidth() throws Exception {
         lineStringStyle.setWidth(20.2f);
-        Assert.assertEquals(20.2f, lineStringStyle.getWidth());
-        Assert.assertEquals(20.2f, lineStringStyle.toPolylineOptions().getWidth());
+        Assert.assertEquals(20.2f, lineStringStyle.getWidth(), 0);
+        Assert.assertEquals(20.2f, lineStringStyle.toPolylineOptions().getWidth(), 0);
     }
 
     @Test
     public void testZIndex() throws Exception {
         lineStringStyle.setZIndex(50.78f);
-        Assert.assertEquals(50.78f, lineStringStyle.getZIndex());
-        Assert.assertEquals(50.78f, lineStringStyle.toPolylineOptions().getZIndex());
+        Assert.assertEquals(50.78f, lineStringStyle.getZIndex(), 0);
+        Assert.assertEquals(50.78f, lineStringStyle.toPolylineOptions().getZIndex(), 0);
     }
 
     @Test
@@ -73,8 +73,8 @@ public class GeoJsonLineStringStyleTest {
         Assert.assertEquals(Color.BLACK, lineStringStyle.getColor());
         Assert.assertFalse(lineStringStyle.isGeodesic());
         Assert.assertTrue(lineStringStyle.isVisible());
-        Assert.assertEquals(10.0f, lineStringStyle.getWidth());
-        Assert.assertEquals(0.0f, lineStringStyle.getZIndex());
+        Assert.assertEquals(10.0f, lineStringStyle.getWidth(), 0);
+        Assert.assertEquals(0.0f, lineStringStyle.getZIndex(), 0);
     }
 
     @Test
@@ -82,7 +82,7 @@ public class GeoJsonLineStringStyleTest {
         Assert.assertEquals(Color.BLACK, lineStringStyle.toPolylineOptions().getColor());
         Assert.assertFalse(lineStringStyle.toPolylineOptions().isGeodesic());
         Assert.assertTrue(lineStringStyle.toPolylineOptions().isVisible());
-        Assert.assertEquals(10.0f, lineStringStyle.toPolylineOptions().getWidth());
-        Assert.assertEquals(0.0f, lineStringStyle.toPolylineOptions().getZIndex());
+        Assert.assertEquals(10.0f, lineStringStyle.toPolylineOptions().getWidth(), 0);
+        Assert.assertEquals(0.0f, lineStringStyle.toPolylineOptions().getZIndex(), 0);
     }
 }

--- a/library/tests/src/com/google/maps/android/data/geojson/GeoJsonPointStyleTest.java
+++ b/library/tests/src/com/google/maps/android/data/geojson/GeoJsonPointStyleTest.java
@@ -1,6 +1,7 @@
 package com.google.maps.android.data.geojson;
 
-import android.support.test.InstrumentationRegistry;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.google.android.gms.maps.MapsInitializer;
 import com.google.android.gms.maps.model.BitmapDescriptor;
@@ -9,6 +10,7 @@ import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.Assert;
+import org.junit.runner.RunWith;
 
 import java.util.Arrays;
 
@@ -18,7 +20,7 @@ public class GeoJsonPointStyleTest {
 
     @Before
     public void setUp() throws Exception {
-        MapsInitializer.initialize(InstrumentationRegistry.getTargetContext());
+        MapsInitializer.initialize(InstrumentationRegistry.getInstrumentation().getTargetContext());
         pointStyle = new GeoJsonPointStyle();
     }
 

--- a/library/tests/src/com/google/maps/android/data/geojson/GeoJsonPolygonStyleTest.java
+++ b/library/tests/src/com/google/maps/android/data/geojson/GeoJsonPolygonStyleTest.java
@@ -66,8 +66,8 @@ public class GeoJsonPolygonStyleTest {
     @Test
     public void testStrokeWidth() throws Exception {
         polygonStyle.setStrokeWidth(20.0f);
-        Assert.assertEquals(20.0f, polygonStyle.getStrokeWidth());
-        Assert.assertEquals(20.0f, polygonStyle.toPolygonOptions().getStrokeWidth());
+        Assert.assertEquals(20.0f, polygonStyle.getStrokeWidth(), 0);
+        Assert.assertEquals(20.0f, polygonStyle.toPolygonOptions().getStrokeWidth(), 0);
     }
 
     @Test
@@ -80,8 +80,8 @@ public class GeoJsonPolygonStyleTest {
     @Test
     public void testZIndex() throws Exception {
         polygonStyle.setZIndex(3.4f);
-        Assert.assertEquals(3.4f, polygonStyle.getZIndex());
-        Assert.assertEquals(3.4f, polygonStyle.toPolygonOptions().getZIndex());
+        Assert.assertEquals(3.4f, polygonStyle.getZIndex(), 0);
+        Assert.assertEquals(3.4f, polygonStyle.toPolygonOptions().getZIndex(), 0);
     }
 
     @Test
@@ -89,9 +89,9 @@ public class GeoJsonPolygonStyleTest {
         Assert.assertEquals(Color.TRANSPARENT, polygonStyle.getFillColor());
         Assert.assertFalse(polygonStyle.isGeodesic());
         Assert.assertEquals(Color.BLACK, polygonStyle.getStrokeColor());
-        Assert.assertEquals(10.0f, polygonStyle.getStrokeWidth());
+        Assert.assertEquals(10.0f, polygonStyle.getStrokeWidth(), 0);
         Assert.assertTrue(polygonStyle.isVisible());
-        Assert.assertEquals(0.0f, polygonStyle.getZIndex());
+        Assert.assertEquals(0.0f, polygonStyle.getZIndex(), 0);
     }
 
     @Test
@@ -99,8 +99,8 @@ public class GeoJsonPolygonStyleTest {
         Assert.assertEquals(Color.TRANSPARENT, polygonStyle.toPolygonOptions().getFillColor());
         Assert.assertFalse(polygonStyle.toPolygonOptions().isGeodesic());
         Assert.assertEquals(Color.BLACK, polygonStyle.toPolygonOptions().getStrokeColor());
-        Assert.assertEquals(10.0f, polygonStyle.toPolygonOptions().getStrokeWidth());
+        Assert.assertEquals(10.0f, polygonStyle.toPolygonOptions().getStrokeWidth(), 0);
         Assert.assertTrue(polygonStyle.isVisible());
-        Assert.assertEquals(0.0f, polygonStyle.toPolygonOptions().getZIndex());
+        Assert.assertEquals(0.0f, polygonStyle.toPolygonOptions().getZIndex(), 0);
     }
 }

--- a/library/tests/src/com/google/maps/android/data/kml/KmlContainerParserTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlContainerParserTest.java
@@ -1,6 +1,6 @@
 package com.google.maps.android.data.kml;
 
-import android.support.test.InstrumentationRegistry;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.junit.Test;
 import org.junit.Assert;
@@ -15,7 +15,7 @@ import java.io.InputStream;
 public class KmlContainerParserTest {
 
     public XmlPullParser createParser(int res) throws Exception {
-        InputStream stream = InstrumentationRegistry.getTargetContext().getResources().openRawResource(res);
+        InputStream stream = InstrumentationRegistry.getInstrumentation().getTargetContext().getResources().openRawResource(res);
         XmlPullParserFactory factory = XmlPullParserFactory.newInstance();
         factory.setNamespaceAware(true);
         XmlPullParser parser = factory.newPullParser();

--- a/library/tests/src/com/google/maps/android/data/kml/KmlFeatureParserTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlFeatureParserTest.java
@@ -1,6 +1,6 @@
 package com.google.maps.android.data.kml;
 
-import android.support.test.InstrumentationRegistry;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.junit.Test;
 import org.junit.Assert;
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 public class KmlFeatureParserTest {
 
     public XmlPullParser createParser(int res) throws Exception {
-        InputStream stream = InstrumentationRegistry.getTargetContext().getResources().openRawResource(res);
+        InputStream stream = InstrumentationRegistry.getInstrumentation().getTargetContext().getResources().openRawResource(res);
         XmlPullParserFactory factory = XmlPullParserFactory.newInstance();
         factory.setNamespaceAware(true);
         XmlPullParser parser = factory.newPullParser();
@@ -70,7 +70,7 @@ public class KmlFeatureParserTest {
         Assert.assertNotNull(groundOverlay);
         Assert.assertEquals(groundOverlay.getProperty("name"), "Sample Ground Overlay");
         Assert.assertNotNull(groundOverlay.getImageUrl());
-        Assert.assertEquals(groundOverlay.getGroundOverlayOptions().getZIndex(), 99.0f);
+        Assert.assertEquals(groundOverlay.getGroundOverlayOptions().getZIndex(), 99.0f, 0);
         Assert.assertTrue(groundOverlay.getGroundOverlayOptions().isVisible());
         Assert.assertNotNull(groundOverlay.getLatLngBox());
         xmlPullParser = createParser(R.raw.amu_ground_overlay_color);

--- a/library/tests/src/com/google/maps/android/data/kml/KmlLineStringTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlLineStringTest.java
@@ -56,16 +56,16 @@ public class KmlLineStringTest {
         Assert.assertNotNull(kmlLineString);
         Assert.assertNotNull(kmlLineString.getGeometryObject());
         Assert.assertEquals(kmlLineString.getGeometryObject().size(), 3);
-        Assert.assertEquals(kmlLineString.getGeometryObject().get(0).latitude, 0.0);
-        Assert.assertEquals(kmlLineString.getGeometryObject().get(1).latitude, 50.0);
-        Assert.assertEquals(kmlLineString.getGeometryObject().get(2).latitude, 90.0);
+        Assert.assertEquals(kmlLineString.getGeometryObject().get(0).latitude, 0.0, 0);
+        Assert.assertEquals(kmlLineString.getGeometryObject().get(1).latitude, 50.0, 0);
+        Assert.assertEquals(kmlLineString.getGeometryObject().get(2).latitude, 90.0, 0);
         kmlLineString = createLoopedLineString();
         Assert.assertNotNull(kmlLineString);
         Assert.assertNotNull(kmlLineString.getGeometryObject());
         Assert.assertEquals(kmlLineString.getGeometryObject().size(), 3);
-        Assert.assertEquals(kmlLineString.getGeometryObject().get(0).latitude, 0.0);
-        Assert.assertEquals(kmlLineString.getGeometryObject().get(1).latitude, 50.0);
-        Assert.assertEquals(kmlLineString.getGeometryObject().get(2).latitude, 0.0);
+        Assert.assertEquals(kmlLineString.getGeometryObject().get(0).latitude, 0.0, 0);
+        Assert.assertEquals(kmlLineString.getGeometryObject().get(1).latitude, 50.0, 0);
+        Assert.assertEquals(kmlLineString.getGeometryObject().get(2).latitude, 0.0, 0);
 
     }
 

--- a/library/tests/src/com/google/maps/android/data/kml/KmlParserTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlParserTest.java
@@ -1,6 +1,6 @@
 package com.google.maps.android.data.kml;
 
-import android.support.test.InstrumentationRegistry;
+import androidx.test.platform.app.InstrumentationRegistry;
 import android.graphics.Color;
 
 import org.junit.Test;
@@ -14,7 +14,7 @@ import java.util.HashMap;
 public class KmlParserTest {
 
     public XmlPullParser createParser(int res) throws Exception {
-        InputStream stream = InstrumentationRegistry.getTargetContext().getResources().openRawResource(res);
+        InputStream stream = InstrumentationRegistry.getInstrumentation().getTargetContext().getResources().openRawResource(res);
         XmlPullParserFactory factory = XmlPullParserFactory.newInstance();
         factory.setNamespaceAware(true);
         XmlPullParser parser = factory.newPullParser();

--- a/library/tests/src/com/google/maps/android/data/kml/KmlPointTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlPointTest.java
@@ -32,8 +32,8 @@ public class KmlPointTest {
         kmlPoint = createSimplePoint();
         Assert.assertNotNull(kmlPoint);
         Assert.assertNotNull(kmlPoint.getGeometryObject());
-        Assert.assertEquals(kmlPoint.getGeometryObject().latitude, 0.0);
-        Assert.assertEquals(kmlPoint.getGeometryObject().longitude, 50.0);
+        Assert.assertEquals(kmlPoint.getGeometryObject().latitude, 0.0, 0);
+        Assert.assertEquals(kmlPoint.getGeometryObject().longitude, 50.0, 0);
     }
 
     @Test

--- a/library/tests/src/com/google/maps/android/data/kml/KmlStyleTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlStyleTest.java
@@ -49,9 +49,9 @@ public class KmlStyleTest {
         KmlStyle kmlStyle = new KmlStyle();
         Assert.assertNotNull(kmlStyle);
         Assert.assertNotNull(kmlStyle.getMarkerOptions());
-        Assert.assertEquals(kmlStyle.getMarkerOptions().getRotation(), 0.0f);
+        Assert.assertEquals(kmlStyle.getMarkerOptions().getRotation(), 0.0f, 0);
         kmlStyle.setHeading(3);
-        Assert.assertEquals(kmlStyle.getMarkerOptions().getRotation(), 3.0f);
+        Assert.assertEquals(kmlStyle.getMarkerOptions().getRotation(), 3.0f, 0);
     }
 
     @Test
@@ -63,8 +63,8 @@ public class KmlStyleTest {
         Assert.assertEquals(kmlStyle.getPolylineOptions().getWidth(), 10.0f, 0);
         Assert.assertEquals(kmlStyle.getPolygonOptions().getStrokeWidth(), 10.0f, 0);
         kmlStyle.setWidth(11.0f);
-        Assert.assertEquals(kmlStyle.getPolylineOptions().getWidth(), 11.0f);
-        Assert.assertEquals(kmlStyle.getPolygonOptions().getStrokeWidth(), 11.0f);
+        Assert.assertEquals(kmlStyle.getPolylineOptions().getWidth(), 11.0f, 0);
+        Assert.assertEquals(kmlStyle.getPolygonOptions().getStrokeWidth(), 11.0f, 0);
     }
 
     @Test

--- a/library/tests/src/com/google/maps/android/quadtree/PointQuadTreeTest.java
+++ b/library/tests/src/com/google/maps/android/quadtree/PointQuadTreeTest.java
@@ -19,6 +19,7 @@ package com.google.maps.android.quadtree;
 import com.google.maps.android.geometry.Bounds;
 import com.google.maps.android.geometry.Point;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.Assert;
 
@@ -29,6 +30,7 @@ public class PointQuadTreeTest {
 
     private PointQuadTree<Item> mTree;
 
+    @Before
     public void setUp() {
         mTree = new PointQuadTree<Item>(0, 1, 0, 1);
     }


### PR DESCRIPTION
Background: @ming13 initially opened #529 on June 13 which contained similar changes. Back then, the project was not using androidx dependencies yet, so a couple more changes were required to make it work with the latest `master` branch.

To test this, run:

```
./gradlew :library:connectedCheck
```

Notice that on the current `master` branch, the tests are broken. With this PR merged, the existing tests will pass.

More follow-up test fixes will be required - The rebased #529 will move test resources, and hopefully we can convert these to pure unit tests so that a connected device is no longer required.

For now, these are the _minimal_ changes required to restore the ability to run the existing tests.