### PR TITLE
Clean up and simplify tests

### DIFF
--- a/library/tests/src/com/google/maps/android/PolyUtilTest.java
+++ b/library/tests/src/com/google/maps/android/PolyUtilTest.java
@@ -19,23 +19,19 @@ package com.google.maps.android;
 import com.google.android.gms.maps.model.LatLng;
 
 import org.junit.Test;
-import org.junit.Assert;
 
-import java.lang.String;
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 public class PolyUtilTest {
-    private static final String TEST_LINE = "_cqeFf~cjVf@p@fA}AtAoB`ArAx@hA`GbIvDiFv@gAh@t@X\\|@z@`@Z\\Xf@Vf@VpA\\tATJ@NBBkC";
-
-    private static void expectNearNumber(double expected, double actual, double epsilon) {
-        Assert.assertTrue(String.format("Expected %f to be near %f", actual, expected),
-                Math.abs(expected - actual) <= epsilon);
-    }
+    private static final String TEST_LINE =
+            "_cqeFf~cjVf@p@fA}AtAoB`ArAx@hA`GbIvDiFv@gAh@t@X\\|@z@`@Z\\Xf@Vf@VpA\\tATJ@NBBkC";
 
     private static List<LatLng> makeList(double... coords) {
         int size = coords.length / 2;
-        ArrayList<LatLng> list = new ArrayList<LatLng>(size);
+        List<LatLng> list = new ArrayList<>(size);
         for (int i = 0; i < size; ++i) {
             list.add(new LatLng(coords[i + i], coords[i + i + 1]));
         }
@@ -44,24 +40,24 @@ public class PolyUtilTest {
 
     private static void containsCase(List<LatLng> poly, List<LatLng> yes, List<LatLng> no) {
         for (LatLng point : yes) {
-            Assert.assertTrue(PolyUtil.containsLocation(point, poly, true));
-            Assert.assertTrue(PolyUtil.containsLocation(point, poly, false));
+            assertTrue(PolyUtil.containsLocation(point, poly, true));
+            assertTrue(PolyUtil.containsLocation(point, poly, false));
         }
         for (LatLng point : no) {
-            Assert.assertFalse(PolyUtil.containsLocation(point, poly, true));
-            Assert.assertFalse(PolyUtil.containsLocation(point, poly, false));
+            assertFalse(PolyUtil.containsLocation(point, poly, true));
+            assertFalse(PolyUtil.containsLocation(point, poly, false));
         }
     }
 
-    private static void onEdgeCase(boolean geodesic,
-                                   List<LatLng> poly, List<LatLng> yes, List<LatLng> no) {
+    private static void onEdgeCase(
+            boolean geodesic, List<LatLng> poly, List<LatLng> yes, List<LatLng> no) {
         for (LatLng point : yes) {
-            Assert.assertTrue(PolyUtil.isLocationOnEdge(point, poly, geodesic));
-            Assert.assertTrue(PolyUtil.isLocationOnPath(point, poly, geodesic));
+            assertTrue(PolyUtil.isLocationOnEdge(point, poly, geodesic));
+            assertTrue(PolyUtil.isLocationOnPath(point, poly, geodesic));
         }
         for (LatLng point : no) {
-            Assert.assertFalse(PolyUtil.isLocationOnEdge(point, poly, geodesic));
-            Assert.assertFalse(PolyUtil.isLocationOnPath(point, poly, geodesic));
+            assertFalse(PolyUtil.isLocationOnEdge(point, poly, geodesic));
+            assertFalse(PolyUtil.isLocationOnPath(point, poly, geodesic));
         }
     }
 
@@ -70,9 +66,9 @@ public class PolyUtilTest {
         onEdgeCase(false, poly, yes, no);
     }
 
-    private static void locationIndexCase(boolean geodesic,
-                                          List<LatLng> poly, LatLng point, int idx) {
-        Assert.assertEquals(idx, PolyUtil.locationIndexOnPath(point, poly, geodesic));
+    private static void locationIndexCase(
+            boolean geodesic, List<LatLng> poly, LatLng point, int idx) {
+        assertEquals(idx, PolyUtil.locationIndexOnPath(point, poly, geodesic));
     }
 
     private static void locationIndexCase(List<LatLng> poly, LatLng point, int idx) {
@@ -80,14 +76,14 @@ public class PolyUtilTest {
         locationIndexCase(false, poly, point, idx);
     }
 
-    private static void locationIndexToleranceCase(boolean geodesic,
-                                                   List<LatLng> poly, LatLng point, double tolerance, int idx) {
-        Assert.assertEquals(idx, PolyUtil.locationIndexOnPath(point, poly, geodesic, tolerance));
+    private static void locationIndexToleranceCase(
+            boolean geodesic, List<LatLng> poly, LatLng point, int idx) {
+        assertEquals(idx, PolyUtil.locationIndexOnPath(point, poly, geodesic, 0.1));
     }
 
-    private static void locationIndexToleranceCase(List<LatLng> poly, LatLng point, double tolerance, int idx) {
-        locationIndexToleranceCase(true, poly, point, tolerance, idx);
-        locationIndexToleranceCase(false, poly, point, tolerance, idx);
+    private static void locationIndexToleranceCase(List<LatLng> poly, LatLng point, int idx) {
+        locationIndexToleranceCase(true, poly, point, idx);
+        locationIndexToleranceCase(false, poly, point, idx);
     }
 
     @Test
@@ -95,52 +91,73 @@ public class PolyUtilTest {
         // Empty
         onEdgeCase(makeList(), makeList(), makeList(0, 0));
 
-        final double small = 5e-7;  // About 5cm on equator, half the default tolerance.
-        final double big = 2e-6;  // About 10cm on equator, double the default tolerance.
+        final double small = 5e-7; // About 5cm on equator, half the default tolerance.
+        final double big = 2e-6; // About 10cm on equator, double the default tolerance.
 
         // Endpoints
         onEdgeCase(makeList(1, 2), makeList(1, 2), makeList(3, 5));
         onEdgeCase(makeList(1, 2, 3, 5), makeList(1, 2, 3, 5), makeList(0, 0));
 
         // On equator.
-        onEdgeCase(makeList(0, 90, 0, 180),
+        onEdgeCase(
+                makeList(0, 90, 0, 180),
                 makeList(0, 90 - small, 0, 90 + small, 0 - small, 90, 0, 135, small, 135),
                 makeList(0, 90 - big, 0, 0, 0, -90, big, 135));
 
         // Ends on same latitude.
-        onEdgeCase(makeList(-45, -180, -45, -small),
+        onEdgeCase(
+                makeList(-45, -180, -45, -small),
                 makeList(-45, 180 + small, -45, 180 - small, -45 - small, 180 - small, -45, 0),
                 makeList(-45, big, -45, 180 - big, -45 + big, -90, -45, 90));
 
         // Meridian.
-        onEdgeCase(makeList(-10, 30, 45, 30),
+        onEdgeCase(
+                makeList(-10, 30, 45, 30),
                 makeList(10, 30 - small, 20, 30 + small, -10 - small, 30 + small),
                 makeList(-10 - big, 30, 10, -150, 0, 30 - big));
 
         // Slanted close to meridian, close to North pole.
-        onEdgeCase(makeList(0, 0, 90 - small, 0 + big),
+        onEdgeCase(
+                makeList(0, 0, 90 - small, 0 + big),
                 makeList(1, 0 + small, 2, 0 - small, 90 - small, -90, 90 - small, 10),
                 makeList(-big, 0, 90 - big, 180, 10, big));
 
         // Arc > 120 deg.
-        onEdgeCase(makeList(0, 0, 0, 179.999),
+        onEdgeCase(
+                makeList(0, 0, 0, 179.999),
                 makeList(0, 90, 0, small, 0, 179, small, 90),
                 makeList(0, -90, small, -100, 0, 180, 0, -big, 90, 0, -90, 180));
 
-        onEdgeCase(makeList(10, 5, 30, 15),
+        onEdgeCase(
+                makeList(10, 5, 30, 15),
                 makeList(10 + 2 * big, 5 + big, 10 + big, 5 + big / 2, 30 - 2 * big, 15 - big),
-                makeList(20, 10, 10 - big, 5 - big / 2, 30 + 2 * big, 15 + big, 10 + 2 * big, 5, 10, 5 + big));
+                makeList(
+                        20,
+                        10,
+                        10 - big,
+                        5 - big / 2,
+                        30 + 2 * big,
+                        15 + big,
+                        10 + 2 * big,
+                        5,
+                        10,
+                        5 + big));
 
-        onEdgeCase(makeList(90 - small, 0, 0, 180 - small / 2),
+        onEdgeCase(
+                makeList(90 - small, 0, 0, 180 - small / 2),
                 makeList(big, -180 + small / 2, big, 180 - small / 4, big, 180 - small),
                 makeList(-big, -180 + small / 2, -big, 180, -big, 180 - small));
 
         // Reaching close to North pole.
-        onEdgeCase(true, makeList(80, 0, 80, 180 - small),
+        onEdgeCase(
+                true,
+                makeList(80, 0, 80, 180 - small),
                 makeList(90 - small, -90, 90, -135, 80 - small, 0, 80 + small, 0),
                 makeList(80, 90, 79, big));
 
-        onEdgeCase(false, makeList(80, 0, 80, 180 - small),
+        onEdgeCase(
+                false,
+                makeList(80, 0, 80, 180 - small),
                 makeList(80 - small, 0, 80 + small, 0, 80, 90),
                 makeList(79, big, 90 - small, -90, 90, -135));
     }
@@ -170,53 +187,57 @@ public class PolyUtilTest {
 
     @Test
     public void testLocationIndexTolerance() {
-        final double small = 5e-7;  // About 5cm on equator, half the default tolerance.
-        final double big = 2e-6;  // About 10cm on equator, double the default tolerance.
+        final double small = 5e-7; // About 5cm on equator, half the default tolerance.
+        final double big = 2e-6; // About 10cm on equator, double the default tolerance.
 
         // Test tolerance.
-        locationIndexToleranceCase(makeList(0, 90 - small, 0, 90, 0, 90 + small), new LatLng(0, 90), 0.1, 0);
-        locationIndexToleranceCase(makeList(0, 90 - small, 0, 90, 0, 90 + small), new LatLng(0, 90 + small), 0.1, 0);
-        locationIndexToleranceCase(makeList(0, 90 - small, 0, 90, 0, 90 + small), new LatLng(0, 90 + 2 * small), 0.1, 1);
-        locationIndexToleranceCase(makeList(0, 90 - small, 0, 90, 0, 90 + small), new LatLng(0, 90 + 3 * small), 0.1, -1);
-        locationIndexToleranceCase(makeList(0, 90 - big, 0, 90, 0, 90 + big), new LatLng(0, 90), 0.1, 0);
-        locationIndexToleranceCase(makeList(0, 90 - big, 0, 90, 0, 90 + big), new LatLng(0, 90 + big), 0.1, 1);
-        locationIndexToleranceCase(makeList(0, 90 - big, 0, 90, 0, 90 + big), new LatLng(0, 90 + 2 * big), 0.1, -1);
+        locationIndexToleranceCase(
+                makeList(0, 90 - small, 0, 90, 0, 90 + small), new LatLng(0, 90), 0);
+        locationIndexToleranceCase(
+                makeList(0, 90 - small, 0, 90, 0, 90 + small), new LatLng(0, 90 + small), 0);
+        locationIndexToleranceCase(
+                makeList(0, 90 - small, 0, 90, 0, 90 + small), new LatLng(0, 90 + 2 * small), 1);
+        locationIndexToleranceCase(
+                makeList(0, 90 - small, 0, 90, 0, 90 + small), new LatLng(0, 90 + 3 * small), -1);
+        locationIndexToleranceCase(makeList(0, 90 - big, 0, 90, 0, 90 + big), new LatLng(0, 90), 0);
+        locationIndexToleranceCase(
+                makeList(0, 90 - big, 0, 90, 0, 90 + big), new LatLng(0, 90 + big), 1);
+        locationIndexToleranceCase(
+                makeList(0, 90 - big, 0, 90, 0, 90 + big), new LatLng(0, 90 + 2 * big), -1);
     }
 
     @Test
     public void testContainsLocation() {
         // Empty.
-        containsCase(makeList(),
-                makeList(),
-                makeList(0, 0));
+        containsCase(makeList(), makeList(), makeList(0, 0));
 
         // One point.
-        containsCase(makeList(1, 2),
-                makeList(1, 2),
-                makeList(0, 0));
+        containsCase(makeList(1, 2), makeList(1, 2), makeList(0, 0));
 
         // Two points.
-        containsCase(makeList(1, 2, 3, 5),
-                makeList(1, 2, 3, 5),
-                makeList(0, 0, 40, 4));
+        containsCase(makeList(1, 2, 3, 5), makeList(1, 2, 3, 5), makeList(0, 0, 40, 4));
 
         // Some arbitrary triangle.
-        containsCase(makeList(0., 0., 10., 12., 20., 5.),
+        containsCase(
+                makeList(0., 0., 10., 12., 20., 5.),
                 makeList(10., 12., 10, 11, 19, 5),
                 makeList(0, 1, 11, 12, 30, 5, 0, -180, 0, 90));
 
         // Around North Pole.
-        containsCase(makeList(89, 0, 89, 120, 89, -120),
+        containsCase(
+                makeList(89, 0, 89, 120, 89, -120),
                 makeList(90, 0, 90, 180, 90, -90),
                 makeList(-90, 0, 0, 0));
 
         // Around South Pole.
-        containsCase(makeList(-89, 0, -89, 120, -89, -120),
+        containsCase(
+                makeList(-89, 0, -89, 120, -89, -120),
                 makeList(90, 0, 90, 180, 90, -90, 0, 0),
                 makeList(-90, 0, -90, 90));
 
         // Over/under segment on meridian and equator.
-        containsCase(makeList(5, 10, 10, 10, 0, 20, 0, -10),
+        containsCase(
+                makeList(5, 10, 10, 10, 0, 20, 0, -10),
                 makeList(2.5, 10, 1, 0),
                 makeList(15, 10, 0, -15, 0, 25, -1, 0));
     }
@@ -226,71 +247,72 @@ public class PolyUtilTest {
         /*
          * Polyline
          */
-        final String LINE = "elfjD~a}uNOnFN~Em@fJv@tEMhGDjDe@hG^nF??@lA?n@IvAC`Ay@A{@DwCA{CF_EC{CEi@PBTFDJBJ?V?n@?D@?A@?@?F?F?LAf@?n@@`@@T@~@FpA?fA?p@?r@?vAH`@OR@^ETFJCLD?JA^?J?P?fAC`B@d@?b@A\\@`@Ad@@\\?`@?f@?V?H?DD@DDBBDBD?D?B?B@B@@@B@B@B@D?D?JAF@H@FCLADBDBDCFAN?b@Af@@x@@";
+        final String LINE =
+                "elfjD~a}uNOnFN~Em@fJv@tEMhGDjDe@hG^nF??@lA?n@IvAC`Ay@A{@DwCA{CF_EC{CEi@PBTFDJBJ?V?n@?D@?A@?@?F?F?LAf@?n@@`@@T@~@FpA?fA?p@?r@?vAH`@OR@^ETFJCLD?JA^?J?P?fAC`B@d@?b@A\\@`@Ad@@\\?`@?f@?V?H?DD@DDBBDBD?D?B?B@B@@@B@B@B@D?D?JAF@H@FCLADBDBDCFAN?b@Af@@x@@";
         List<LatLng> line = PolyUtil.decode(LINE);
-        Assert.assertEquals(95, line.size());
+        assertEquals(95, line.size());
 
         List<LatLng> simplifiedLine;
         List<LatLng> copy;
 
         double tolerance = 5; // meters
-        copy = copyList(line);
+        copy = new ArrayList<>(line);
         simplifiedLine = PolyUtil.simplify(line, tolerance);
-        Assert.assertEquals(21, simplifiedLine.size());
+        assertEquals(21, simplifiedLine.size());
         assertEndPoints(line, simplifiedLine);
         assertSimplifiedPointsFromLine(line, simplifiedLine);
         assertLineLength(line, simplifiedLine);
         assertInputUnchanged(line, copy);
 
         tolerance = 10; // meters
-        copy = copyList(line);
+        copy = new ArrayList<>(line);
         simplifiedLine = PolyUtil.simplify(line, tolerance);
-        Assert.assertEquals(14, simplifiedLine.size());
+        assertEquals(14, simplifiedLine.size());
         assertEndPoints(line, simplifiedLine);
         assertSimplifiedPointsFromLine(line, simplifiedLine);
         assertLineLength(line, simplifiedLine);
         assertInputUnchanged(line, copy);
 
         tolerance = 15; // meters
-        copy = copyList(line);
+        copy = new ArrayList<>(line);
         simplifiedLine = PolyUtil.simplify(line, tolerance);
-        Assert.assertEquals(10, simplifiedLine.size());
+        assertEquals(10, simplifiedLine.size());
         assertEndPoints(line, simplifiedLine);
         assertSimplifiedPointsFromLine(line, simplifiedLine);
         assertLineLength(line, simplifiedLine);
         assertInputUnchanged(line, copy);
 
         tolerance = 20; // meters
-        copy = copyList(line);
+        copy = new ArrayList<>(line);
         simplifiedLine = PolyUtil.simplify(line, tolerance);
-        Assert.assertEquals(8, simplifiedLine.size());
+        assertEquals(8, simplifiedLine.size());
         assertEndPoints(line, simplifiedLine);
         assertSimplifiedPointsFromLine(line, simplifiedLine);
         assertLineLength(line, simplifiedLine);
         assertInputUnchanged(line, copy);
 
         tolerance = 50; // meters
-        copy = copyList(line);
+        copy = new ArrayList<>(line);
         simplifiedLine = PolyUtil.simplify(line, tolerance);
-        Assert.assertEquals(6, simplifiedLine.size());
+        assertEquals(6, simplifiedLine.size());
         assertEndPoints(line, simplifiedLine);
         assertSimplifiedPointsFromLine(line, simplifiedLine);
         assertLineLength(line, simplifiedLine);
         assertInputUnchanged(line, copy);
 
         tolerance = 500; // meters
-        copy = copyList(line);
+        copy = new ArrayList<>(line);
         simplifiedLine = PolyUtil.simplify(line, tolerance);
-        Assert.assertEquals(3, simplifiedLine.size());
+        assertEquals(3, simplifiedLine.size());
         assertEndPoints(line, simplifiedLine);
         assertSimplifiedPointsFromLine(line, simplifiedLine);
         assertLineLength(line, simplifiedLine);
         assertInputUnchanged(line, copy);
 
         tolerance = 1000; // meters
-        copy = copyList(line);
+        copy = new ArrayList<>(line);
         simplifiedLine = PolyUtil.simplify(line, tolerance);
-        Assert.assertEquals(2, simplifiedLine.size());
+        assertEquals(2, simplifiedLine.size());
         assertEndPoints(line, simplifiedLine);
         assertSimplifiedPointsFromLine(line, simplifiedLine);
         assertLineLength(line, simplifiedLine);
@@ -307,12 +329,12 @@ public class PolyUtilTest {
         triangle.add(new LatLng(28.06125, -82.40850));
         triangle.add(new LatLng(28.06035, -82.40834));
         triangle.add(new LatLng(28.06038, -82.40924));
-        Assert.assertFalse(PolyUtil.isClosedPolygon(triangle));
+        assertFalse(PolyUtil.isClosedPolygon(triangle));
 
-        copy = copyList(triangle);
+        copy = new ArrayList<>(triangle);
         tolerance = 88; // meters
         List<LatLng> simplifiedTriangle = PolyUtil.simplify(triangle, tolerance);
-        Assert.assertEquals(4, simplifiedTriangle.size());
+        assertEquals(4, simplifiedTriangle.size());
         assertEndPoints(triangle, simplifiedTriangle);
         assertSimplifiedPointsFromLine(triangle, simplifiedTriangle);
         assertLineLength(triangle, simplifiedTriangle);
@@ -322,26 +344,27 @@ public class PolyUtilTest {
         LatLng p = triangle.get(0);
         LatLng closePoint = new LatLng(p.latitude, p.longitude);
         triangle.add(closePoint);
-        Assert.assertTrue(PolyUtil.isClosedPolygon(triangle));
+        assertTrue(PolyUtil.isClosedPolygon(triangle));
 
-        copy = copyList(triangle);
+        copy = new ArrayList<>(triangle);
         tolerance = 88; // meters
         simplifiedTriangle = PolyUtil.simplify(triangle, tolerance);
-        Assert.assertEquals(4, simplifiedTriangle.size());
+        assertEquals(4, simplifiedTriangle.size());
         assertEndPoints(triangle, simplifiedTriangle);
         assertSimplifiedPointsFromLine(triangle, simplifiedTriangle);
         assertLineLength(triangle, simplifiedTriangle);
         assertInputUnchanged(triangle, copy);
 
         // Open oval
-        final String OVAL_POLYGON = "}wgjDxw_vNuAd@}AN{A]w@_Au@kAUaA?{@Ke@@_@C]D[FULWFOLSNMTOVOXO\\I\\CX?VJXJTDTNXTVVLVJ`@FXA\\AVLZBTATBZ@ZAT?\\?VFT@XGZ";
+        final String OVAL_POLYGON =
+                "}wgjDxw_vNuAd@}AN{A]w@_Au@kAUaA?{@Ke@@_@C]D[FULWFOLSNMTOVOXO\\I\\CX?VJXJTDTNXTVVLVJ`@FXA\\AVLZBTATBZ@ZAT?\\?VFT@XGZ";
         List<LatLng> oval = PolyUtil.decode(OVAL_POLYGON);
-        Assert.assertFalse(PolyUtil.isClosedPolygon(oval));
+        assertFalse(PolyUtil.isClosedPolygon(oval));
 
-        copy = copyList(oval);
+        copy = new ArrayList<>(oval);
         tolerance = 10; // meters
-        List simplifiedOval = PolyUtil.simplify(oval, tolerance);
-        Assert.assertEquals(13, simplifiedOval.size());
+        List<LatLng> simplifiedOval = PolyUtil.simplify(oval, tolerance);
+        assertEquals(13, simplifiedOval.size());
         assertEndPoints(oval, simplifiedOval);
         assertSimplifiedPointsFromLine(oval, simplifiedOval);
         assertLineLength(oval, simplifiedOval);
@@ -351,12 +374,12 @@ public class PolyUtilTest {
         p = oval.get(0);
         closePoint = new LatLng(p.latitude, p.longitude);
         oval.add(closePoint);
-        Assert.assertTrue(PolyUtil.isClosedPolygon(oval));
+        assertTrue(PolyUtil.isClosedPolygon(oval));
 
-        copy = copyList(oval);
+        copy = new ArrayList<>(oval);
         tolerance = 10; // meters
         simplifiedOval = PolyUtil.simplify(oval, tolerance);
-        Assert.assertEquals(13, simplifiedOval.size());
+        assertEquals(13, simplifiedOval.size());
         assertEndPoints(oval, simplifiedOval);
         assertSimplifiedPointsFromLine(oval, simplifiedOval);
         assertLineLength(oval, simplifiedOval);
@@ -368,23 +391,23 @@ public class PolyUtilTest {
      * simplified line, and that the end point of the original line matches the end point of the
      * simplified line.
      *
-     * @param line           original line
+     * @param line original line
      * @param simplifiedLine simplified line
      */
     private void assertEndPoints(List<LatLng> line, List<LatLng> simplifiedLine) {
-        Assert.assertEquals(line.get(0), simplifiedLine.get(0));
-        Assert.assertEquals(line.get(line.size() - 1), simplifiedLine.get(simplifiedLine.size() - 1));
+        assertEquals(line.get(0), simplifiedLine.get(0));
+        assertEquals(line.get(line.size() - 1), simplifiedLine.get(simplifiedLine.size() - 1));
     }
 
     /**
      * Asserts that the simplified line is composed of points from the original line.
      *
-     * @param line           original line
+     * @param line original line
      * @param simplifiedLine simplified line
      */
     private void assertSimplifiedPointsFromLine(List<LatLng> line, List<LatLng> simplifiedLine) {
         for (LatLng l : simplifiedLine) {
-            Assert.assertTrue(line.contains(l));
+            assertTrue(line.contains(l));
         }
     }
 
@@ -392,53 +415,41 @@ public class PolyUtilTest {
      * Asserts that the length of the simplified line is always equal to or less than the length of
      * the original line, if simplification has eliminated any points from the original line
      *
-     * @param line           original line
+     * @param line original line
      * @param simplifiedLine simplified line
      */
     private void assertLineLength(List<LatLng> line, List<LatLng> simplifiedLine) {
         if (line.size() == simplifiedLine.size()) {
             // If no points were eliminated, then the length of both lines should be the same
-            Assert.assertEquals(SphericalUtil.computeLength(simplifiedLine), SphericalUtil.computeLength(line), 0.0);
+            assertEquals(
+                    SphericalUtil.computeLength(simplifiedLine),
+                    SphericalUtil.computeLength(line),
+                    0.0);
         } else {
-            Assert.assertTrue(simplifiedLine.size() < line.size());
+            assertTrue(simplifiedLine.size() < line.size());
             // If points were eliminated, then the simplified line should always be shorter
-            Assert.assertTrue(SphericalUtil.computeLength(simplifiedLine) < SphericalUtil.computeLength(line));
+            assertTrue(
+                    SphericalUtil.computeLength(simplifiedLine)
+                            < SphericalUtil.computeLength(line));
         }
-    }
-
-    /**
-     * Returns a copy of the LatLng objects contained in one list to another list.  LatLng.latitude
-     * and LatLng.longitude are immutable, so having references to the same LatLng object is
-     * sufficient to guarantee that the contents are the same.
-     *
-     * @param original original list
-     * @return a copy of the original list, containing references to the same LatLng elements in
-     * the same order.
-     */
-    private List<LatLng> copyList(List<LatLng> original) {
-        ArrayList<LatLng> copy = new ArrayList<>(original.size());
-        for (LatLng l : original) {
-            copy.add(l);
-        }
-        return copy;
     }
 
     /**
      * Asserts that the contents of the original List passed into the PolyUtil.simplify() method
-     * doesn't change after the method is executed.  We test for this because the poly is modified
-     * (a small offset is added to the last point) to allow for polygon simplification.
+     * doesn't change after the method is executed. We test for this because the poly is modified (a
+     * small offset is added to the last point) to allow for polygon simplification.
      *
-     * @param afterInput  the list passed into PolyUtil.simplify(), after PolyUtil.simplify() has
-     *                    finished executing
+     * @param afterInput the list passed into PolyUtil.simplify(), after PolyUtil.simplify() has
+     *         finished executing
      * @param beforeInput a copy of the list before it is passed into PolyUtil.simplify()
      */
     private void assertInputUnchanged(List<LatLng> afterInput, List<LatLng> beforeInput) {
         // Check values
-        Assert.assertEquals(beforeInput, afterInput);
+        assertEquals(beforeInput, afterInput);
 
         // Check references
         for (int i = 0; i < beforeInput.size(); i++) {
-            Assert.assertSame(afterInput.get(i), beforeInput.get(i));
+            assertSame(afterInput.get(i), beforeInput.get(i));
         }
     }
 
@@ -451,11 +462,11 @@ public class PolyUtilTest {
         poly.add(new LatLng(28.06125, -82.40850));
         poly.add(new LatLng(28.06035, -82.40834));
 
-        Assert.assertFalse(PolyUtil.isClosedPolygon(poly));
+        assertFalse(PolyUtil.isClosedPolygon(poly));
 
         // Add the closing point that's same as the first
         poly.add(new LatLng(28.06025, -82.41030));
-        Assert.assertTrue(PolyUtil.isClosedPolygon(poly));
+        assertTrue(PolyUtil.isClosedPolygon(poly));
     }
 
     @Test
@@ -465,7 +476,7 @@ public class PolyUtilTest {
         LatLng p = new LatLng(28.05342, -82.41594);
 
         double distance = PolyUtil.distanceToLine(p, startLine, endLine);
-        expectNearNumber(42.989894, distance, 1e-6);
+        assertEquals(42.989894, distance, 1e-6);
     }
 
     @Test
@@ -473,17 +484,17 @@ public class PolyUtilTest {
         List<LatLng> latLngs = PolyUtil.decode(TEST_LINE);
 
         int expectedLength = 21;
-        Assert.assertEquals("Wrong length.", expectedLength, latLngs.size());
+        assertEquals("Wrong length.", expectedLength, latLngs.size());
 
         LatLng lastPoint = latLngs.get(expectedLength - 1);
-        expectNearNumber(37.76953, lastPoint.latitude, 1e-6);
-        expectNearNumber(-122.41488, lastPoint.longitude, 1e-6);
+        assertEquals(37.76953, lastPoint.latitude, 1e-6);
+        assertEquals(-122.41488, lastPoint.longitude, 1e-6);
     }
 
     @Test
     public void testEncodePath() {
         List<LatLng> path = PolyUtil.decode(TEST_LINE);
         String encoded = PolyUtil.encode(path);
-        Assert.assertEquals(TEST_LINE, encoded);
+        assertEquals(TEST_LINE, encoded);
     }
 }

--- a/library/tests/src/com/google/maps/android/SphericalUtilTest.java
+++ b/library/tests/src/com/google/maps/android/SphericalUtilTest.java
@@ -19,14 +19,15 @@ package com.google.maps.android;
 import com.google.android.gms.maps.model.LatLng;
 
 import org.junit.Test;
-import org.junit.Assert;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static com.google.maps.android.MathUtil.EARTH_RADIUS;
+import static org.junit.Assert.*;
+
 public class SphericalUtilTest {
-    static final double EARTH_RADIUS = MathUtil.EARTH_RADIUS;
     // The vertices of an octahedron, for testing
     private final LatLng up = new LatLng(90, 0);
     private final LatLng down = new LatLng(-90, 0);
@@ -35,92 +36,94 @@ public class SphericalUtilTest {
     private final LatLng back = new LatLng(0, -180);
     private final LatLng left = new LatLng(0, -90);
 
-    private static void expectEq(Object expected, Object actual) {
-        Assert.assertEquals(expected, actual);
-    }
-
     /**
      * Tests for approximate equality.
      */
     private static void expectLatLngApproxEquals(LatLng actual, LatLng expected) {
-        expectNearNumber(actual.latitude, expected.latitude, 1e-6);
+        assertEquals(actual.latitude, expected.latitude, 1e-6);
         // Account for the convergence of longitude lines at the poles
         double cosLat = Math.cos(Math.toRadians(actual.latitude));
-        expectNearNumber(cosLat * actual.longitude, cosLat * expected.longitude, 1e-6);
+        assertEquals(cosLat * actual.longitude, cosLat * expected.longitude, 1e-6);
     }
 
-    private static void expectNearNumber(double actual, double expected, double epsilon) {
-        Assert.assertTrue(String.format("Expected %g to be near %g", actual, expected),
-                Math.abs(expected - actual) <= epsilon);
+    private static double computeSignedTriangleArea(LatLng a, LatLng b, LatLng c) {
+        List<LatLng> path = Arrays.asList(a, b, c);
+        return SphericalUtil.computeSignedArea(path, 1);
+    }
+
+    private static double computeTriangleArea(LatLng a, LatLng b, LatLng c) {
+        return Math.abs(computeSignedTriangleArea(a, b, c));
+    }
+
+    private static int isCCW(LatLng a, LatLng b, LatLng c) {
+        return computeSignedTriangleArea(a, b, c) > 0 ? 1 : -1;
     }
 
     @Test
     public void testAngles() {
         // Same vertex
-        expectNearNumber(SphericalUtil.computeAngleBetween(up, up), 0, 1e-6);
-        expectNearNumber(SphericalUtil.computeAngleBetween(down, down), 0, 1e-6);
-        expectNearNumber(SphericalUtil.computeAngleBetween(left, left), 0, 1e-6);
-        expectNearNumber(SphericalUtil.computeAngleBetween(right, right), 0, 1e-6);
-        expectNearNumber(SphericalUtil.computeAngleBetween(front, front), 0, 1e-6);
-        expectNearNumber(SphericalUtil.computeAngleBetween(back, back), 0, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(up, up), 0, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(down, down), 0, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(left, left), 0, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(right, right), 0, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(front, front), 0, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(back, back), 0, 1e-6);
 
         // Adjacent vertices
-        expectNearNumber(SphericalUtil.computeAngleBetween(up, front), Math.PI / 2, 1e-6);
-        expectNearNumber(SphericalUtil.computeAngleBetween(up, right), Math.PI / 2, 1e-6);
-        expectNearNumber(SphericalUtil.computeAngleBetween(up, back), Math.PI / 2, 1e-6);
-        expectNearNumber(SphericalUtil.computeAngleBetween(up, left), Math.PI / 2, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(up, front), Math.PI / 2, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(up, right), Math.PI / 2, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(up, back), Math.PI / 2, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(up, left), Math.PI / 2, 1e-6);
 
-        expectNearNumber(SphericalUtil.computeAngleBetween(down, front), Math.PI / 2, 1e-6);
-        expectNearNumber(SphericalUtil.computeAngleBetween(down, right), Math.PI / 2, 1e-6);
-        expectNearNumber(SphericalUtil.computeAngleBetween(down, back), Math.PI / 2, 1e-6);
-        expectNearNumber(SphericalUtil.computeAngleBetween(down, left), Math.PI / 2, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(down, front), Math.PI / 2, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(down, right), Math.PI / 2, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(down, back), Math.PI / 2, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(down, left), Math.PI / 2, 1e-6);
 
-        expectNearNumber(SphericalUtil.computeAngleBetween(back, up), Math.PI / 2, 1e-6);
-        expectNearNumber(SphericalUtil.computeAngleBetween(back, right), Math.PI / 2, 1e-6);
-        expectNearNumber(SphericalUtil.computeAngleBetween(back, down), Math.PI / 2, 1e-6);
-        expectNearNumber(SphericalUtil.computeAngleBetween(back, left), Math.PI / 2, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(back, up), Math.PI / 2, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(back, right), Math.PI / 2, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(back, down), Math.PI / 2, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(back, left), Math.PI / 2, 1e-6);
 
         // Opposite vertices
-        expectNearNumber(SphericalUtil.computeAngleBetween(up, down), Math.PI, 1e-6);
-        expectNearNumber(SphericalUtil.computeAngleBetween(front, back), Math.PI, 1e-6);
-        expectNearNumber(SphericalUtil.computeAngleBetween(left, right), Math.PI, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(up, down), Math.PI, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(front, back), Math.PI, 1e-6);
+        assertEquals(SphericalUtil.computeAngleBetween(left, right), Math.PI, 1e-6);
     }
 
     @Test
     public void testDistances() {
-        expectNearNumber(SphericalUtil.computeDistanceBetween(up, down),
-                Math.PI * EARTH_RADIUS, 1e-6);
+        assertEquals(SphericalUtil.computeDistanceBetween(up, down), Math.PI * EARTH_RADIUS, 1e-6);
     }
 
     @Test
     public void testHeadings() {
         // Opposing vertices for which there is a result
-        expectNearNumber(SphericalUtil.computeHeading(up, down), -180, 1e-6);
-        expectNearNumber(SphericalUtil.computeHeading(down, up), 0, 1e-6);
+        assertEquals(SphericalUtil.computeHeading(up, down), -180, 1e-6);
+        assertEquals(SphericalUtil.computeHeading(down, up), 0, 1e-6);
 
         // Adjacent vertices for which there is a result
-        expectNearNumber(SphericalUtil.computeHeading(front, up), 0, 1e-6);
-        expectNearNumber(SphericalUtil.computeHeading(right, up), 0, 1e-6);
-        expectNearNumber(SphericalUtil.computeHeading(back, up), 0, 1e-6);
-        expectNearNumber(SphericalUtil.computeHeading(down, up), 0, 1e-6);
+        assertEquals(SphericalUtil.computeHeading(front, up), 0, 1e-6);
+        assertEquals(SphericalUtil.computeHeading(right, up), 0, 1e-6);
+        assertEquals(SphericalUtil.computeHeading(back, up), 0, 1e-6);
+        assertEquals(SphericalUtil.computeHeading(down, up), 0, 1e-6);
 
-        expectNearNumber(SphericalUtil.computeHeading(front, down), -180, 1e-6);
-        expectNearNumber(SphericalUtil.computeHeading(right, down), -180, 1e-6);
-        expectNearNumber(SphericalUtil.computeHeading(back, down), -180, 1e-6);
-        expectNearNumber(SphericalUtil.computeHeading(left, down), -180, 1e-6);
+        assertEquals(SphericalUtil.computeHeading(front, down), -180, 1e-6);
+        assertEquals(SphericalUtil.computeHeading(right, down), -180, 1e-6);
+        assertEquals(SphericalUtil.computeHeading(back, down), -180, 1e-6);
+        assertEquals(SphericalUtil.computeHeading(left, down), -180, 1e-6);
 
-        expectNearNumber(SphericalUtil.computeHeading(right, front), -90, 1e-6);
-        expectNearNumber(SphericalUtil.computeHeading(left, front), 90, 1e-6);
+        assertEquals(SphericalUtil.computeHeading(right, front), -90, 1e-6);
+        assertEquals(SphericalUtil.computeHeading(left, front), 90, 1e-6);
 
-        expectNearNumber(SphericalUtil.computeHeading(front, right), 90, 1e-6);
-        expectNearNumber(SphericalUtil.computeHeading(back, right), -90, 1e-6);
+        assertEquals(SphericalUtil.computeHeading(front, right), 90, 1e-6);
+        assertEquals(SphericalUtil.computeHeading(back, right), -90, 1e-6);
     }
 
     @Test
     public void testComputeOffset() {
         // From front
-        expectLatLngApproxEquals(
-                front, SphericalUtil.computeOffset(front, 0, 0));
+        expectLatLngApproxEquals(front, SphericalUtil.computeOffset(front, 0, 0));
         expectLatLngApproxEquals(
                 up, SphericalUtil.computeOffset(front, Math.PI * EARTH_RADIUS / 2, 0));
         expectLatLngApproxEquals(
@@ -135,8 +138,7 @@ public class SphericalUtilTest {
                 back, SphericalUtil.computeOffset(front, Math.PI * EARTH_RADIUS, 90));
 
         // From left
-        expectLatLngApproxEquals(
-                left, SphericalUtil.computeOffset(left, 0, 0));
+        expectLatLngApproxEquals(left, SphericalUtil.computeOffset(left, 0, 0));
         expectLatLngApproxEquals(
                 up, SphericalUtil.computeOffset(left, Math.PI * EARTH_RADIUS / 2, 0));
         expectLatLngApproxEquals(
@@ -156,32 +158,37 @@ public class SphericalUtilTest {
 
     @Test
     public void testComputeOffsetOrigin() {
-        expectLatLngApproxEquals(
-                front, SphericalUtil.computeOffsetOrigin(front, 0, 0));
+        expectLatLngApproxEquals(front, SphericalUtil.computeOffsetOrigin(front, 0, 0));
 
         expectLatLngApproxEquals(
-                front, SphericalUtil.computeOffsetOrigin(new LatLng(0, 45),
-                        Math.PI * EARTH_RADIUS / 4, 90));
+                front,
+                SphericalUtil.computeOffsetOrigin(
+                        new LatLng(0, 45), Math.PI * EARTH_RADIUS / 4, 90));
         expectLatLngApproxEquals(
-                front, SphericalUtil.computeOffsetOrigin(new LatLng(0, -45),
-                        Math.PI * EARTH_RADIUS / 4, -90));
+                front,
+                SphericalUtil.computeOffsetOrigin(
+                        new LatLng(0, -45), Math.PI * EARTH_RADIUS / 4, -90));
         expectLatLngApproxEquals(
-                front, SphericalUtil.computeOffsetOrigin(new LatLng(45, 0),
-                        Math.PI * EARTH_RADIUS / 4, 0));
+                front,
+                SphericalUtil.computeOffsetOrigin(
+                        new LatLng(45, 0), Math.PI * EARTH_RADIUS / 4, 0));
         expectLatLngApproxEquals(
-                front, SphericalUtil.computeOffsetOrigin(new LatLng(-45, 0),
-                        Math.PI * EARTH_RADIUS / 4, 180));
+                front,
+                SphericalUtil.computeOffsetOrigin(
+                        new LatLng(-45, 0), Math.PI * EARTH_RADIUS / 4, 180));
         /*expectLatLngApproxEquals(
-                front, SphericalUtil.computeOffsetOrigin(new LatLng(-45, 0),
-                Math.PI / 4, 180, 1)); */
+        front, SphericalUtil.computeOffsetOrigin(new LatLng(-45, 0),
+        Math.PI / 4, 180, 1)); */
         // Situations with no solution, should return null.
         //
         // First 'over' the pole.
-        expectEq(null, SphericalUtil.computeOffsetOrigin(new LatLng(80, 0),
-                Math.PI * EARTH_RADIUS / 4, 180));
+        assertNull(
+                SphericalUtil.computeOffsetOrigin(
+                        new LatLng(80, 0), Math.PI * EARTH_RADIUS / 4, 180));
         // Second a distance that doesn't fit on the earth.
-        expectEq(null, SphericalUtil.computeOffsetOrigin(new LatLng(80, 0),
-                Math.PI * EARTH_RADIUS / 4, 90));
+        assertNull(
+                SphericalUtil.computeOffsetOrigin(
+                        new LatLng(80, 0), Math.PI * EARTH_RADIUS / 4, 90));
     }
 
     @Test
@@ -194,38 +201,34 @@ public class SphericalUtilTest {
         // Some semi-random values to demonstrate going forward and backward yields
         // the same location.
         end = SphericalUtil.computeOffset(start, distance, heading);
-        expectLatLngApproxEquals(
-                start, SphericalUtil.computeOffsetOrigin(end, distance, heading));
+        expectLatLngApproxEquals(start, SphericalUtil.computeOffsetOrigin(end, distance, heading));
 
         heading = -37;
         end = SphericalUtil.computeOffset(start, distance, heading);
-        expectLatLngApproxEquals(
-                start, SphericalUtil.computeOffsetOrigin(end, distance, heading));
+        expectLatLngApproxEquals(start, SphericalUtil.computeOffsetOrigin(end, distance, heading));
 
         distance = 3.8e+7;
         end = SphericalUtil.computeOffset(start, distance, heading);
-        expectLatLngApproxEquals(
-                start, SphericalUtil.computeOffsetOrigin(end, distance, heading));
+        expectLatLngApproxEquals(start, SphericalUtil.computeOffsetOrigin(end, distance, heading));
 
         start = new LatLng(-21, -73);
         end = SphericalUtil.computeOffset(start, distance, heading);
-        expectLatLngApproxEquals(
-                start, SphericalUtil.computeOffsetOrigin(end, distance, heading));
+        expectLatLngApproxEquals(start, SphericalUtil.computeOffsetOrigin(end, distance, heading));
 
         // computeOffsetOrigin with multiple solutions, all we care about is that
         // going from there yields the requested result.
         //
         // First, for this particular situation the latitude is completely arbitrary.
-        start = SphericalUtil.computeOffsetOrigin(new LatLng(0, 90),
-                Math.PI * EARTH_RADIUS / 2, 90);
+        start =
+                SphericalUtil.computeOffsetOrigin(
+                        new LatLng(0, 90), Math.PI * EARTH_RADIUS / 2, 90);
         expectLatLngApproxEquals(
                 new LatLng(0, 90),
                 SphericalUtil.computeOffset(start, Math.PI * EARTH_RADIUS / 2, 90));
 
         // Second, for this particular situation the longitude is completely
         // arbitrary.
-        start = SphericalUtil.computeOffsetOrigin(new LatLng(90, 0),
-                Math.PI * EARTH_RADIUS / 4, 0);
+        start = SphericalUtil.computeOffsetOrigin(new LatLng(90, 0), Math.PI * EARTH_RADIUS / 4, 0);
         expectLatLngApproxEquals(
                 new LatLng(90, 0),
                 SphericalUtil.computeOffset(start, Math.PI * EARTH_RADIUS / 4, 0));
@@ -234,22 +237,16 @@ public class SphericalUtilTest {
     @Test
     public void testInterpolate() {
         // Same point
-        expectLatLngApproxEquals(
-                up, SphericalUtil.interpolate(up, up, 1 / 2.0));
-        expectLatLngApproxEquals(
-                down, SphericalUtil.interpolate(down, down, 1 / 2.0));
-        expectLatLngApproxEquals(
-                left, SphericalUtil.interpolate(left, left, 1 / 2.0));
+        expectLatLngApproxEquals(up, SphericalUtil.interpolate(up, up, 1 / 2.0));
+        expectLatLngApproxEquals(down, SphericalUtil.interpolate(down, down, 1 / 2.0));
+        expectLatLngApproxEquals(left, SphericalUtil.interpolate(left, left, 1 / 2.0));
 
         // Between front and up
-        expectLatLngApproxEquals(
-                new LatLng(1, 0), SphericalUtil.interpolate(front, up, 1 / 90.0));
-        expectLatLngApproxEquals(
-                new LatLng(1, 0), SphericalUtil.interpolate(up, front, 89 / 90.0));
+        expectLatLngApproxEquals(new LatLng(1, 0), SphericalUtil.interpolate(front, up, 1 / 90.0));
+        expectLatLngApproxEquals(new LatLng(1, 0), SphericalUtil.interpolate(up, front, 89 / 90.0));
         expectLatLngApproxEquals(
                 new LatLng(89, 0), SphericalUtil.interpolate(front, up, 89 / 90.0));
-        expectLatLngApproxEquals(
-                new LatLng(89, 0), SphericalUtil.interpolate(up, front, 1 / 90.0));
+        expectLatLngApproxEquals(new LatLng(89, 0), SphericalUtil.interpolate(up, front, 1 / 90.0));
 
         // Between front and down
         expectLatLngApproxEquals(
@@ -275,14 +272,11 @@ public class SphericalUtilTest {
         expectLatLngApproxEquals(
                 up, SphericalUtil.interpolate(new LatLng(45, 0), new LatLng(45, 180), 1 / 2.0));
         expectLatLngApproxEquals(
-                down,
-                SphericalUtil.interpolate(new LatLng(-45, 0), new LatLng(-45, 180), 1 / 2.0));
+                down, SphericalUtil.interpolate(new LatLng(-45, 0), new LatLng(-45, 180), 1 / 2.0));
 
         // boundary values for fraction, between left and back
-        expectLatLngApproxEquals(
-                left, SphericalUtil.interpolate(left, back, 0));
-        expectLatLngApproxEquals(
-                back, SphericalUtil.interpolate(left, back, 1.0));
+        expectLatLngApproxEquals(left, SphericalUtil.interpolate(left, back, 0));
+        expectLatLngApproxEquals(back, SphericalUtil.interpolate(left, back, 1.0));
 
         // two nearby points, separated by ~4m, for which the Slerp algorithm is not stable and we
         // have to fall back to linear interpolation.
@@ -290,91 +284,87 @@ public class SphericalUtilTest {
                 new LatLng(-37.756872, 175.325252),
                 SphericalUtil.interpolate(
                         new LatLng(-37.756891, 175.325262),
-                        new LatLng(-37.756853, 175.325242), 0.5));
+                        new LatLng(-37.756853, 175.325242),
+                        0.5));
     }
 
     @Test
     public void testComputeLength() {
         List<LatLng> latLngs;
 
-        expectNearNumber(SphericalUtil.computeLength(Collections.<LatLng>emptyList()), 0, 1e-6);
-        expectNearNumber(SphericalUtil.computeLength(Arrays.asList(new LatLng(0, 0))), 0, 1e-6);
+        assertEquals(SphericalUtil.computeLength(Collections.<LatLng>emptyList()), 0, 1e-6);
+        assertEquals(SphericalUtil.computeLength(Arrays.asList(new LatLng(0, 0))), 0, 1e-6);
 
         latLngs = Arrays.asList(new LatLng(0, 0), new LatLng(0.1, 0.1));
-        expectNearNumber(SphericalUtil.computeLength(latLngs),
-                Math.toRadians(0.1) * Math.sqrt(2) * EARTH_RADIUS, 1);
+        assertEquals(
+                SphericalUtil.computeLength(latLngs),
+                Math.toRadians(0.1) * Math.sqrt(2) * EARTH_RADIUS,
+                1);
 
         latLngs = Arrays.asList(new LatLng(0, 0), new LatLng(90, 0), new LatLng(0, 90));
-        expectNearNumber(SphericalUtil.computeLength(latLngs), Math.PI * EARTH_RADIUS, 1e-6);
-    }
-
-    private static double computeSignedTriangleArea(LatLng a, LatLng b, LatLng c) {
-        List<LatLng> path = Arrays.asList(a, b, c);
-        return SphericalUtil.computeSignedArea(path, 1);
-    }
-
-    private static double computeTriangleArea(LatLng a, LatLng b, LatLng c) {
-        return Math.abs(computeSignedTriangleArea(a, b, c));
-    }
-
-    private static int isCCW(LatLng a, LatLng b, LatLng c) {
-        return computeSignedTriangleArea(a, b, c) > 0 ? 1 : -1;
+        assertEquals(SphericalUtil.computeLength(latLngs), Math.PI * EARTH_RADIUS, 1e-6);
     }
 
     @Test
     public void testIsCCW() {
         // One face of the octahedron
-        expectEq(1, isCCW(right, up, front));
-        expectEq(1, isCCW(up, front, right));
-        expectEq(1, isCCW(front, right, up));
-        expectEq(-1, isCCW(front, up, right));
-        expectEq(-1, isCCW(up, right, front));
-        expectEq(-1, isCCW(right, front, up));
+        assertEquals(1, isCCW(right, up, front));
+        assertEquals(1, isCCW(up, front, right));
+        assertEquals(1, isCCW(front, right, up));
+        assertEquals(-1, isCCW(front, up, right));
+        assertEquals(-1, isCCW(up, right, front));
+        assertEquals(-1, isCCW(right, front, up));
     }
 
     @Test
     public void testComputeTriangleArea() {
-        expectNearNumber(computeTriangleArea(right, up, front), Math.PI / 2, 1e-6);
-        expectNearNumber(computeTriangleArea(front, up, right), Math.PI / 2, 1e-6);
+        assertEquals(computeTriangleArea(right, up, front), Math.PI / 2, 1e-6);
+        assertEquals(computeTriangleArea(front, up, right), Math.PI / 2, 1e-6);
 
         // computeArea returns area of zero on small polys
-        double area = computeTriangleArea(
-                new LatLng(0, 0),
-                new LatLng(0, Math.toDegrees(1E-6)),
-                new LatLng(Math.toDegrees(1E-6), 0));
+        double area =
+                computeTriangleArea(
+                        new LatLng(0, 0),
+                        new LatLng(0, Math.toDegrees(1E-6)),
+                        new LatLng(Math.toDegrees(1E-6), 0));
         double expectedArea = 1E-12 / 2;
 
-        Assert.assertTrue(Math.abs(expectedArea - area) < 1e-20);
+        assertTrue(Math.abs(expectedArea - area) < 1e-20);
     }
 
     @Test
     public void testComputeSignedTriangleArea() {
-        expectNearNumber(
+        assertEquals(
                 computeSignedTriangleArea(
                         new LatLng(0, 0), new LatLng(0, 0.1), new LatLng(0.1, 0.1)),
-                Math.toRadians(0.1) * Math.toRadians(0.1) / 2, 1e-6);
+                Math.toRadians(0.1) * Math.toRadians(0.1) / 2,
+                1e-6);
 
-        expectNearNumber(computeSignedTriangleArea(right, up, front),
-                Math.PI / 2, 1e-6);
+        assertEquals(computeSignedTriangleArea(right, up, front), Math.PI / 2, 1e-6);
 
-        expectNearNumber(computeSignedTriangleArea(front, up, right),
-                -Math.PI / 2, 1e-6);
+        assertEquals(computeSignedTriangleArea(front, up, right), -Math.PI / 2, 1e-6);
     }
 
     @Test
     public void testComputeArea() {
-        expectNearNumber(SphericalUtil.computeArea(Arrays.asList(right, up, front, down, right)),
-                Math.PI * EARTH_RADIUS * EARTH_RADIUS, .4);
+        assertEquals(
+                SphericalUtil.computeArea(Arrays.asList(right, up, front, down, right)),
+                Math.PI * EARTH_RADIUS * EARTH_RADIUS,
+                .4);
 
-        expectNearNumber(SphericalUtil.computeArea(Arrays.asList(right, down, front, up, right)),
-                Math.PI * EARTH_RADIUS * EARTH_RADIUS, .4);
+        assertEquals(
+                SphericalUtil.computeArea(Arrays.asList(right, down, front, up, right)),
+                Math.PI * EARTH_RADIUS * EARTH_RADIUS,
+                .4);
     }
 
     @Test
     public void testComputeSignedArea() {
         List<LatLng> path = Arrays.asList(right, up, front, down, right);
         List<LatLng> pathReversed = Arrays.asList(right, down, front, up, right);
-        expectEq(-SphericalUtil.computeSignedArea(path), SphericalUtil.computeSignedArea(pathReversed));
+        assertEquals(
+                -SphericalUtil.computeSignedArea(path),
+                SphericalUtil.computeSignedArea(pathReversed),
+                0);
     }
 }
-

--- a/library/tests/src/com/google/maps/android/clustering/QuadItemTest.java
+++ b/library/tests/src/com/google/maps/android/clustering/QuadItemTest.java
@@ -20,14 +20,34 @@ import com.google.android.gms.maps.model.LatLng;
 import com.google.maps.android.clustering.algo.NonHierarchicalDistanceBasedAlgorithm;
 
 import org.junit.Test;
-import org.junit.Assert;
+
+import static org.junit.Assert.*;
 
 public class QuadItemTest {
+    @Test
+    public void testRemoval() {
+        TestingItem item_1_5 = new TestingItem(0.1, 0.5);
+        TestingItem item_2_3 = new TestingItem(0.2, 0.3);
+
+        NonHierarchicalDistanceBasedAlgorithm<ClusterItem> algo =
+                new NonHierarchicalDistanceBasedAlgorithm<>();
+        algo.addItem(item_1_5);
+        algo.addItem(item_2_3);
+
+        assertEquals(2, algo.getItems().size());
+
+        algo.removeItem(item_1_5);
+
+        assertEquals(1, algo.getItems().size());
+
+        assertFalse(algo.getItems().contains(item_1_5));
+        assertTrue(algo.getItems().contains(item_2_3));
+    }
 
     public class TestingItem implements ClusterItem {
         private final LatLng mPosition;
 
-        public TestingItem(double lat, double lng) {
+        TestingItem(double lat, double lng) {
             mPosition = new LatLng(lat, lng);
         }
 
@@ -45,29 +65,5 @@ public class QuadItemTest {
         public String getSnippet() {
             return null;
         }
-    }
-
-    public void setUp() {
-        // nothing to setup
-    }
-
-    @Test
-    public void testRemoval() {
-        TestingItem item_1_5 = new TestingItem(0.1, 0.5);
-        TestingItem item_2_3 = new TestingItem(0.2, 0.3);
-
-        NonHierarchicalDistanceBasedAlgorithm<ClusterItem> algo
-                = new NonHierarchicalDistanceBasedAlgorithm<ClusterItem>();
-        algo.addItem(item_1_5);
-        algo.addItem(item_2_3);
-
-        Assert.assertEquals(2, algo.getItems().size());
-
-        algo.removeItem(item_1_5);
-
-        Assert.assertEquals(1, algo.getItems().size());
-
-        Assert.assertFalse(algo.getItems().contains(item_1_5));
-        Assert.assertTrue(algo.getItems().contains(item_2_3));
     }
 }

--- a/library/tests/src/com/google/maps/android/clustering/StaticClusterTest.java
+++ b/library/tests/src/com/google/maps/android/clustering/StaticClusterTest.java
@@ -19,35 +19,27 @@ package com.google.maps.android.clustering;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.maps.android.clustering.algo.StaticCluster;
 
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Assert;
+
+import static org.junit.Assert.*;
 
 public class StaticClusterTest {
-
-    private StaticCluster<ClusterItem> mCluster;
-
-    @Before
-    public void setUp() {
-        mCluster = new StaticCluster<ClusterItem>(new LatLng(0.1, 0.5));
-    }
-
     @Test
     public void testEquality() {
-        StaticCluster<ClusterItem> cluster_1_5 = new StaticCluster<ClusterItem>(
-                new LatLng(0.1, 0.5));
+        StaticCluster<ClusterItem> cluster1 = new StaticCluster<>(new LatLng(0.1, 0.5));
+        StaticCluster<ClusterItem> cluster2 = new StaticCluster<>(new LatLng(0.1, 0.5));
 
-        Assert.assertEquals(cluster_1_5, mCluster);
-        Assert.assertNotSame(cluster_1_5, mCluster);
-        Assert.assertEquals(cluster_1_5.hashCode(), mCluster.hashCode());
+        assertEquals(cluster1, cluster2);
+        assertNotSame(cluster1, cluster2);
+        assertEquals(cluster1.hashCode(), cluster2.hashCode());
     }
 
     @Test
     public void testUnequality() {
-        StaticCluster<ClusterItem> cluster_2_3 = new StaticCluster<ClusterItem>(
-                new LatLng(0.2, 0.3));
+        StaticCluster<ClusterItem> cluster1 = new StaticCluster<>(new LatLng(0.1, 0.5));
+        StaticCluster<ClusterItem> cluster2 = new StaticCluster<>(new LatLng(0.2, 0.3));
 
-        Assert.assertNotEquals(mCluster, cluster_2_3);
-        Assert.assertNotEquals(cluster_2_3.hashCode(), mCluster.hashCode());
+        assertNotEquals(cluster1, cluster2);
+        assertNotEquals(cluster1.hashCode(), cluster2.hashCode());
     }
 }

--- a/library/tests/src/com/google/maps/android/data/FeatureTest.java
+++ b/library/tests/src/com/google/maps/android/data/FeatureTest.java
@@ -3,61 +3,61 @@ package com.google.maps.android.data;
 import com.google.android.gms.maps.model.LatLng;
 
 import org.junit.Test;
-import org.junit.Assert;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
 
 public class FeatureTest {
-    Feature feature;
-
     @Test
-    public void testGetId() throws Exception {
-        feature = new Feature(null, "Pirate", null);
-        Assert.assertNotNull(feature.getId());
-        Assert.assertEquals("Pirate", feature.getId());
+    public void testGetId() {
+        Feature feature = new Feature(null, "Pirate", null);
+        assertNotNull(feature.getId());
+        assertEquals("Pirate", feature.getId());
         feature = new Feature(null, null, null);
-        Assert.assertNull(feature.getId());
+        assertNull(feature.getId());
     }
 
     @Test
-    public void testProperty() throws Exception {
-        HashMap<String, String> properties = new HashMap<>();
+    public void testProperty() {
+        Map<String, String> properties = new HashMap<>();
         properties.put("Color", "Red");
         properties.put("Width", "3");
-        feature = new Feature(null, null, properties);
-        Assert.assertFalse(feature.hasProperty("llama"));
-        Assert.assertTrue(feature.hasProperty("Color"));
-        Assert.assertEquals("Red", feature.getProperty("Color"));
-        Assert.assertTrue(feature.hasProperty("Width"));
-        Assert.assertEquals("3", feature.getProperty("Width"));
-        Assert.assertNull(feature.removeProperty("banana"));
-        Assert.assertEquals("3", feature.removeProperty("Width"));
-        Assert.assertNull(feature.setProperty("Width", "10"));
-        Assert.assertEquals("10", feature.setProperty("Width", "500"));
+        Feature feature = new Feature(null, null, properties);
+        assertFalse(feature.hasProperty("llama"));
+        assertTrue(feature.hasProperty("Color"));
+        assertEquals("Red", feature.getProperty("Color"));
+        assertTrue(feature.hasProperty("Width"));
+        assertEquals("3", feature.getProperty("Width"));
+        assertNull(feature.removeProperty("banana"));
+        assertEquals("3", feature.removeProperty("Width"));
+        assertNull(feature.setProperty("Width", "10"));
+        assertEquals("10", feature.setProperty("Width", "500"));
     }
 
     @Test
     public void testGeometry() {
-        feature = new Feature(null, null, null);
-        Assert.assertNull(feature.getGeometry());
+        Feature feature = new Feature(null, null, null);
+        assertNull(feature.getGeometry());
         Point point = new Point(new LatLng(0, 0));
         feature.setGeometry(point);
-        Assert.assertEquals(point, feature.getGeometry());
+        assertEquals(point, feature.getGeometry());
         feature.setGeometry(null);
-        Assert.assertNull(feature.getGeometry());
+        assertNull(feature.getGeometry());
 
-        LineString lineString = new LineString(new ArrayList<>(Arrays.asList(new LatLng(0, 0), new LatLng(50, 50))));
+        LineString lineString =
+                new LineString(
+                        new ArrayList<>(Arrays.asList(new LatLng(0, 0), new LatLng(50, 50))));
         feature = new Feature(lineString, null, null);
-        Assert.assertEquals(lineString, feature.getGeometry());
+        assertEquals(lineString, feature.getGeometry());
         feature.setGeometry(point);
-        Assert.assertEquals(point, feature.getGeometry());
+        assertEquals(point, feature.getGeometry());
         feature.setGeometry(null);
-        Assert.assertNull(feature.getGeometry());
+        assertNull(feature.getGeometry());
         feature.setGeometry(lineString);
-        Assert.assertEquals(lineString, feature.getGeometry());
+        assertEquals(lineString, feature.getGeometry());
     }
-
-
 }

--- a/library/tests/src/com/google/maps/android/data/LineStringTest.java
+++ b/library/tests/src/com/google/maps/android/data/LineStringTest.java
@@ -3,15 +3,15 @@ package com.google.maps.android.data;
 import com.google.android.gms.maps.model.LatLng;
 
 import org.junit.Test;
-import org.junit.Assert;
 
 import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 public class LineStringTest {
-    LineString lineString;
-
-    public LineString createSimpleLineString() {
-        ArrayList<LatLng> coordinates = new ArrayList<LatLng>();
+    private LineString createSimpleLineString() {
+        List<LatLng> coordinates = new ArrayList<>();
         coordinates.add(new LatLng(95, 60));
         coordinates.add(new LatLng(93, 57));
         coordinates.add(new LatLng(95, 55));
@@ -21,8 +21,8 @@ public class LineStringTest {
         return new LineString(coordinates);
     }
 
-    public LineString createLoopedLineString() {
-        ArrayList<LatLng> coordinates = new ArrayList<LatLng>();
+    private LineString createLoopedLineString() {
+        List<LatLng> coordinates = new ArrayList<>();
         coordinates.add(new LatLng(92, 66));
         coordinates.add(new LatLng(89, 64));
         coordinates.add(new LatLng(94, 62));
@@ -31,37 +31,35 @@ public class LineStringTest {
     }
 
     @Test
-    public void testGetType() throws Exception {
-        lineString = createSimpleLineString();
-        Assert.assertNotNull(lineString);
-        Assert.assertNotNull(lineString.getGeometryType());
-        Assert.assertEquals("LineString", lineString.getGeometryType());
+    public void testGetType() {
+        LineString lineString = createSimpleLineString();
+        assertNotNull(lineString);
+        assertNotNull(lineString.getGeometryType());
+        assertEquals("LineString", lineString.getGeometryType());
         lineString = createLoopedLineString();
-        Assert.assertNotNull(lineString);
-        Assert.assertNotNull(lineString.getGeometryType());
-        Assert.assertEquals("LineString", lineString.getGeometryType());
+        assertNotNull(lineString);
+        assertNotNull(lineString.getGeometryType());
+        assertEquals("LineString", lineString.getGeometryType());
     }
 
     @Test
-    public void testGetGeometryObject() throws Exception {
-        lineString = createSimpleLineString();
-        Assert.assertNotNull(lineString);
-        Assert.assertNotNull(lineString.getGeometryObject());
-        Assert.assertEquals(lineString.getGeometryObject().size(), 6);
-        Assert.assertEquals(lineString.getGeometryObject().get(0).latitude, 90.0, 0);
-        Assert.assertEquals(lineString.getGeometryObject().get(1).latitude, 90.0, 0);
-        Assert.assertEquals(lineString.getGeometryObject().get(2).latitude, 90.0, 0);
-        Assert.assertEquals(lineString.getGeometryObject().get(3).longitude, 53.0, 0);
-        Assert.assertEquals(lineString.getGeometryObject().get(4).longitude, 54.0, 0);
+    public void testGetGeometryObject() {
+        LineString lineString = createSimpleLineString();
+        assertNotNull(lineString);
+        assertNotNull(lineString.getGeometryObject());
+        assertEquals(lineString.getGeometryObject().size(), 6);
+        assertEquals(lineString.getGeometryObject().get(0).latitude, 90.0, 0);
+        assertEquals(lineString.getGeometryObject().get(1).latitude, 90.0, 0);
+        assertEquals(lineString.getGeometryObject().get(2).latitude, 90.0, 0);
+        assertEquals(lineString.getGeometryObject().get(3).longitude, 53.0, 0);
+        assertEquals(lineString.getGeometryObject().get(4).longitude, 54.0, 0);
         lineString = createLoopedLineString();
-        Assert.assertNotNull(lineString);
-        Assert.assertNotNull(lineString.getGeometryObject());
-        Assert.assertEquals(lineString.getGeometryObject().size(), 4);
-        Assert.assertEquals(lineString.getGeometryObject().get(0).latitude, 90.0, 0);
-        Assert.assertEquals(lineString.getGeometryObject().get(1).latitude, 89.0, 0);
-        Assert.assertEquals(lineString.getGeometryObject().get(2).longitude, 62.0, 0);
-        Assert.assertEquals(lineString.getGeometryObject().get(3).longitude, 66.0, 0);
-
+        assertNotNull(lineString);
+        assertNotNull(lineString.getGeometryObject());
+        assertEquals(lineString.getGeometryObject().size(), 4);
+        assertEquals(lineString.getGeometryObject().get(0).latitude, 90.0, 0);
+        assertEquals(lineString.getGeometryObject().get(1).latitude, 89.0, 0);
+        assertEquals(lineString.getGeometryObject().get(2).longitude, 62.0, 0);
+        assertEquals(lineString.getGeometryObject().get(3).longitude, 66.0, 0);
     }
-
 }

--- a/library/tests/src/com/google/maps/android/data/MultiGeometryTest.java
+++ b/library/tests/src/com/google/maps/android/data/MultiGeometryTest.java
@@ -4,73 +4,89 @@ import com.google.android.gms.maps.model.LatLng;
 import com.google.maps.android.data.geojson.GeoJsonPolygon;
 
 import org.junit.Test;
-import org.junit.Assert;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 public class MultiGeometryTest {
     MultiGeometry mg;
 
     @Test
-    public void testGetGeometryType() throws Exception {
-        ArrayList<LineString> lineStrings = new ArrayList<>();
-        lineStrings.add(new LineString(
-                new ArrayList<>(Arrays.asList(new LatLng(0, 0), new LatLng(50, 50)))));
-        lineStrings.add(new LineString(
-                new ArrayList<>(Arrays.asList(new LatLng(56, 65), new LatLng(23, 23)))));
+    public void testGetGeometryType() {
+        List<LineString> lineStrings = new ArrayList<>();
+        lineStrings.add(
+                new LineString(
+                        new ArrayList<>(Arrays.asList(new LatLng(0, 0), new LatLng(50, 50)))));
+        lineStrings.add(
+                new LineString(
+                        new ArrayList<>(Arrays.asList(new LatLng(56, 65), new LatLng(23, 23)))));
         mg = new MultiGeometry(lineStrings);
-        Assert.assertEquals("MultiGeometry", mg.getGeometryType());
-        ArrayList<GeoJsonPolygon> polygons = new ArrayList<GeoJsonPolygon>();
-        ArrayList<ArrayList<LatLng>> polygon = new ArrayList<ArrayList<LatLng>>();
-        polygon.add(new ArrayList<LatLng>(
-                Arrays.asList(new LatLng(0, 0), new LatLng(20, 20), new LatLng(60, 60),
-                        new LatLng(0, 0))));
+        assertEquals("MultiGeometry", mg.getGeometryType());
+        List<GeoJsonPolygon> polygons = new ArrayList<>();
+        List<ArrayList<LatLng>> polygon = new ArrayList<>();
+        polygon.add(
+                new ArrayList<>(
+                        Arrays.asList(
+                                new LatLng(0, 0),
+                                new LatLng(20, 20),
+                                new LatLng(60, 60),
+                                new LatLng(0, 0))));
         polygons.add(new GeoJsonPolygon(polygon));
-        polygon = new ArrayList<ArrayList<LatLng>>();
-        polygon.add(new ArrayList<LatLng>(
-                Arrays.asList(new LatLng(0, 0), new LatLng(50, 80), new LatLng(10, 15),
-                        new LatLng(0, 0))));
-        polygon.add(new ArrayList<LatLng>(
-                Arrays.asList(new LatLng(0, 0), new LatLng(20, 20), new LatLng(60, 60),
-                        new LatLng(0, 0))));
+        polygon = new ArrayList<>();
+        polygon.add(
+                new ArrayList<>(
+                        Arrays.asList(
+                                new LatLng(0, 0),
+                                new LatLng(50, 80),
+                                new LatLng(10, 15),
+                                new LatLng(0, 0))));
+        polygon.add(
+                new ArrayList<>(
+                        Arrays.asList(
+                                new LatLng(0, 0),
+                                new LatLng(20, 20),
+                                new LatLng(60, 60),
+                                new LatLng(0, 0))));
         polygons.add(new GeoJsonPolygon(polygon));
         mg = new MultiGeometry(polygons);
-        Assert.assertEquals("MultiGeometry", mg.getGeometryType());
+        assertEquals("MultiGeometry", mg.getGeometryType());
     }
 
     @Test
-    public void testSetGeometryType() throws Exception {
-        ArrayList<LineString> lineStrings = new ArrayList<>();
-        lineStrings.add(new LineString(
-                new ArrayList<>(Arrays.asList(new LatLng(0, 0), new LatLng(50, 50)))));
-        lineStrings.add(new LineString(
-                new ArrayList<>(Arrays.asList(new LatLng(56, 65), new LatLng(23, 23)))));
+    public void testSetGeometryType() {
+        List<LineString> lineStrings = new ArrayList<>();
+        lineStrings.add(
+                new LineString(
+                        new ArrayList<>(Arrays.asList(new LatLng(0, 0), new LatLng(50, 50)))));
+        lineStrings.add(
+                new LineString(
+                        new ArrayList<>(Arrays.asList(new LatLng(56, 65), new LatLng(23, 23)))));
         mg = new MultiGeometry(lineStrings);
-        Assert.assertEquals("MultiGeometry", mg.getGeometryType());
+        assertEquals("MultiGeometry", mg.getGeometryType());
         mg.setGeometryType("MultiLineString");
-        Assert.assertEquals("MultiLineString", mg.getGeometryType());
+        assertEquals("MultiLineString", mg.getGeometryType());
     }
 
     @Test
-    public void testGetGeometryObject() throws Exception {
-        ArrayList<Point> points = new ArrayList<>();
+    public void testGetGeometryObject() {
+        List<Point> points = new ArrayList<>();
         points.add(new Point(new LatLng(0, 0)));
         points.add(new Point(new LatLng(5, 5)));
         points.add(new Point(new LatLng(10, 10)));
         mg = new MultiGeometry(points);
-        Assert.assertEquals(points, mg.getGeometryObject());
+        assertEquals(points, mg.getGeometryObject());
         points = new ArrayList<>();
         mg = new MultiGeometry(points);
-        Assert.assertEquals(new ArrayList<Point>(), mg.getGeometryObject());
+        assertEquals(new ArrayList<Point>(), mg.getGeometryObject());
 
         try {
             mg = new MultiGeometry(null);
-            Assert.fail();
+            fail();
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("Geometries cannot be null", e.getMessage());
+            assertEquals("Geometries cannot be null", e.getMessage());
         }
     }
-
-
 }

--- a/library/tests/src/com/google/maps/android/data/PointTest.java
+++ b/library/tests/src/com/google/maps/android/data/PointTest.java
@@ -1,31 +1,27 @@
 package com.google.maps.android.data;
 
-
 import com.google.android.gms.maps.model.LatLng;
 
 import org.junit.Test;
-import org.junit.Assert;
+
+import static org.junit.Assert.*;
 
 public class PointTest {
-
-    Point p;
-
     @Test
-    public void testGetGeometryType() throws Exception {
-        p = new Point(new LatLng(0, 50));
-        Assert.assertEquals("Point", p.getGeometryType());
+    public void testGetGeometryType() {
+        Point p = new Point(new LatLng(0, 50));
+        assertEquals("Point", p.getGeometryType());
     }
 
     @Test
-    public void testGetGeometryObject() throws Exception {
-        p = new Point(new LatLng(0, 50));
-        Assert.assertEquals(new LatLng(0, 50), p.getGeometryObject());
+    public void testGetGeometryObject() {
+        Point p = new Point(new LatLng(0, 50));
+        assertEquals(new LatLng(0, 50), p.getGeometryObject());
         try {
-            p = new Point(null);
-            Assert.fail();
+            new Point(null);
+            fail();
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("Coordinates cannot be null", e.getMessage());
+            assertEquals("Coordinates cannot be null", e.getMessage());
         }
     }
-
 }

--- a/library/tests/src/com/google/maps/android/data/RendererTest.java
+++ b/library/tests/src/com/google/maps/android/data/RendererTest.java
@@ -1,29 +1,30 @@
 package com.google.maps.android.data;
 
-
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.LatLng;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Assert;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Set;
 
-public class RendererTest {
+import static org.junit.Assert.*;
 
+public class RendererTest {
     GoogleMap mMap1;
     Renderer mRenderer;
     Set<Feature> featureSet;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         HashMap<Feature, Object> features = new HashMap<>();
 
-        LineString lineString = new LineString(new ArrayList<>(Arrays.asList(new LatLng(0, 0), new LatLng(50, 50))));
+        LineString lineString =
+                new LineString(
+                        new ArrayList<>(Arrays.asList(new LatLng(0, 0), new LatLng(50, 50))));
         Feature feature1 = new Feature(lineString, null, null);
         Point point = new Point(new LatLng(0, 0));
         Feature feature2 = new Feature(point, null, null);
@@ -34,29 +35,29 @@ public class RendererTest {
     }
 
     @Test
-    public void testGetMap() throws Exception {
-        Assert.assertEquals(mMap1, mRenderer.getMap());
+    public void testGetMap() {
+        assertEquals(mMap1, mRenderer.getMap());
     }
 
     @Test
-    public void testGetFeatures() throws Exception {
-        Assert.assertEquals(featureSet, mRenderer.getFeatures());
+    public void testGetFeatures() {
+        assertEquals(featureSet, mRenderer.getFeatures());
     }
 
     @Test
-    public void testAddFeature() throws Exception {
+    public void testAddFeature() {
         Point p = new Point(new LatLng(30, 50));
         Feature feature1 = new Feature(p, null, null);
         mRenderer.addFeature(feature1);
-        Assert.assertTrue(mRenderer.getFeatures().contains(feature1));
+        assertTrue(mRenderer.getFeatures().contains(feature1));
     }
 
     @Test
-    public void testRemoveFeature() throws Exception {
+    public void testRemoveFeature() {
         Point p = new Point(new LatLng(40, 50));
         Feature feature1 = new Feature(p, null, null);
         mRenderer.addFeature(feature1);
         mRenderer.removeFeature(feature1);
-        Assert.assertFalse(mRenderer.getFeatures().contains(feature1));
+        assertFalse(mRenderer.getFeatures().contains(feature1));
     }
 }

--- a/library/tests/src/com/google/maps/android/data/geojson/BiMultiMapTest.java
+++ b/library/tests/src/com/google/maps/android/data/geojson/BiMultiMapTest.java
@@ -1,26 +1,26 @@
 package com.google.maps.android.data.geojson;
 
 import org.junit.Test;
-import org.junit.Assert;
 
 import java.util.Arrays;
 import java.util.List;
 
-public class BiMultiMapTest {
+import static org.junit.Assert.*;
 
+public class BiMultiMapTest {
     @Test
     public void testSingle() {
         BiMultiMap<String> map = new BiMultiMap<>();
         String key = "foo";
         String value = "bar";
         map.put(key, value);
-        Assert.assertEquals(1, map.size());
-        Assert.assertEquals(value, map.get(key));
-        Assert.assertEquals(key, map.getKey(value));
+        assertEquals(1, map.size());
+        assertEquals(value, map.get(key));
+        assertEquals(key, map.getKey(value));
         map.remove(key);
-        Assert.assertEquals(0, map.size());
-        Assert.assertNull(map.get(key));
-        Assert.assertNull(map.getKey(value));
+        assertEquals(0, map.size());
+        assertNull(map.get(key));
+        assertNull(map.getKey(value));
     }
 
     @Test
@@ -29,16 +29,16 @@ public class BiMultiMapTest {
         String key = "foo";
         List<String> values = Arrays.asList("bar", "baz");
         map.put(key, values);
-        Assert.assertEquals(1, map.size());
-        Assert.assertEquals(values, map.get(key));
+        assertEquals(1, map.size());
+        assertEquals(values, map.get(key));
         for (String value : values) {
-            Assert.assertEquals(key, map.getKey(value));
+            assertEquals(key, map.getKey(value));
         }
         map.remove(key);
-        Assert.assertEquals(0, map.size());
-        Assert.assertNull(map.get(key));
+        assertEquals(0, map.size());
+        assertNull(map.get(key));
         for (String value : values) {
-            Assert.assertNull(map.getKey(value));
+            assertNull(map.getKey(value));
         }
     }
 
@@ -48,15 +48,15 @@ public class BiMultiMapTest {
         String key = "foo";
         List<String> values = Arrays.asList("bar", "baz");
         map.put(key, values);
-        Assert.assertEquals(1, map.size());
-        Assert.assertEquals(values, map.get(key));
+        assertEquals(1, map.size());
+        assertEquals(values, map.get(key));
         for (String value : values) {
-            Assert.assertEquals(key, map.getKey(value));
+            assertEquals(key, map.getKey(value));
         }
         map.remove(key);
-        Assert.assertEquals(0, map.size());
+        assertEquals(0, map.size());
         for (String value : values) {
-            Assert.assertNull(map.getKey(value));
+            assertNull(map.getKey(value));
         }
     }
 }

--- a/library/tests/src/com/google/maps/android/data/geojson/GeoJsonFeatureTest.java
+++ b/library/tests/src/com/google/maps/android/data/geojson/GeoJsonFeatureTest.java
@@ -3,141 +3,147 @@ package com.google.maps.android.data.geojson;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
 
-import org.junit.Test;
-import org.junit.Assert;
-
+import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 
+import static org.junit.Assert.*;
+
 public class GeoJsonFeatureTest {
-
-    GeoJsonFeature feature;
-
     @Test
-    public void testGetId() throws Exception {
-        feature = new GeoJsonFeature(null, "Pirate", null, null);
-        Assert.assertNotNull(feature.getId());
-        Assert.assertEquals("Pirate", feature.getId());
+    public void testGetId() {
+        GeoJsonFeature feature = new GeoJsonFeature(null, "Pirate", null, null);
+        assertNotNull(feature.getId());
+        assertEquals("Pirate", feature.getId());
         feature = new GeoJsonFeature(null, null, null, null);
-        Assert.assertNull(feature.getId());
+        assertNull(feature.getId());
     }
 
     @Test
-    public void testProperty() throws Exception {
+    public void testProperty() {
         HashMap<String, String> properties = new HashMap<>();
         properties.put("Color", "Yellow");
         properties.put("Width", "5");
-        feature = new GeoJsonFeature(null, null, properties, null);
-        Assert.assertFalse(feature.hasProperty("llama"));
-        Assert.assertTrue(feature.hasProperty("Color"));
-        Assert.assertEquals("Yellow", feature.getProperty("Color"));
-        Assert.assertTrue(feature.hasProperty("Width"));
-        Assert.assertEquals("5", feature.getProperty("Width"));
-        Assert.assertNull(feature.removeProperty("banana"));
-        Assert.assertEquals("5", feature.removeProperty("Width"));
-        Assert.assertNull(feature.setProperty("Width", "10"));
-        Assert.assertEquals("10", feature.setProperty("Width", "500"));
+        GeoJsonFeature feature = new GeoJsonFeature(null, null, properties, null);
+        assertFalse(feature.hasProperty("llama"));
+        assertTrue(feature.hasProperty("Color"));
+        assertEquals("Yellow", feature.getProperty("Color"));
+        assertTrue(feature.hasProperty("Width"));
+        assertEquals("5", feature.getProperty("Width"));
+        assertNull(feature.removeProperty("banana"));
+        assertEquals("5", feature.removeProperty("Width"));
+        assertNull(feature.setProperty("Width", "10"));
+        assertEquals("10", feature.setProperty("Width", "500"));
     }
 
     @Test
-    public void testNullProperty() throws Exception {
+    public void testNullProperty() {
         GeoJsonLayer layer = new GeoJsonLayer(null, createFeatureCollection());
         GeoJsonFeature feature = layer.getFeatures().iterator().next();
-        Assert.assertTrue(feature.hasProperty("prop0"));
-        Assert.assertNull(feature.getProperty("prop0"));
-        Assert.assertFalse(feature.hasProperty("prop1"));
-        Assert.assertNull(feature.getProperty("prop1"));
+        assertTrue(feature.hasProperty("prop0"));
+        assertNull(feature.getProperty("prop0"));
+        assertFalse(feature.hasProperty("prop1"));
+        assertNull(feature.getProperty("prop1"));
     }
 
     @Test
     public void testPointStyle() {
-        feature = new GeoJsonFeature(null, null, null, null);
+        GeoJsonFeature feature = new GeoJsonFeature(null, null, null, null);
         GeoJsonPointStyle pointStyle = new GeoJsonPointStyle();
         feature.setPointStyle(pointStyle);
-        Assert.assertEquals(pointStyle, feature.getPointStyle());
+        assertEquals(pointStyle, feature.getPointStyle());
 
         try {
             feature.setPointStyle(null);
-            Assert.fail();
+            fail();
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("Point style cannot be null", e.getMessage());
+            assertEquals("Point style cannot be null", e.getMessage());
         }
     }
 
     @Test
     public void testLineStringStyle() {
-        feature = new GeoJsonFeature(null, null, null, null);
+        GeoJsonFeature feature = new GeoJsonFeature(null, null, null, null);
         GeoJsonLineStringStyle lineStringStyle = new GeoJsonLineStringStyle();
         feature.setLineStringStyle(lineStringStyle);
-        Assert.assertEquals(lineStringStyle, feature.getLineStringStyle());
+        assertEquals(lineStringStyle, feature.getLineStringStyle());
 
         try {
             feature.setLineStringStyle(null);
-            Assert.fail();
+            fail();
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("Line string style cannot be null", e.getMessage());
+            assertEquals("Line string style cannot be null", e.getMessage());
         }
     }
 
+    @Test
     public void testPolygonStyle() {
-        feature = new GeoJsonFeature(null, null, null, null);
+        GeoJsonFeature feature = new GeoJsonFeature(null, null, null, null);
         GeoJsonPolygonStyle polygonStyle = new GeoJsonPolygonStyle();
         feature.setPolygonStyle(polygonStyle);
-        Assert.assertEquals(polygonStyle, feature.getPolygonStyle());
+        assertEquals(polygonStyle, feature.getPolygonStyle());
 
         try {
             feature.setPolygonStyle(null);
-            Assert.fail();
+            fail();
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("Polygon style cannot be null", e.getMessage());
+            assertEquals("Polygon style cannot be null", e.getMessage());
         }
     }
 
+    @Test
     public void testGeometry() {
-        feature = new GeoJsonFeature(null, null, null, null);
-        Assert.assertNull(feature.getGeometry());
+        GeoJsonFeature feature = new GeoJsonFeature(null, null, null, null);
+        assertNull(feature.getGeometry());
         GeoJsonPoint point = new GeoJsonPoint(new LatLng(0, 0));
         feature.setGeometry(point);
-        Assert.assertEquals(point, feature.getGeometry());
+        assertEquals(point, feature.getGeometry());
         feature.setGeometry(null);
-        Assert.assertNull(feature.getGeometry());
+        assertNull(feature.getGeometry());
 
-        GeoJsonLineString lineString = new GeoJsonLineString(new ArrayList<LatLng>(Arrays.asList(new LatLng(0, 0), new LatLng(50, 50))));
+        GeoJsonLineString lineString =
+                new GeoJsonLineString(
+                        new ArrayList<>(Arrays.asList(new LatLng(0, 0), new LatLng(50, 50))));
         feature = new GeoJsonFeature(lineString, null, null, null);
-        Assert.assertEquals(lineString, feature.getGeometry());
+        assertEquals(lineString, feature.getGeometry());
         feature.setGeometry(point);
-        Assert.assertEquals(point, feature.getGeometry());
+        assertEquals(point, feature.getGeometry());
         feature.setGeometry(null);
-        Assert.assertNull(feature.getGeometry());
+        assertNull(feature.getGeometry());
         feature.setGeometry(lineString);
-        Assert.assertEquals(lineString, feature.getGeometry());
+        assertEquals(lineString, feature.getGeometry());
     }
 
+    @Test
     public void testGetBoundingBox() {
-        feature = new GeoJsonFeature(null, null, null, null);
-        Assert.assertNull(feature.getBoundingBox());
+        GeoJsonFeature feature = new GeoJsonFeature(null, null, null, null);
+        assertNull(feature.getBoundingBox());
 
         LatLngBounds boundingBox = new LatLngBounds(new LatLng(-20, -20), new LatLng(50, 50));
         feature = new GeoJsonFeature(null, null, null, boundingBox);
-        Assert.assertEquals(boundingBox, feature.getBoundingBox());
+        assertEquals(boundingBox, feature.getBoundingBox());
     }
 
-    private JSONObject createFeatureCollection() throws Exception {
-        return new JSONObject(
-                "{ \"type\": \"FeatureCollection\",\n"
-                        + "\"bbox\": [-150.0, -80.0, 150.0, 80.0],"
-                        + "    \"features\": [\n"
-                        + "      { \"type\": \"Feature\",\n"
-                        + "        \"id\": \"point\", \n"
-                        + "        \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]},\n"
-                        + "        \"properties\": {\"prop0\": null}\n"
-                        + "        }\n"
-                        + "       ]\n"
-                        + "     }"
-        );
+    private JSONObject createFeatureCollection() {
+        try {
+            return new JSONObject(
+                    "{ \"type\": \"FeatureCollection\",\n"
+                            + "\"bbox\": [-150.0, -80.0, 150.0, 80.0],    \"features\": [\n"
+                            + "      { \"type\": \"Feature\",\n"
+                            + "        \"id\": \"point\", \n"
+                            + "        \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0,"
+                            + " 0.5]},\n"
+                            + "        \"properties\": {\"prop0\": null}\n"
+                            + "        }\n"
+                            + "       ]\n"
+                            + "     }");
+        } catch (JSONException e) {
+            fail();
+        }
+        return null;
     }
-
 }

--- a/library/tests/src/com/google/maps/android/data/geojson/GeoJsonLayerTest.java
+++ b/library/tests/src/com/google/maps/android/data/geojson/GeoJsonLayerTest.java
@@ -1,17 +1,17 @@
 package com.google.maps.android.data.geojson;
 
+import android.graphics.Color;
+
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
 import com.google.maps.android.data.Feature;
 
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Assert;
 
-import org.json.JSONObject;
-
-import android.graphics.Color;
+import static org.junit.Assert.*;
 
 public class GeoJsonLayerTest {
     GoogleMap map;
@@ -24,73 +24,75 @@ public class GeoJsonLayerTest {
     }
 
     @Test
-    public void testGetFeatures() throws Exception {
+    public void testGetFeatures() {
         int featureCount = 0;
         for (Feature ignored : mLayer.getFeatures()) {
             featureCount++;
         }
-        Assert.assertEquals(3, featureCount);
+        assertEquals(3, featureCount);
     }
 
     @Test
-    public void testAddFeature() throws Exception {
+    public void testAddFeature() {
         int featureCount = 0;
         mLayer.addFeature(new GeoJsonFeature(null, null, null, null));
         for (Feature ignored : mLayer.getFeatures()) {
             featureCount++;
         }
-        Assert.assertEquals(4, featureCount);
+        assertEquals(4, featureCount);
     }
 
     @Test
-    public void testRemoveFeature() throws Exception {
+    public void testRemoveFeature() {
         int featureCount = 0;
         for (Feature ignored : mLayer.getFeatures()) {
             featureCount++;
         }
-        Assert.assertEquals(3, featureCount);
+        assertEquals(3, featureCount);
     }
 
     @Test
-    public void testMap() throws Exception {
-        Assert.assertEquals(map, mLayer.getMap());
+    public void testMap() {
+        assertEquals(map, mLayer.getMap());
         mLayer.setMap(map2);
-        Assert.assertEquals(map2, mLayer.getMap());
+        assertEquals(map2, mLayer.getMap());
         mLayer.setMap(null);
-        Assert.assertNull(mLayer.getMap());
+        assertNull(mLayer.getMap());
     }
 
     @Test
-    public void testDefaultPointStyle() throws Exception {
+    public void testDefaultPointStyle() {
         mLayer.getDefaultPointStyle().setTitle("Dolphin");
-        Assert.assertEquals("Dolphin", mLayer.getDefaultPointStyle().getTitle());
+        assertEquals("Dolphin", mLayer.getDefaultPointStyle().getTitle());
     }
 
     @Test
-    public void testDefaultLineStringStyle() throws Exception {
+    public void testDefaultLineStringStyle() {
         mLayer.getDefaultLineStringStyle().setColor(Color.BLUE);
-        Assert.assertEquals(Color.BLUE, mLayer.getDefaultLineStringStyle().getColor());
+        assertEquals(Color.BLUE, mLayer.getDefaultLineStringStyle().getColor());
     }
 
     @Test
-    public void testDefaultPolygonStyle() throws Exception {
+    public void testDefaultPolygonStyle() {
         mLayer.getDefaultPolygonStyle().setGeodesic(true);
-        Assert.assertTrue(mLayer.getDefaultPolygonStyle().isGeodesic());
+        assertTrue(mLayer.getDefaultPolygonStyle().isGeodesic());
     }
 
     @Test
-    public void testGetBoundingBox() throws Exception {
-        Assert.assertEquals(new LatLngBounds(new LatLng(-80, -150), new LatLng(80, 150)), mLayer.getBoundingBox());
+    public void testGetBoundingBox() {
+        assertEquals(
+                new LatLngBounds(new LatLng(-80, -150), new LatLng(80, 150)),
+                mLayer.getBoundingBox());
     }
 
     private JSONObject createFeatureCollection() throws Exception {
         return new JSONObject(
                 "{ \"type\": \"FeatureCollection\",\n"
-                        + "\"bbox\": [-150.0, -80.0, 150.0, 80.0],"
-                        + "    \"features\": [\n"
+                        + "\"bbox\": [-150.0, -80.0, 150.0, 80.0],    \"features\": [\n"
                         + "      { \"type\": \"Feature\",\n"
                         + "        \"id\": \"point\", \n"
-                        + "        \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]},\n"
+                        + "        \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0,"
+                        + " 0.5]},\n"
                         + "        \"properties\": {\"prop0\": \"value0\"}\n"
                         + "        },\n"
                         + "      { \"type\": \"Feature\",\n"
@@ -119,7 +121,6 @@ public class GeoJsonLayerTest {
                         + "           }\n"
                         + "         }\n"
                         + "       ]\n"
-                        + "     }"
-        );
+                        + "     }");
     }
 }

--- a/library/tests/src/com/google/maps/android/data/geojson/GeoJsonLineStringStyleTest.java
+++ b/library/tests/src/com/google/maps/android/data/geojson/GeoJsonLineStringStyleTest.java
@@ -1,88 +1,88 @@
 package com.google.maps.android.data.geojson;
 
+import android.graphics.Color;
+
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Assert;
-
-import android.graphics.Color;
 
 import java.util.Arrays;
 
-public class GeoJsonLineStringStyleTest {
+import static org.junit.Assert.*;
 
+public class GeoJsonLineStringStyleTest {
     GeoJsonLineStringStyle lineStringStyle;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         lineStringStyle = new GeoJsonLineStringStyle();
     }
 
     @Test
-    public void testGetGeometryType() throws Exception {
-        Assert.assertTrue(Arrays.asList(lineStringStyle.getGeometryType()).contains("LineString"));
-        Assert.assertTrue(Arrays.asList(lineStringStyle.getGeometryType()).contains("MultiLineString"));
-        Assert.assertTrue(Arrays.asList(lineStringStyle.getGeometryType()).contains("GeometryCollection"));
-        Assert.assertEquals(3, lineStringStyle.getGeometryType().length);
+    public void testGetGeometryType() {
+        assertTrue(Arrays.asList(lineStringStyle.getGeometryType()).contains("LineString"));
+        assertTrue(Arrays.asList(lineStringStyle.getGeometryType()).contains("MultiLineString"));
+        assertTrue(Arrays.asList(lineStringStyle.getGeometryType()).contains("GeometryCollection"));
+        assertEquals(3, lineStringStyle.getGeometryType().length);
     }
 
     @Test
-    public void testColor() throws Exception {
+    public void testColor() {
         lineStringStyle.setColor(Color.YELLOW);
-        Assert.assertEquals(Color.YELLOW, lineStringStyle.getColor());
-        Assert.assertEquals(Color.YELLOW, lineStringStyle.toPolylineOptions().getColor());
+        assertEquals(Color.YELLOW, lineStringStyle.getColor());
+        assertEquals(Color.YELLOW, lineStringStyle.toPolylineOptions().getColor());
 
         lineStringStyle.setColor(0x76543210);
-        Assert.assertEquals(0x76543210, lineStringStyle.getColor());
-        Assert.assertEquals(0x76543210, lineStringStyle.toPolylineOptions().getColor());
+        assertEquals(0x76543210, lineStringStyle.getColor());
+        assertEquals(0x76543210, lineStringStyle.toPolylineOptions().getColor());
 
         lineStringStyle.setColor(Color.parseColor("#000000"));
-        Assert.assertEquals(Color.parseColor("#000000"), lineStringStyle.getColor());
-        Assert.assertEquals(Color.parseColor("#000000"), lineStringStyle.toPolylineOptions().getColor());
+        assertEquals(Color.parseColor("#000000"), lineStringStyle.getColor());
+        assertEquals(Color.parseColor("#000000"), lineStringStyle.toPolylineOptions().getColor());
     }
 
     @Test
-    public void testGeodesic() throws Exception {
+    public void testGeodesic() {
         lineStringStyle.setGeodesic(true);
-        Assert.assertTrue(lineStringStyle.isGeodesic());
-        Assert.assertTrue(lineStringStyle.toPolylineOptions().isGeodesic());
+        assertTrue(lineStringStyle.isGeodesic());
+        assertTrue(lineStringStyle.toPolylineOptions().isGeodesic());
     }
 
     @Test
-    public void testVisible() throws Exception {
+    public void testVisible() {
         lineStringStyle.setVisible(false);
-        Assert.assertFalse(lineStringStyle.isVisible());
-        Assert.assertFalse(lineStringStyle.toPolylineOptions().isVisible());
+        assertFalse(lineStringStyle.isVisible());
+        assertFalse(lineStringStyle.toPolylineOptions().isVisible());
     }
 
     @Test
-    public void testWidth() throws Exception {
+    public void testWidth() {
         lineStringStyle.setWidth(20.2f);
-        Assert.assertEquals(20.2f, lineStringStyle.getWidth(), 0);
-        Assert.assertEquals(20.2f, lineStringStyle.toPolylineOptions().getWidth(), 0);
+        assertEquals(20.2f, lineStringStyle.getWidth(), 0);
+        assertEquals(20.2f, lineStringStyle.toPolylineOptions().getWidth(), 0);
     }
 
     @Test
-    public void testZIndex() throws Exception {
+    public void testZIndex() {
         lineStringStyle.setZIndex(50.78f);
-        Assert.assertEquals(50.78f, lineStringStyle.getZIndex(), 0);
-        Assert.assertEquals(50.78f, lineStringStyle.toPolylineOptions().getZIndex(), 0);
+        assertEquals(50.78f, lineStringStyle.getZIndex(), 0);
+        assertEquals(50.78f, lineStringStyle.toPolylineOptions().getZIndex(), 0);
     }
 
     @Test
     public void testDefaultLineStringStyle() {
-        Assert.assertEquals(Color.BLACK, lineStringStyle.getColor());
-        Assert.assertFalse(lineStringStyle.isGeodesic());
-        Assert.assertTrue(lineStringStyle.isVisible());
-        Assert.assertEquals(10.0f, lineStringStyle.getWidth(), 0);
-        Assert.assertEquals(0.0f, lineStringStyle.getZIndex(), 0);
+        assertEquals(Color.BLACK, lineStringStyle.getColor());
+        assertFalse(lineStringStyle.isGeodesic());
+        assertTrue(lineStringStyle.isVisible());
+        assertEquals(10.0f, lineStringStyle.getWidth(), 0);
+        assertEquals(0.0f, lineStringStyle.getZIndex(), 0);
     }
 
     @Test
-    public void testDefaultGetPolylineOptions() throws Exception {
-        Assert.assertEquals(Color.BLACK, lineStringStyle.toPolylineOptions().getColor());
-        Assert.assertFalse(lineStringStyle.toPolylineOptions().isGeodesic());
-        Assert.assertTrue(lineStringStyle.toPolylineOptions().isVisible());
-        Assert.assertEquals(10.0f, lineStringStyle.toPolylineOptions().getWidth(), 0);
-        Assert.assertEquals(0.0f, lineStringStyle.toPolylineOptions().getZIndex(), 0);
+    public void testDefaultGetPolylineOptions() {
+        assertEquals(Color.BLACK, lineStringStyle.toPolylineOptions().getColor());
+        assertFalse(lineStringStyle.toPolylineOptions().isGeodesic());
+        assertTrue(lineStringStyle.toPolylineOptions().isVisible());
+        assertEquals(10.0f, lineStringStyle.toPolylineOptions().getWidth(), 0);
+        assertEquals(0.0f, lineStringStyle.toPolylineOptions().getZIndex(), 0);
     }
 }

--- a/library/tests/src/com/google/maps/android/data/geojson/GeoJsonLineStringTest.java
+++ b/library/tests/src/com/google/maps/android/data/geojson/GeoJsonLineStringTest.java
@@ -3,55 +3,56 @@ package com.google.maps.android.data.geojson;
 import com.google.android.gms.maps.model.LatLng;
 
 import org.junit.Test;
-import org.junit.Assert;
 
 import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 public class GeoJsonLineStringTest {
-
     GeoJsonLineString ls;
 
     @Test
-    public void testGetType() throws Exception {
-        ArrayList<LatLng> coordinates = new ArrayList<LatLng>();
+    public void testGetType() {
+        List<LatLng> coordinates = new ArrayList<>();
         coordinates.add(new LatLng(0, 0));
         coordinates.add(new LatLng(50, 50));
         coordinates.add(new LatLng(100, 100));
         ls = new GeoJsonLineString(coordinates);
-        Assert.assertEquals("LineString", ls.getType());
+        assertEquals("LineString", ls.getType());
     }
 
     @Test
-    public void testGetCoordinates() throws Exception {
-        ArrayList<LatLng> coordinates = new ArrayList<LatLng>();
+    public void testGetCoordinates() {
+        List<LatLng> coordinates = new ArrayList<>();
         coordinates.add(new LatLng(0, 0));
         coordinates.add(new LatLng(50, 50));
         coordinates.add(new LatLng(100, 100));
         ls = new GeoJsonLineString(coordinates);
-        Assert.assertEquals(coordinates, ls.getCoordinates());
+        assertEquals(coordinates, ls.getCoordinates());
 
         try {
             ls = new GeoJsonLineString(null);
-            Assert.fail();
+            fail();
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("Coordinates cannot be null", e.getMessage());
+            assertEquals("Coordinates cannot be null", e.getMessage());
         }
     }
 
     @Test
-    public void testGetAltitudes() throws Exception {
-        ArrayList<LatLng> coordinates = new ArrayList<LatLng>();
+    public void testGetAltitudes() {
+        List<LatLng> coordinates = new ArrayList<>();
         coordinates.add(new LatLng(0, 0));
         coordinates.add(new LatLng(50, 50));
         coordinates.add(new LatLng(100, 100));
-        ArrayList<Double> altitudes = new ArrayList<Double>();
-        altitudes.add(new Double(100));
-        altitudes.add(new Double(200));
-        altitudes.add(new Double(300));
+        List<Double> altitudes = new ArrayList<>();
+        altitudes.add(100d);
+        altitudes.add(200d);
+        altitudes.add(300d);
         ls = new GeoJsonLineString(coordinates, altitudes);
-        Assert.assertEquals(altitudes, ls.getAltitudes());
-        Assert.assertEquals(ls.getAltitudes().get(0), 100.0, 0);
-        Assert.assertEquals(ls.getAltitudes().get(1), 200.0, 0);
-        Assert.assertEquals(ls.getAltitudes().get(2), 300.0, 0);
+        assertEquals(altitudes, ls.getAltitudes());
+        assertEquals(ls.getAltitudes().get(0), 100.0, 0);
+        assertEquals(ls.getAltitudes().get(1), 200.0, 0);
+        assertEquals(ls.getAltitudes().get(2), 300.0, 0);
     }
 }

--- a/library/tests/src/com/google/maps/android/data/geojson/GeoJsonMultiLineStringTest.java
+++ b/library/tests/src/com/google/maps/android/data/geojson/GeoJsonMultiLineStringTest.java
@@ -3,45 +3,50 @@ package com.google.maps.android.data.geojson;
 import com.google.android.gms.maps.model.LatLng;
 
 import org.junit.Test;
-import org.junit.Assert;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 public class GeoJsonMultiLineStringTest {
-
     GeoJsonMultiLineString mls;
 
     @Test
-    public void testGetType() throws Exception {
-        ArrayList<GeoJsonLineString> lineStrings = new ArrayList<GeoJsonLineString>();
-        lineStrings.add(new GeoJsonLineString(
-                new ArrayList<LatLng>(Arrays.asList(new LatLng(0, 0), new LatLng(50, 50)))));
-        lineStrings.add(new GeoJsonLineString(
-                new ArrayList<LatLng>(Arrays.asList(new LatLng(80, 10), new LatLng(-54, 12.7)))));
+    public void testGetType() {
+        List<GeoJsonLineString> lineStrings = new ArrayList<>();
+        lineStrings.add(
+                new GeoJsonLineString(
+                        new ArrayList<>(Arrays.asList(new LatLng(0, 0), new LatLng(50, 50)))));
+        lineStrings.add(
+                new GeoJsonLineString(
+                        new ArrayList<>(Arrays.asList(new LatLng(80, 10), new LatLng(-54, 12.7)))));
         mls = new GeoJsonMultiLineString(lineStrings);
-        Assert.assertEquals("MultiLineString", mls.getType());
+        assertEquals("MultiLineString", mls.getType());
     }
 
     @Test
-    public void testGetLineStrings() throws Exception {
-        ArrayList<GeoJsonLineString> lineStrings = new ArrayList<GeoJsonLineString>();
-        lineStrings.add(new GeoJsonLineString(
-                new ArrayList<LatLng>(Arrays.asList(new LatLng(0, 0), new LatLng(50, 50)))));
-        lineStrings.add(new GeoJsonLineString(
-                new ArrayList<LatLng>(Arrays.asList(new LatLng(80, 10), new LatLng(-54, 12.7)))));
+    public void testGetLineStrings() {
+        List<GeoJsonLineString> lineStrings = new ArrayList<>();
+        lineStrings.add(
+                new GeoJsonLineString(
+                        new ArrayList<>(Arrays.asList(new LatLng(0, 0), new LatLng(50, 50)))));
+        lineStrings.add(
+                new GeoJsonLineString(
+                        new ArrayList<>(Arrays.asList(new LatLng(80, 10), new LatLng(-54, 12.7)))));
         mls = new GeoJsonMultiLineString(lineStrings);
-        Assert.assertEquals(lineStrings, mls.getLineStrings());
+        assertEquals(lineStrings, mls.getLineStrings());
 
-        lineStrings = new ArrayList<GeoJsonLineString>();
+        lineStrings = new ArrayList<>();
         mls = new GeoJsonMultiLineString(lineStrings);
-        Assert.assertEquals(new ArrayList<GeoJsonLineString>(), mls.getLineStrings());
+        assertEquals(new ArrayList<GeoJsonLineString>(), mls.getLineStrings());
 
         try {
             mls = new GeoJsonMultiLineString(null);
-            Assert.fail();
+            fail();
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("Geometries cannot be null", e.getMessage());
+            assertEquals("Geometries cannot be null", e.getMessage());
         }
     }
 }

--- a/library/tests/src/com/google/maps/android/data/geojson/GeoJsonMultiPointTest.java
+++ b/library/tests/src/com/google/maps/android/data/geojson/GeoJsonMultiPointTest.java
@@ -3,42 +3,43 @@ package com.google.maps.android.data.geojson;
 import com.google.android.gms.maps.model.LatLng;
 
 import org.junit.Test;
-import org.junit.Assert;
 
 import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 public class GeoJsonMultiPointTest {
-
     GeoJsonMultiPoint mp;
 
     @Test
-    public void testGetType() throws Exception {
-        ArrayList<GeoJsonPoint> points = new ArrayList<GeoJsonPoint>();
+    public void testGetType() {
+        List<GeoJsonPoint> points = new ArrayList<>();
         points.add(new GeoJsonPoint(new LatLng(0, 0)));
         points.add(new GeoJsonPoint(new LatLng(5, 5)));
         points.add(new GeoJsonPoint(new LatLng(10, 10)));
         mp = new GeoJsonMultiPoint(points);
-        Assert.assertEquals("MultiPoint", mp.getType());
+        assertEquals("MultiPoint", mp.getType());
     }
 
     @Test
-    public void testGetPoints() throws Exception {
-        ArrayList<GeoJsonPoint> points = new ArrayList<GeoJsonPoint>();
+    public void testGetPoints() {
+        List<GeoJsonPoint> points = new ArrayList<>();
         points.add(new GeoJsonPoint(new LatLng(0, 0)));
         points.add(new GeoJsonPoint(new LatLng(5, 5)));
         points.add(new GeoJsonPoint(new LatLng(10, 10)));
         mp = new GeoJsonMultiPoint(points);
-        Assert.assertEquals(points, mp.getPoints());
+        assertEquals(points, mp.getPoints());
 
         points = new ArrayList<>();
         mp = new GeoJsonMultiPoint(points);
-        Assert.assertEquals(new ArrayList<GeoJsonPoint>(), mp.getPoints());
+        assertEquals(new ArrayList<GeoJsonPoint>(), mp.getPoints());
 
         try {
             mp = new GeoJsonMultiPoint(null);
-            Assert.fail();
+            fail();
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("Geometries cannot be null", e.getMessage());
+            assertEquals("Geometries cannot be null", e.getMessage());
         }
     }
 }

--- a/library/tests/src/com/google/maps/android/data/geojson/GeoJsonMultiPolygonTest.java
+++ b/library/tests/src/com/google/maps/android/data/geojson/GeoJsonMultiPolygonTest.java
@@ -3,63 +3,88 @@ package com.google.maps.android.data.geojson;
 import com.google.android.gms.maps.model.LatLng;
 
 import org.junit.Test;
-import org.junit.Assert;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 public class GeoJsonMultiPolygonTest {
-
     GeoJsonMultiPolygon mp;
 
     @Test
-    public void testGetType() throws Exception {
-        ArrayList<GeoJsonPolygon> polygons = new ArrayList<GeoJsonPolygon>();
-        ArrayList<ArrayList<LatLng>> polygon = new ArrayList<ArrayList<LatLng>>();
-        polygon.add(new ArrayList<LatLng>(
-                Arrays.asList(new LatLng(0, 0), new LatLng(20, 20), new LatLng(60, 60),
-                        new LatLng(0, 0))));
+    public void testGetType() {
+        List<GeoJsonPolygon> polygons = new ArrayList<>();
+        List<ArrayList<LatLng>> polygon = new ArrayList<>();
+        polygon.add(
+                new ArrayList<>(
+                        Arrays.asList(
+                                new LatLng(0, 0),
+                                new LatLng(20, 20),
+                                new LatLng(60, 60),
+                                new LatLng(0, 0))));
         polygons.add(new GeoJsonPolygon(polygon));
-        polygon = new ArrayList<ArrayList<LatLng>>();
-        polygon.add(new ArrayList<LatLng>(
-                Arrays.asList(new LatLng(0, 0), new LatLng(50, 80), new LatLng(10, 15),
-                        new LatLng(0, 0))));
-        polygon.add(new ArrayList<LatLng>(
-                Arrays.asList(new LatLng(0, 0), new LatLng(20, 20), new LatLng(60, 60),
-                        new LatLng(0, 0))));
+        polygon = new ArrayList<>();
+        polygon.add(
+                new ArrayList<>(
+                        Arrays.asList(
+                                new LatLng(0, 0),
+                                new LatLng(50, 80),
+                                new LatLng(10, 15),
+                                new LatLng(0, 0))));
+        polygon.add(
+                new ArrayList<>(
+                        Arrays.asList(
+                                new LatLng(0, 0),
+                                new LatLng(20, 20),
+                                new LatLng(60, 60),
+                                new LatLng(0, 0))));
         polygons.add(new GeoJsonPolygon(polygon));
         mp = new GeoJsonMultiPolygon(polygons);
-        Assert.assertEquals("MultiPolygon", mp.getType());
+        assertEquals("MultiPolygon", mp.getType());
     }
 
     @Test
-    public void testGetPolygons() throws Exception {
-        ArrayList<GeoJsonPolygon> polygons = new ArrayList<GeoJsonPolygon>();
-        ArrayList<ArrayList<LatLng>> polygon = new ArrayList<ArrayList<LatLng>>();
-        polygon.add(new ArrayList<LatLng>(
-                Arrays.asList(new LatLng(0, 0), new LatLng(20, 20), new LatLng(60, 60),
-                        new LatLng(0, 0))));
+    public void testGetPolygons() {
+        List<GeoJsonPolygon> polygons = new ArrayList<>();
+        List<ArrayList<LatLng>> polygon = new ArrayList<>();
+        polygon.add(
+                new ArrayList<>(
+                        Arrays.asList(
+                                new LatLng(0, 0),
+                                new LatLng(20, 20),
+                                new LatLng(60, 60),
+                                new LatLng(0, 0))));
         polygons.add(new GeoJsonPolygon(polygon));
-        polygon = new ArrayList<ArrayList<LatLng>>();
-        polygon.add(new ArrayList<LatLng>(
-                Arrays.asList(new LatLng(0, 0), new LatLng(50, 80), new LatLng(10, 15),
-                        new LatLng(0, 0))));
-        polygon.add(new ArrayList<LatLng>(
-                Arrays.asList(new LatLng(0, 0), new LatLng(20, 20), new LatLng(60, 60),
-                        new LatLng(0, 0))));
+        polygon = new ArrayList<>();
+        polygon.add(
+                new ArrayList<>(
+                        Arrays.asList(
+                                new LatLng(0, 0),
+                                new LatLng(50, 80),
+                                new LatLng(10, 15),
+                                new LatLng(0, 0))));
+        polygon.add(
+                new ArrayList<>(
+                        Arrays.asList(
+                                new LatLng(0, 0),
+                                new LatLng(20, 20),
+                                new LatLng(60, 60),
+                                new LatLng(0, 0))));
         polygons.add(new GeoJsonPolygon(polygon));
         mp = new GeoJsonMultiPolygon(polygons);
-        Assert.assertEquals(polygons, mp.getPolygons());
+        assertEquals(polygons, mp.getPolygons());
 
-        polygons = new ArrayList<GeoJsonPolygon>();
+        polygons = new ArrayList<>();
         mp = new GeoJsonMultiPolygon(polygons);
-        Assert.assertEquals(new ArrayList<GeoJsonPolygon>(), mp.getPolygons());
+        assertEquals(new ArrayList<GeoJsonPolygon>(), mp.getPolygons());
 
         try {
             mp = new GeoJsonMultiPolygon(null);
-            Assert.fail();
+            fail();
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("Geometries cannot be null", e.getMessage());
+            assertEquals("Geometries cannot be null", e.getMessage());
         }
     }
 }

--- a/library/tests/src/com/google/maps/android/data/geojson/GeoJsonParserTest.java
+++ b/library/tests/src/com/google/maps/android/data/geojson/GeoJsonParserTest.java
@@ -3,62 +3,60 @@ package com.google.maps.android.data.geojson;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.maps.android.data.Geometry;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.Assert;
-
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 public class GeoJsonParserTest {
-
-    @Before
-    public void setUp() throws Exception {
-    }
-
     @Test
     public void testParseGeoJson() throws Exception {
-        JSONObject validGeoJsonObject = new JSONObject("{ \"type\": \"MultiLineString\",\n"
-                + "    \"coordinates\": [\n"
-                + "        [ [100.0, 0.0], [101.0, 1.0] ],\n"
-                + "        [ [102.0, 2.0], [103.0, 3.0] ]\n"
-                + "      ]\n"
-                + "    }");
+        JSONObject validGeoJsonObject =
+                new JSONObject(
+                        "{ \"type\": \"MultiLineString\",\n"
+                                + "    \"coordinates\": [\n"
+                                + "        [ [100.0, 0.0], [101.0, 1.0] ],\n"
+                                + "        [ [102.0, 2.0], [103.0, 3.0] ]\n"
+                                + "      ]\n"
+                                + "    }");
 
         GeoJsonParser parser = new GeoJsonParser(validGeoJsonObject);
-        GeoJsonLineString ls1 = new GeoJsonLineString(
-                new ArrayList<LatLng>(Arrays.asList(new LatLng(0, 100), new LatLng(1, 101))));
-        GeoJsonLineString ls2 = new GeoJsonLineString(
-                new ArrayList<LatLng>(Arrays.asList(new LatLng(2, 102), new LatLng(3, 103))));
-        GeoJsonMultiLineString geoJsonMultiLineString = new GeoJsonMultiLineString(
-                new ArrayList<GeoJsonLineString>(Arrays.asList(ls1, ls2)));
-        GeoJsonFeature geoJsonFeature = new GeoJsonFeature(geoJsonMultiLineString, null, null,
-                null);
-        ArrayList<GeoJsonFeature> geoJsonFeatures = new ArrayList<GeoJsonFeature>(
-                Arrays.asList(geoJsonFeature));
-        Assert.assertEquals(geoJsonFeatures.get(0).getId(), parser.getFeatures().get(0).getId());
+        GeoJsonLineString ls1 =
+                new GeoJsonLineString(
+                        new ArrayList<>(Arrays.asList(new LatLng(0, 100), new LatLng(1, 101))));
+        GeoJsonLineString ls2 =
+                new GeoJsonLineString(
+                        new ArrayList<>(Arrays.asList(new LatLng(2, 102), new LatLng(3, 103))));
+        GeoJsonMultiLineString geoJsonMultiLineString =
+                new GeoJsonMultiLineString(new ArrayList<>(Arrays.asList(ls1, ls2)));
+        GeoJsonFeature geoJsonFeature =
+                new GeoJsonFeature(geoJsonMultiLineString, null, null, null);
+        List<GeoJsonFeature> geoJsonFeatures = new ArrayList<>(Arrays.asList(geoJsonFeature));
+        assertEquals(geoJsonFeatures.get(0).getId(), parser.getFeatures().get(0).getId());
     }
 
     @Test
     public void testParseGeometryCollection() throws Exception {
         GeoJsonParser parser = new GeoJsonParser(validGeometryCollection());
-        Assert.assertEquals(1, parser.getFeatures().size());
+        assertEquals(1, parser.getFeatures().size());
         for (GeoJsonFeature feature : parser.getFeatures()) {
-            Assert.assertEquals("GeometryCollection", feature.getGeometry().getGeometryType());
+            assertEquals("GeometryCollection", feature.getGeometry().getGeometryType());
             int size = 0;
             for (String property : feature.getPropertyKeys()) {
                 size++;
             }
-            Assert.assertEquals(2, size);
-            Assert.assertEquals("Popsicles", feature.getId());
-            GeoJsonGeometryCollection geometry = ((GeoJsonGeometryCollection) feature
-                    .getGeometry());
-            Assert.assertEquals(1, geometry.getGeometries().size());
+            assertEquals(2, size);
+            assertEquals("Popsicles", feature.getId());
+            GeoJsonGeometryCollection geometry =
+                    ((GeoJsonGeometryCollection) feature.getGeometry());
+            assertEquals(1, geometry.getGeometries().size());
             for (Geometry geoJsonGeometry : geometry.getGeometries()) {
-                Assert.assertEquals("GeometryCollection", geoJsonGeometry.getGeometryType());
+                assertEquals("GeometryCollection", geoJsonGeometry.getGeometryType());
             }
         }
     }
@@ -66,134 +64,158 @@ public class GeoJsonParserTest {
     @Test
     public void testParsePoint() throws Exception {
         GeoJsonParser parser = new GeoJsonParser(validPoint());
-        Assert.assertEquals(1, parser.getFeatures().size());
-        Assert.assertNull(parser.getFeatures().get(0).getBoundingBox());
-        Assert.assertNull(parser.getFeatures().get(0).getId());
+        assertEquals(1, parser.getFeatures().size());
+        assertNull(parser.getFeatures().get(0).getBoundingBox());
+        assertNull(parser.getFeatures().get(0).getId());
         int size = 0;
         for (String property : parser.getFeatures().get(0).getPropertyKeys()) {
             size++;
         }
-        Assert.assertEquals(0, size);
-        Assert.assertTrue(parser.getFeatures().get(0).getGeometry() instanceof GeoJsonPoint);
+        assertEquals(0, size);
+        assertTrue(parser.getFeatures().get(0).getGeometry() instanceof GeoJsonPoint);
         GeoJsonPoint point = (GeoJsonPoint) parser.getFeatures().get(0).getGeometry();
-        Assert.assertEquals(new LatLng(0.0, 100.0), point.getCoordinates());
+        assertEquals(new LatLng(0.0, 100.0), point.getCoordinates());
     }
 
     @Test
     public void testParseLineString() throws Exception {
         GeoJsonParser parser = new GeoJsonParser(validLineString());
-        Assert.assertEquals(1, parser.getFeatures().size());
-        Assert.assertNull(parser.getFeatures().get(0).getBoundingBox());
-        Assert.assertNull(parser.getFeatures().get(0).getId());
+        assertEquals(1, parser.getFeatures().size());
+        assertNull(parser.getFeatures().get(0).getBoundingBox());
+        assertNull(parser.getFeatures().get(0).getId());
         int size = 0;
         for (String property : parser.getFeatures().get(0).getPropertyKeys()) {
             size++;
         }
-        Assert.assertEquals(0, size);
-        Assert.assertTrue(parser.getFeatures().get(0).getGeometry() instanceof GeoJsonLineString);
-        GeoJsonLineString lineString = (GeoJsonLineString) parser.getFeatures().get(0)
-                .getGeometry();
-        Assert.assertEquals(2, lineString.getCoordinates().size());
-        ArrayList<LatLng> ls = new ArrayList<LatLng>(
-                Arrays.asList(new LatLng(0, 100), new LatLng(1, 101)));
-        Assert.assertEquals(ls, lineString.getCoordinates());
+        assertEquals(0, size);
+        assertTrue(parser.getFeatures().get(0).getGeometry() instanceof GeoJsonLineString);
+        GeoJsonLineString lineString =
+                (GeoJsonLineString) parser.getFeatures().get(0).getGeometry();
+        assertEquals(2, lineString.getCoordinates().size());
+        List<LatLng> ls = new ArrayList<>(Arrays.asList(new LatLng(0, 100), new LatLng(1, 101)));
+        assertEquals(ls, lineString.getCoordinates());
     }
 
     @Test
     public void testParsePolygon() throws Exception {
         GeoJsonParser parser = new GeoJsonParser(validPolygon());
-        Assert.assertEquals(1, parser.getFeatures().size());
-        Assert.assertNull(parser.getFeatures().get(0).getBoundingBox());
-        Assert.assertNull(parser.getFeatures().get(0).getId());
+        assertEquals(1, parser.getFeatures().size());
+        assertNull(parser.getFeatures().get(0).getBoundingBox());
+        assertNull(parser.getFeatures().get(0).getId());
         int size = 0;
         for (String property : parser.getFeatures().get(0).getPropertyKeys()) {
             size++;
         }
-        Assert.assertEquals(0, size);
-        Assert.assertTrue(parser.getFeatures().get(0).getGeometry() instanceof GeoJsonPolygon);
+        assertEquals(0, size);
+        assertTrue(parser.getFeatures().get(0).getGeometry() instanceof GeoJsonPolygon);
         GeoJsonPolygon polygon = (GeoJsonPolygon) parser.getFeatures().get(0).getGeometry();
-        Assert.assertEquals(2, polygon.getCoordinates().size());
-        Assert.assertEquals(5, polygon.getCoordinates().get(0).size());
-        Assert.assertEquals(5, polygon.getCoordinates().get(1).size());
-        ArrayList<ArrayList<LatLng>> p = new ArrayList<ArrayList<LatLng>>();
-        p.add(new ArrayList<LatLng>(
-                Arrays.asList(new LatLng(0, 100), new LatLng(0, 101), new LatLng(1, 101),
-                        new LatLng(1, 100), new LatLng(0, 100))));
-        p.add(new ArrayList<LatLng>(Arrays.asList(new LatLng(0.2, 100.2), new LatLng(0.2, 100.8),
-                new LatLng(0.8, 100.8), new LatLng(0.8, 100.2), new LatLng(0.2, 100.2))));
-        Assert.assertEquals(p, polygon.getCoordinates());
+        assertEquals(2, polygon.getCoordinates().size());
+        assertEquals(5, polygon.getCoordinates().get(0).size());
+        assertEquals(5, polygon.getCoordinates().get(1).size());
+        List<ArrayList<LatLng>> p = new ArrayList<>();
+        p.add(
+                new ArrayList<>(
+                        Arrays.asList(
+                                new LatLng(0, 100),
+                                new LatLng(0, 101),
+                                new LatLng(1, 101),
+                                new LatLng(1, 100),
+                                new LatLng(0, 100))));
+        p.add(
+                new ArrayList<>(
+                        Arrays.asList(
+                                new LatLng(0.2, 100.2),
+                                new LatLng(0.2, 100.8),
+                                new LatLng(0.8, 100.8),
+                                new LatLng(0.8, 100.2),
+                                new LatLng(0.2, 100.2))));
+        assertEquals(p, polygon.getCoordinates());
     }
 
     @Test
     public void testParseMultiPoint() throws Exception {
         GeoJsonParser parser = new GeoJsonParser(validMultiPoint());
-        Assert.assertEquals(1, parser.getFeatures().size());
-        Assert.assertNull(parser.getFeatures().get(0).getBoundingBox());
-        Assert.assertNull(parser.getFeatures().get(0).getId());
+        assertEquals(1, parser.getFeatures().size());
+        assertNull(parser.getFeatures().get(0).getBoundingBox());
+        assertNull(parser.getFeatures().get(0).getId());
         int size = 0;
         for (String property : parser.getFeatures().get(0).getPropertyKeys()) {
             size++;
         }
-        Assert.assertEquals(0, size);
-        Assert.assertTrue(parser.getFeatures().get(0).getGeometry() instanceof GeoJsonMultiPoint);
-        GeoJsonMultiPoint multiPoint = (GeoJsonMultiPoint) parser.getFeatures().get(0)
-                .getGeometry();
-        Assert.assertEquals(2, multiPoint.getPoints().size());
-        Assert.assertEquals(new LatLng(0, 100), multiPoint.getPoints().get(0).getCoordinates());
-        Assert.assertEquals(new LatLng(1, 101), multiPoint.getPoints().get(1).getCoordinates());
+        assertEquals(0, size);
+        assertTrue(parser.getFeatures().get(0).getGeometry() instanceof GeoJsonMultiPoint);
+        GeoJsonMultiPoint multiPoint =
+                (GeoJsonMultiPoint) parser.getFeatures().get(0).getGeometry();
+        assertEquals(2, multiPoint.getPoints().size());
+        assertEquals(new LatLng(0, 100), multiPoint.getPoints().get(0).getCoordinates());
+        assertEquals(new LatLng(1, 101), multiPoint.getPoints().get(1).getCoordinates());
     }
 
     @Test
     public void testParseMultiLineString() throws Exception {
         GeoJsonParser parser = new GeoJsonParser(validMultiLineString());
-        Assert.assertEquals(1, parser.getFeatures().size());
-        Assert.assertNull(parser.getFeatures().get(0).getBoundingBox());
-        Assert.assertNull(parser.getFeatures().get(0).getId());
+        assertEquals(1, parser.getFeatures().size());
+        assertNull(parser.getFeatures().get(0).getBoundingBox());
+        assertNull(parser.getFeatures().get(0).getId());
         int size = 0;
         for (String property : parser.getFeatures().get(0).getPropertyKeys()) {
             size++;
         }
-        Assert.assertEquals(0, size);
-        Assert.assertTrue(parser.getFeatures().get(0).getGeometry() instanceof GeoJsonMultiLineString);
-        GeoJsonMultiLineString multiLineString = (GeoJsonMultiLineString) parser.getFeatures()
-                .get(0).getGeometry();
-        Assert.assertEquals(2, multiLineString.getLineStrings().size());
-        ArrayList<LatLng> ls = new ArrayList<LatLng>(
-                Arrays.asList(new LatLng(0, 100), new LatLng(1, 101)));
-        Assert.assertEquals(ls, multiLineString.getLineStrings().get(0).getCoordinates());
-        ls = new ArrayList<LatLng>(
-                Arrays.asList(new LatLng(2, 102), new LatLng(3, 103)));
-        Assert.assertEquals(ls, multiLineString.getLineStrings().get(1).getCoordinates());
+        assertEquals(0, size);
+        assertTrue(parser.getFeatures().get(0).getGeometry() instanceof GeoJsonMultiLineString);
+        GeoJsonMultiLineString multiLineString =
+                (GeoJsonMultiLineString) parser.getFeatures().get(0).getGeometry();
+        assertEquals(2, multiLineString.getLineStrings().size());
+        List<LatLng> ls = new ArrayList<>(Arrays.asList(new LatLng(0, 100), new LatLng(1, 101)));
+        assertEquals(ls, multiLineString.getLineStrings().get(0).getCoordinates());
+        ls = new ArrayList<>(Arrays.asList(new LatLng(2, 102), new LatLng(3, 103)));
+        assertEquals(ls, multiLineString.getLineStrings().get(1).getCoordinates());
     }
 
     @Test
     public void testParseMultiPolygon() throws Exception {
         GeoJsonParser parser = new GeoJsonParser(validMultiPolygon());
-        Assert.assertEquals(1, parser.getFeatures().size());
+        assertEquals(1, parser.getFeatures().size());
         GeoJsonFeature feature = parser.getFeatures().get(0);
         GeoJsonMultiPolygon polygon = ((GeoJsonMultiPolygon) feature.getGeometry());
-        Assert.assertEquals(2, polygon.getPolygons().size());
-        Assert.assertEquals(1, polygon.getPolygons().get(0).getCoordinates().size());
-        ArrayList<ArrayList<LatLng>> p1 = new ArrayList<ArrayList<LatLng>>();
-        p1.add(new ArrayList<LatLng>(
-                Arrays.asList(new LatLng(2, 102), new LatLng(2, 103), new LatLng(3, 103),
-                        new LatLng(3, 102), new LatLng(2, 102))));
-        Assert.assertEquals(p1, polygon.getPolygons().get(0).getCoordinates());
-        Assert.assertEquals(2, polygon.getPolygons().get(1).getCoordinates().size());
-        ArrayList<ArrayList<LatLng>> p2 = new ArrayList<ArrayList<LatLng>>();
-        p2.add(new ArrayList<LatLng>(
-                Arrays.asList(new LatLng(0, 100), new LatLng(0, 101), new LatLng(1, 101),
-                        new LatLng(1, 100), new LatLng(0, 100))));
-        p2.add(new ArrayList<LatLng>(Arrays.asList(new LatLng(0.2, 100.2), new LatLng(0.2, 100.8),
-                new LatLng(0.8, 100.8), new LatLng(0.8, 100.2), new LatLng(0.2, 100.2))));
-        Assert.assertEquals(p2, polygon.getPolygons().get(1).getCoordinates());
+        assertEquals(2, polygon.getPolygons().size());
+        assertEquals(1, polygon.getPolygons().get(0).getCoordinates().size());
+        List<List<LatLng>> p1 = new ArrayList<>();
+        p1.add(
+                new ArrayList<>(
+                        Arrays.asList(
+                                new LatLng(2, 102),
+                                new LatLng(2, 103),
+                                new LatLng(3, 103),
+                                new LatLng(3, 102),
+                                new LatLng(2, 102))));
+        assertEquals(p1, polygon.getPolygons().get(0).getCoordinates());
+        assertEquals(2, polygon.getPolygons().get(1).getCoordinates().size());
+        List<List<LatLng>> p2 = new ArrayList<>();
+        p2.add(
+                new ArrayList<>(
+                        Arrays.asList(
+                                new LatLng(0, 100),
+                                new LatLng(0, 101),
+                                new LatLng(1, 101),
+                                new LatLng(1, 100),
+                                new LatLng(0, 100))));
+        p2.add(
+                new ArrayList<>(
+                        Arrays.asList(
+                                new LatLng(0.2, 100.2),
+                                new LatLng(0.2, 100.8),
+                                new LatLng(0.8, 100.8),
+                                new LatLng(0.8, 100.2),
+                                new LatLng(0.2, 100.2))));
+        assertEquals(p2, polygon.getPolygons().get(1).getCoordinates());
     }
 
     @Test
-    public void testEmptyFile() throws Exception {
+    public void testEmptyFile() {
         GeoJsonParser parser = new GeoJsonParser(emptyFile());
-        Assert.assertNull(parser.getBoundingBox());
-        Assert.assertEquals(0, parser.getFeatures().size());
+        assertNull(parser.getBoundingBox());
+        assertEquals(0, parser.getFeatures().size());
     }
 
     @Test
@@ -202,38 +224,41 @@ public class GeoJsonParserTest {
 
         // Feature exists without geometry
         parser = new GeoJsonParser(invalidFeatureNoGeometry());
-        Assert.assertNull(parser.getBoundingBox());
-        Assert.assertEquals(1, parser.getFeatures().size());
-        Assert.assertNull(parser.getFeatures().get(0).getGeometry());
-        Assert.assertEquals("Dinagat Islands", parser.getFeatures().get(0).getProperty("name"));
+        assertNull(parser.getBoundingBox());
+        assertEquals(1, parser.getFeatures().size());
+        assertNull(parser.getFeatures().get(0).getGeometry());
+        assertEquals("Dinagat Islands", parser.getFeatures().get(0).getProperty("name"));
 
         // Feature exists without properties
         parser = new GeoJsonParser(invalidFeatureNoProperties());
-        Assert.assertNull(parser.getBoundingBox());
-        Assert.assertEquals(1, parser.getFeatures().size());
+        assertNull(parser.getBoundingBox());
+        assertEquals(1, parser.getFeatures().size());
         int size = 0;
         for (String property : parser.getFeatures().get(0).getPropertyKeys()) {
             size++;
         }
-        Assert.assertEquals(0, size);
+        assertEquals(0, size);
 
         // No features exist due to no type
         parser = new GeoJsonParser(invalidFeatureMissingType());
-        Assert.assertNull(parser.getBoundingBox());
-        Assert.assertEquals(0, parser.getFeatures().size());
+        assertNull(parser.getBoundingBox());
+        assertEquals(0, parser.getFeatures().size());
 
         // 1 geometry in geometry collection, other geometry was invalid
         parser = new GeoJsonParser(invalidFeatureGeometryCollectionInvalidGeometry());
-        Assert.assertNull(parser.getBoundingBox());
-        Assert.assertEquals(1, parser.getFeatures().size());
-        Assert.assertEquals(1, ((GeoJsonGeometryCollection) parser.getFeatures().get(0).getGeometry())
-                .getGeometries().size());
+        assertNull(parser.getBoundingBox());
+        assertEquals(1, parser.getFeatures().size());
+        assertEquals(
+                1,
+                ((GeoJsonGeometryCollection) parser.getFeatures().get(0).getGeometry())
+                        .getGeometries()
+                        .size());
 
         // No geometry due to no geometries array member
         parser = new GeoJsonParser(invalidFeatureGeometryCollectionNoGeometries());
-        Assert.assertNull(parser.getBoundingBox());
-        Assert.assertEquals(1, parser.getFeatures().size());
-        Assert.assertNull(parser.getFeatures().get(0).getGeometry());
+        assertNull(parser.getBoundingBox());
+        assertEquals(1, parser.getFeatures().size());
+        assertNull(parser.getFeatures().get(0).getGeometry());
     }
 
     @Test
@@ -242,37 +267,42 @@ public class GeoJsonParserTest {
 
         // 1 feature without geometry
         parser = new GeoJsonParser(invalidFeatureCollectionNoCoordinatesInGeometryInFeature());
-        Assert.assertNull(parser.getBoundingBox());
-        Assert.assertEquals(3, parser.getFeatures().size());
-        Assert.assertNotNull(parser.getFeatures().get(0).getGeometry());
-        Assert.assertNull(parser.getFeatures().get(1).getGeometry());
-        Assert.assertNotNull(parser.getFeatures().get(2).getGeometry());
+        assertNull(parser.getBoundingBox());
+        assertEquals(3, parser.getFeatures().size());
+        assertNotNull(parser.getFeatures().get(0).getGeometry());
+        assertNull(parser.getFeatures().get(1).getGeometry());
+        assertNotNull(parser.getFeatures().get(2).getGeometry());
 
         // 1 feature without geometry
         parser = new GeoJsonParser(invalidFeatureCollectionNoTypeInGeometryInFeature());
-        Assert.assertNull(parser.getBoundingBox());
-        Assert.assertEquals(3, parser.getFeatures().size());
-        Assert.assertNotNull(parser.getFeatures().get(0).getGeometry());
-        Assert.assertNotNull(parser.getFeatures().get(1).getGeometry());
-        Assert.assertNull(parser.getFeatures().get(2).getGeometry());
+        assertNull(parser.getBoundingBox());
+        assertEquals(3, parser.getFeatures().size());
+        assertNotNull(parser.getFeatures().get(0).getGeometry());
+        assertNotNull(parser.getFeatures().get(1).getGeometry());
+        assertNull(parser.getFeatures().get(2).getGeometry());
 
         // No features due to no features array
         parser = new GeoJsonParser(invalidFeatureCollectionNoFeaturesArray());
-        Assert.assertNull(parser.getBoundingBox());
-        Assert.assertEquals(0, parser.getFeatures().size());
+        assertNull(parser.getBoundingBox());
+        assertEquals(0, parser.getFeatures().size());
 
         // 1 feature not parsed due to no type indicating it is a feature
         parser = new GeoJsonParser(invalidFeatureCollectionNoGeometryTypeInFeature());
-        Assert.assertNull(parser.getBoundingBox());
-        Assert.assertEquals(2, parser.getFeatures().size());
-        Assert.assertTrue(!parser.getFeatures().get(0).getGeometry().getGeometryType().equals("Polygon") && !parser
-                .getFeatures().get(1).getGeometry().getGeometryType().equals("Polygon"));
+        assertNull(parser.getBoundingBox());
+        assertEquals(2, parser.getFeatures().size());
+        assertTrue(
+                !parser.getFeatures().get(0).getGeometry().getGeometryType().equals("Polygon")
+                        && !parser.getFeatures()
+                        .get(1)
+                        .getGeometry()
+                        .getGeometryType()
+                        .equals("Polygon"));
 
         // Contains 1 feature element with no geometry as it was missing a coordinates member
         parser = new GeoJsonParser(invalidFeatureNoCoordinatesInGeometry());
-        Assert.assertNull(parser.getBoundingBox());
-        Assert.assertEquals(1, parser.getFeatures().size());
-        Assert.assertNull(parser.getFeatures().get(0).getGeometry());
+        assertNull(parser.getBoundingBox());
+        assertEquals(1, parser.getFeatures().size());
+        assertNull(parser.getFeatures().get(0).getGeometry());
     }
 
     @Test
@@ -281,134 +311,127 @@ public class GeoJsonParserTest {
 
         // No geometry due to no type member
         parser = new GeoJsonParser(invalidGeometryNoType());
-        Assert.assertNull(parser.getBoundingBox());
-        Assert.assertEquals(0, parser.getFeatures().size());
+        assertNull(parser.getBoundingBox());
+        assertEquals(0, parser.getFeatures().size());
 
         // No geometry due to no coordinates member
         parser = new GeoJsonParser(invalidGeometryNoCoordinates());
-        Assert.assertNull(parser.getBoundingBox());
-        Assert.assertEquals(0, parser.getFeatures().size());
+        assertNull(parser.getBoundingBox());
+        assertEquals(0, parser.getFeatures().size());
 
         // Geometry collection has 1 valid and 1 invalid geometry
         parser = new GeoJsonParser(invalidGeometryCollectionInvalidGeometry());
-        Assert.assertNull(parser.getBoundingBox());
-        Assert.assertEquals(1, parser.getFeatures().size());
-        Assert.assertEquals(1, ((GeoJsonGeometryCollection) parser.getFeatures().get(0).getGeometry())
-                .getGeometries().size());
+        assertNull(parser.getBoundingBox());
+        assertEquals(1, parser.getFeatures().size());
+        assertEquals(
+                1,
+                ((GeoJsonGeometryCollection) parser.getFeatures().get(0).getGeometry())
+                        .getGeometries()
+                        .size());
 
         // No geometry due to invalid geometry collection
         parser = new GeoJsonParser(invalidGeometryCollectionInvalidGeometries());
-        Assert.assertNull(parser.getBoundingBox());
-        Assert.assertEquals(0, parser.getFeatures().size());
+        assertNull(parser.getBoundingBox());
+        assertEquals(0, parser.getFeatures().size());
 
         // No geometry due to only lng provided
         parser = new GeoJsonParser(invalidGeometryInvalidCoordinatesPair());
-        Assert.assertEquals(0, parser.getFeatures().size());
+        assertEquals(0, parser.getFeatures().size());
 
         // No geometry due to coordinates being strings instead of doubles
         parser = new GeoJsonParser(invalidGeometryInvalidCoordinatesString());
-        Assert.assertEquals(0, parser.getFeatures().size());
+        assertEquals(0, parser.getFeatures().size());
     }
 
-    public JSONObject validGeometryCollection() throws Exception {
+    private JSONObject validGeometryCollection() throws Exception {
         return new JSONObject(
-                "{\n" +
-                        "   \"type\": \"Feature\",\n" +
-                        "   \"id\": \"Popsicles\",\n" +
-                        "   \"geometry\": {\n" +
-                        "      \"type\": \"GeometryCollection\",\n" +
-                        "      \"geometries\": [\n" +
-                        "          { \"type\": \"GeometryCollection\",\n" +
-                        "            \"geometries\": [\n" +
-                        "              { \"type\": \"Point\",\n" +
-                        "                \"coordinates\": [103.0, 0.0]\n" +
-                        "                }\n" +
-                        "            ]\n" +
-                        "          }\n" +
-                        "      ]\n" +
-                        "   },\n" +
-                        "   \"properties\": {\n" +
-                        "       \"prop0\": \"value0\",\n" +
-                        "       \"prop1\": \"value1\"\n" +
-                        "   }\n" +
-                        "}");
+                "{\n"
+                        + "   \"type\": \"Feature\",\n"
+                        + "   \"id\": \"Popsicles\",\n"
+                        + "   \"geometry\": {\n"
+                        + "      \"type\": \"GeometryCollection\",\n"
+                        + "      \"geometries\": [\n"
+                        + "          { \"type\": \"GeometryCollection\",\n"
+                        + "            \"geometries\": [\n"
+                        + "              { \"type\": \"Point\",\n"
+                        + "                \"coordinates\": [103.0, 0.0]\n"
+                        + "                }\n"
+                        + "            ]\n"
+                        + "          }\n"
+                        + "      ]\n"
+                        + "   },\n"
+                        + "   \"properties\": {\n"
+                        + "       \"prop0\": \"value0\",\n"
+                        + "       \"prop1\": \"value1\"\n"
+                        + "   }\n"
+                        + "}");
     }
 
-    public JSONObject validPoint() throws JSONException {
-        return new JSONObject(
-                "{ \"type\": \"Point\", \"coordinates\": [100.0, 0.0] }"
-        );
+    private JSONObject validPoint() throws JSONException {
+        return new JSONObject("{ \"type\": \"Point\", \"coordinates\": [100.0, 0.0] }");
     }
 
-    public JSONObject validLineString() throws JSONException {
+    private JSONObject validLineString() throws JSONException {
         return new JSONObject(
                 "{ \"type\": \"LineString\",\n"
                         + "    \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ]\n"
-                        + "    }"
-        );
+                        + "    }");
     }
 
-    public JSONObject validPolygon() throws JSONException {
+    private JSONObject validPolygon() throws JSONException {
         return new JSONObject(
                 "{ \"type\": \"Polygon\",\n"
                         + "    \"coordinates\": [\n"
-                        + "      [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ],\n"
-                        + "      [ [100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2] ]\n"
+                        + "      [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0,"
+                        + " 0.0] ],\n"
+                        + "      [ [100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2,"
+                        + " 0.2] ]\n"
                         + "      ]\n"
-                        + "   }"
-        );
+                        + "   }");
     }
 
-    public JSONObject validMultiPoint() throws JSONException {
+    private JSONObject validMultiPoint() throws JSONException {
         return new JSONObject(
                 "{ \"type\": \"MultiPoint\",\n"
                         + "    \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ]\n"
-                        + "    }"
-        );
+                        + "    }");
     }
 
-    public JSONObject validMultiLineString() throws JSONException {
+    private JSONObject validMultiLineString() throws JSONException {
         return new JSONObject(
                 "{ \"type\": \"MultiLineString\",\n"
                         + "    \"coordinates\": [\n"
                         + "        [ [100.0, 0.0], [101.0, 1.0] ],\n"
                         + "        [ [102.0, 2.0], [103.0, 3.0] ]\n"
                         + "      ]\n"
-                        + "    }"
-        );
+                        + "    }");
     }
 
-    public JSONObject validMultiPolygon() throws Exception {
+    private JSONObject validMultiPolygon() throws Exception {
         return new JSONObject(
                 "{ \"type\": \"MultiPolygon\",\n"
                         + "    \"coordinates\": [\n"
-                        + "      [[[102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0]]],\n"
-                        + "      [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]],\n"
-                        + "       [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]]\n"
+                        + "      [[[102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0,"
+                        + " 2.0]]],\n"
+                        + "      [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0,"
+                        + " 0.0]],\n"
+                        + "       [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2,"
+                        + " 0.2]]]\n"
                         + "      ]\n"
-                        + "    }"
-        );
-
+                        + "    }");
     }
 
-    public JSONObject validEmptyFeatureCollection() throws Exception {
+    private JSONObject validEmptyFeatureCollection() throws Exception {
         return new JSONObject(
-                "{ \"type\": \"FeatureCollection\",\n"
-                        + "  \"features\": [\n"
-                        + "     ]\n"
-                        + "}");
+                "{ \"type\": \"FeatureCollection\",\n" + "  \"features\": [\n" + "     ]\n" + "}");
     }
 
-    public JSONObject emptyFile() {
+    private JSONObject emptyFile() {
         return new JSONObject();
     }
 
-    public JSONObject invalidGeometryNoType() throws Exception {
-        return new JSONObject(
-                "{\n"
-                        + "    \"coordinates\": [100.0, 0.0] \n"
-                        + "}"
-        );
+    private JSONObject invalidGeometryNoType() throws Exception {
+        return new JSONObject("{\n" + "    \"coordinates\": [100.0, 0.0] \n" + "}");
     }
 
     /**
@@ -416,7 +439,7 @@ public class GeoJsonParserTest {
      *
      * @return geometry with invalid coordinates member
      */
-    public JSONObject invalidGeometryInvalidCoordinatesPair() throws Exception {
+    private JSONObject invalidGeometryInvalidCoordinatesPair() throws Exception {
         return new JSONObject("{ \"type\": \"Point\", \"coordinates\": [100.0] }");
     }
 
@@ -425,7 +448,7 @@ public class GeoJsonParserTest {
      *
      * @return geometry with invalid coordinates member
      */
-    public JSONObject invalidGeometryInvalidCoordinatesString() throws Exception {
+    private JSONObject invalidGeometryInvalidCoordinatesString() throws Exception {
         return new JSONObject("{ \"type\": \"Point\", \"coordinates\": [\"BANANA\", \"BOAT\"] }");
     }
 
@@ -434,15 +457,14 @@ public class GeoJsonParserTest {
      *
      * @return feature missing its geometry
      */
-    public JSONObject invalidFeatureNoGeometry() throws Exception {
+    private JSONObject invalidFeatureNoGeometry() throws Exception {
         return new JSONObject(
                 "{\n"
                         + "  \"type\": \"Feature\",\n"
                         + "  \"properties\": {\n"
                         + "    \"name\": \"Dinagat Islands\"\n"
                         + "  }\n"
-                        + "}"
-        );
+                        + "}");
     }
 
     /**
@@ -450,7 +472,7 @@ public class GeoJsonParserTest {
      *
      * @return Geometry collection with invalid geometry
      */
-    public JSONObject invalidGeometryCollectionInvalidGeometry() throws Exception {
+    private JSONObject invalidGeometryCollectionInvalidGeometry() throws Exception {
         return new JSONObject(
                 "{ \"type\": \"GeometryCollection\",\n"
                         + "  \"geometries\": [\n"
@@ -461,8 +483,7 @@ public class GeoJsonParserTest {
                         + "      \"coordinates\": [ [101.0, 0.0], [102.0, 1.0] ]\n"
                         + "      }\n"
                         + "  ]\n"
-                        + "}"
-        );
+                        + "}");
     }
 
     /**
@@ -470,7 +491,7 @@ public class GeoJsonParserTest {
      *
      * @return Geometry collection with no geometries
      */
-    public JSONObject invalidGeometryCollectionInvalidGeometries() throws Exception {
+    private JSONObject invalidGeometryCollectionInvalidGeometries() throws Exception {
         return new JSONObject(
                 "{ \"type\": \"GeometryCollection\",\n"
                         + "  \"doge\": [\n"
@@ -481,8 +502,7 @@ public class GeoJsonParserTest {
                         + "      \"coordinates\": [ [101.0, 0.0], [102.0, 1.0] ]\n"
                         + "      }\n"
                         + "  ]\n"
-                        + "}"
-        );
+                        + "}");
     }
 
     /**
@@ -491,7 +511,7 @@ public class GeoJsonParserTest {
      *
      * @return Feature containing a geometry collection with an invalid geometry
      */
-    public JSONObject invalidFeatureGeometryCollectionInvalidGeometry() throws Exception {
+    private JSONObject invalidFeatureGeometryCollectionInvalidGeometry() throws Exception {
         return new JSONObject(
                 "{\n"
                         + "  \"type\":\"FeatureCollection\",\n"
@@ -528,8 +548,7 @@ public class GeoJsonParserTest {
                         + "      }\n"
                         + "    }\n"
                         + "  ]\n"
-                        + "}"
-        );
+                        + "}");
     }
 
     /**
@@ -537,7 +556,7 @@ public class GeoJsonParserTest {
      *
      * @return Feature collection with no geometries array
      */
-    public JSONObject invalidFeatureGeometryCollectionNoGeometries() throws Exception {
+    private JSONObject invalidFeatureGeometryCollectionNoGeometries() throws Exception {
         return new JSONObject(
                 "{\n"
                         + "  \"type\":\"FeatureCollection\",\n"
@@ -574,8 +593,7 @@ public class GeoJsonParserTest {
                         + "      }\n"
                         + "    }\n"
                         + "  ]\n"
-                        + "}"
-        );
+                        + "}");
     }
 
     /**
@@ -583,7 +601,7 @@ public class GeoJsonParserTest {
      *
      * @return feature missing its properties
      */
-    public JSONObject invalidFeatureNoProperties() throws Exception {
+    private JSONObject invalidFeatureNoProperties() throws Exception {
         return new JSONObject(
                 "{\n"
                         + "  \"type\": \"Feature\",\n"
@@ -591,8 +609,7 @@ public class GeoJsonParserTest {
                         + "    \"type\": \"Point\",\n"
                         + "    \"coordinates\": [125.6, 10.1]\n"
                         + "  }\n"
-                        + "}"
-        );
+                        + "}");
     }
 
     /**
@@ -601,12 +618,13 @@ public class GeoJsonParserTest {
      *
      * @return 2 valid features with 1 invalid feature
      */
-    public JSONObject invalidFeatureCollectionNoGeometryTypeInFeature() throws Exception {
+    private JSONObject invalidFeatureCollectionNoGeometryTypeInFeature() throws Exception {
         return new JSONObject(
                 "{ \"type\": \"FeatureCollection\",\n"
                         + "    \"features\": [\n"
                         + "      { \"type\": \"Feature\",\n"
-                        + "        \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]},\n"
+                        + "        \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0,"
+                        + " 0.5]},\n"
                         + "        \"properties\": {\"prop0\": \"value0\"}\n"
                         + "        },\n"
                         + "      { \"type\": \"Feature\",\n"
@@ -635,9 +653,7 @@ public class GeoJsonParserTest {
                         + "           }\n"
                         + "         }\n"
                         + "       ]\n"
-                        + "     }"
-
-        );
+                        + "     }");
     }
 
     /**
@@ -645,12 +661,13 @@ public class GeoJsonParserTest {
      *
      * @return FeatureCollection missing its feature array
      */
-    public JSONObject invalidFeatureCollectionNoFeaturesArray() throws JSONException {
+    private JSONObject invalidFeatureCollectionNoFeaturesArray() throws JSONException {
         return new JSONObject(
                 "{ \"type\": \"FeatureCollection\",\n"
                         + "    \"INVALID\": [\n"
                         + "      { \"type\": \"Feature\",\n"
-                        + "        \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]},\n"
+                        + "        \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0,"
+                        + " 0.5]},\n"
                         + "        \"properties\": {\"prop0\": \"value0\"}\n"
                         + "        },\n"
                         + "      { \"type\": \"Feature\",\n"
@@ -679,19 +696,17 @@ public class GeoJsonParserTest {
                         + "           }\n"
                         + "         }\n"
                         + "       ]\n"
-                        + "     }"
-        );
+                        + "     }");
     }
 
     /**
      * Geometry missing its coordinates member
      */
-    public JSONObject invalidGeometryNoCoordinates() throws JSONException {
+    private JSONObject invalidGeometryNoCoordinates() throws JSONException {
         return new JSONObject(
                 "{ \"type\": \"LineString\",\n"
                         + "    \"banana\": [ [100.0, 0.0], [101.0, 1.0] ]\n"
-                        + "    }"
-        );
+                        + "    }");
     }
 
     /**
@@ -710,8 +725,7 @@ public class GeoJsonParserTest {
                         + "  \"properties\": {\n"
                         + "    \"name\": \"Dinagat Islands\"\n"
                         + "  }\n"
-                        + "}"
-        );
+                        + "}");
     }
 
     /**
@@ -719,7 +733,7 @@ public class GeoJsonParserTest {
      *
      * @return Feature missing its type
      */
-    public JSONObject invalidFeatureMissingType() throws JSONException {
+    private JSONObject invalidFeatureMissingType() throws JSONException {
         return new JSONObject(
                 "{\n"
                         + "  \"cow\": \"Feature\",\n"
@@ -730,8 +744,7 @@ public class GeoJsonParserTest {
                         + "  \"properties\": {\n"
                         + "    \"name\": \"Dinagat Islands\"\n"
                         + "  }\n"
-                        + "}"
-        );
+                        + "}");
     }
 
     /**
@@ -739,12 +752,13 @@ public class GeoJsonParserTest {
      *
      * @return Feature collection with feature missing its coordinates
      */
-    public JSONObject invalidFeatureCollectionNoCoordinatesInGeometryInFeature() throws Exception {
+    private JSONObject invalidFeatureCollectionNoCoordinatesInGeometryInFeature() throws Exception {
         return new JSONObject(
                 "{ \"type\": \"FeatureCollection\",\n"
                         + "    \"features\": [\n"
                         + "      { \"type\": \"Feature\",\n"
-                        + "        \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]},\n"
+                        + "        \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0,"
+                        + " 0.5]},\n"
                         + "        \"properties\": {\"prop0\": \"value0\"}\n"
                         + "        },\n"
                         + "      { \"type\": \"Feature\",\n"
@@ -773,8 +787,7 @@ public class GeoJsonParserTest {
                         + "           }\n"
                         + "         }\n"
                         + "       ]\n"
-                        + "     }"
-        );
+                        + "     }");
     }
 
     /**
@@ -782,12 +795,13 @@ public class GeoJsonParserTest {
      *
      * @return Feature collection with a feature missing its type
      */
-    public JSONObject invalidFeatureCollectionNoTypeInGeometryInFeature() throws Exception {
+    private JSONObject invalidFeatureCollectionNoTypeInGeometryInFeature() throws Exception {
         return new JSONObject(
                 "{ \"type\": \"FeatureCollection\",\n"
                         + "    \"features\": [\n"
                         + "      { \"type\": \"Feature\",\n"
-                        + "        \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0, 0.5]},\n"
+                        + "        \"geometry\": {\"type\": \"Point\", \"coordinates\": [102.0,"
+                        + " 0.5]},\n"
                         + "        \"properties\": {\"prop0\": \"value0\"}\n"
                         + "        },\n"
                         + "      { \"type\": \"Feature\",\n"
@@ -816,7 +830,6 @@ public class GeoJsonParserTest {
                         + "           }\n"
                         + "         }\n"
                         + "       ]\n"
-                        + "     }"
-        );
+                        + "     }");
     }
 }

--- a/library/tests/src/com/google/maps/android/data/geojson/GeoJsonPointStyleTest.java
+++ b/library/tests/src/com/google/maps/android/data/geojson/GeoJsonPointStyleTest.java
@@ -6,139 +6,135 @@ import com.google.android.gms.maps.MapsInitializer;
 import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
 
-public class GeoJsonPointStyleTest {
+import static org.junit.Assert.*;
 
+public class GeoJsonPointStyleTest {
     GeoJsonPointStyle pointStyle;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         MapsInitializer.initialize(InstrumentationRegistry.getInstrumentation().getTargetContext());
         pointStyle = new GeoJsonPointStyle();
     }
 
     @Test
-    public void testGetGeometryType() throws Exception {
-        Assert.assertTrue(Arrays.asList(pointStyle.getGeometryType()).contains("Point"));
-        Assert.assertTrue(Arrays.asList(pointStyle.getGeometryType()).contains("MultiPoint"));
-        Assert.assertTrue(Arrays.asList(pointStyle.getGeometryType()).contains("GeometryCollection"));
-        Assert.assertEquals(3, pointStyle.getGeometryType().length);
+    public void testGetGeometryType() {
+        assertTrue(Arrays.asList(pointStyle.getGeometryType()).contains("Point"));
+        assertTrue(Arrays.asList(pointStyle.getGeometryType()).contains("MultiPoint"));
+        assertTrue(Arrays.asList(pointStyle.getGeometryType()).contains("GeometryCollection"));
+        assertEquals(3, pointStyle.getGeometryType().length);
     }
 
     @Test
-    public void testAlpha() throws Exception {
+    public void testAlpha() {
         pointStyle.setAlpha(0.1234f);
-        Assert.assertEquals(0.1234f, pointStyle.getAlpha(), 0);
-        Assert.assertEquals(0.1234f, pointStyle.toMarkerOptions().getAlpha(), 0);
+        assertEquals(0.1234f, pointStyle.getAlpha(), 0);
+        assertEquals(0.1234f, pointStyle.toMarkerOptions().getAlpha(), 0);
     }
 
     @Test
-    public void testAnchor() throws Exception {
+    public void testAnchor() {
         pointStyle.setAnchor(0.23f, 0.87f);
-        Assert.assertEquals(0.23f, pointStyle.getAnchorU(), 0);
-        Assert.assertEquals(0.87f, pointStyle.getAnchorV(), 0);
-        Assert.assertEquals(0.23f, pointStyle.toMarkerOptions().getAnchorU(), 0);
-        Assert.assertEquals(0.87f, pointStyle.toMarkerOptions().getAnchorV(), 0);
+        assertEquals(0.23f, pointStyle.getAnchorU(), 0);
+        assertEquals(0.87f, pointStyle.getAnchorV(), 0);
+        assertEquals(0.23f, pointStyle.toMarkerOptions().getAnchorU(), 0);
+        assertEquals(0.87f, pointStyle.toMarkerOptions().getAnchorV(), 0);
     }
 
     @Test
-    public void testDraggable() throws Exception {
+    public void testDraggable() {
         pointStyle.setDraggable(true);
-        Assert.assertTrue(pointStyle.isDraggable());
-        Assert.assertTrue(pointStyle.toMarkerOptions().isDraggable());
+        assertTrue(pointStyle.isDraggable());
+        assertTrue(pointStyle.toMarkerOptions().isDraggable());
     }
 
     @Test
-    public void testFlat() throws Exception {
+    public void testFlat() {
         pointStyle.setFlat(true);
-        Assert.assertTrue(pointStyle.isFlat());
-        Assert.assertTrue(pointStyle.toMarkerOptions().isFlat());
+        assertTrue(pointStyle.isFlat());
+        assertTrue(pointStyle.toMarkerOptions().isFlat());
     }
 
     @Test
-    public void testIcon() throws Exception {
-        BitmapDescriptor icon = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_GREEN);
-        pointStyle
-                .setIcon(icon);
-        Assert.assertEquals(icon,
-                pointStyle.getIcon());
-        Assert.assertEquals(icon,
-                pointStyle.toMarkerOptions().getIcon());
+    public void testIcon() {
+        BitmapDescriptor icon =
+                BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_GREEN);
+        pointStyle.setIcon(icon);
+        assertEquals(icon, pointStyle.getIcon());
+        assertEquals(icon, pointStyle.toMarkerOptions().getIcon());
     }
 
     @Test
-    public void testInfoWindowAnchor() throws Exception {
+    public void testInfoWindowAnchor() {
         pointStyle.setInfoWindowAnchor(0.12f, 0.98f);
-        Assert.assertEquals(0.12f, pointStyle.getInfoWindowAnchorU(), 0);
-        Assert.assertEquals(0.98f, pointStyle.getInfoWindowAnchorV(), 0);
-        Assert.assertEquals(0.12f, pointStyle.toMarkerOptions().getInfoWindowAnchorU(), 0);
-        Assert.assertEquals(0.98f, pointStyle.toMarkerOptions().getInfoWindowAnchorV(), 0);
+        assertEquals(0.12f, pointStyle.getInfoWindowAnchorU(), 0);
+        assertEquals(0.98f, pointStyle.getInfoWindowAnchorV(), 0);
+        assertEquals(0.12f, pointStyle.toMarkerOptions().getInfoWindowAnchorU(), 0);
+        assertEquals(0.98f, pointStyle.toMarkerOptions().getInfoWindowAnchorV(), 0);
     }
 
     @Test
-    public void testRotation() throws Exception {
+    public void testRotation() {
         pointStyle.setRotation(156.24f);
-        Assert.assertEquals(156.24f, pointStyle.getRotation(), 0);
-        Assert.assertEquals(156.24f, pointStyle.toMarkerOptions().getRotation(), 0);
+        assertEquals(156.24f, pointStyle.getRotation(), 0);
+        assertEquals(156.24f, pointStyle.toMarkerOptions().getRotation(), 0);
     }
 
     @Test
-    public void testSnippet() throws Exception {
+    public void testSnippet() {
         pointStyle.setSnippet("The peaches are in a jar");
-        Assert.assertEquals("The peaches are in a jar", pointStyle.getSnippet());
-        Assert.assertEquals("The peaches are in a jar", pointStyle.toMarkerOptions().getSnippet());
+        assertEquals("The peaches are in a jar", pointStyle.getSnippet());
+        assertEquals("The peaches are in a jar", pointStyle.toMarkerOptions().getSnippet());
     }
 
     @Test
-    public void testTitle() throws Exception {
+    public void testTitle() {
         pointStyle.setTitle("Peaches");
-        Assert.assertEquals("Peaches", pointStyle.getTitle());
-        Assert.assertEquals("Peaches", pointStyle.toMarkerOptions().getTitle());
+        assertEquals("Peaches", pointStyle.getTitle());
+        assertEquals("Peaches", pointStyle.toMarkerOptions().getTitle());
     }
 
     @Test
-    public void testVisible() throws Exception {
+    public void testVisible() {
         pointStyle.setVisible(false);
-        Assert.assertFalse(pointStyle.isVisible());
-        Assert.assertFalse(pointStyle.toMarkerOptions().isVisible());
-
+        assertFalse(pointStyle.isVisible());
+        assertFalse(pointStyle.toMarkerOptions().isVisible());
     }
 
     @Test
-    public void testDefaultPointStyle() throws Exception {
-        Assert.assertEquals(1.0f, pointStyle.getAlpha(), 0);
-        Assert.assertEquals(0.5f, pointStyle.getAnchorU(), 0);
-        Assert.assertEquals(1.0f, pointStyle.getAnchorV(), 0);
-        Assert.assertFalse(pointStyle.isDraggable());
-        Assert.assertFalse(pointStyle.isFlat());
-        Assert.assertNull(pointStyle.getIcon());
-        Assert.assertEquals(0.5f, pointStyle.getInfoWindowAnchorU(), 0);
-        Assert.assertEquals(0.0f, pointStyle.getInfoWindowAnchorV(), 0);
-        Assert.assertEquals(0.0f, pointStyle.getRotation(), 0);
-        Assert.assertNull(pointStyle.getSnippet());
-        Assert.assertNull(pointStyle.getTitle());
-        Assert.assertTrue(pointStyle.isVisible());
+    public void testDefaultPointStyle() {
+        assertEquals(1.0f, pointStyle.getAlpha(), 0);
+        assertEquals(0.5f, pointStyle.getAnchorU(), 0);
+        assertEquals(1.0f, pointStyle.getAnchorV(), 0);
+        assertFalse(pointStyle.isDraggable());
+        assertFalse(pointStyle.isFlat());
+        assertNull(pointStyle.getIcon());
+        assertEquals(0.5f, pointStyle.getInfoWindowAnchorU(), 0);
+        assertEquals(0.0f, pointStyle.getInfoWindowAnchorV(), 0);
+        assertEquals(0.0f, pointStyle.getRotation(), 0);
+        assertNull(pointStyle.getSnippet());
+        assertNull(pointStyle.getTitle());
+        assertTrue(pointStyle.isVisible());
     }
 
     @Test
-    public void testDefaultGetMarkerOptions() throws Exception {
-        Assert.assertEquals(1.0f, pointStyle.toMarkerOptions().getAlpha(), 0);
-        Assert.assertEquals(0.5f, pointStyle.toMarkerOptions().getAnchorU(), 0);
-        Assert.assertEquals(1.0f, pointStyle.toMarkerOptions().getAnchorV(), 0);
-        Assert.assertFalse(pointStyle.toMarkerOptions().isDraggable());
-        Assert.assertFalse(pointStyle.toMarkerOptions().isFlat());
-        Assert.assertNull(pointStyle.toMarkerOptions().getIcon());
-        Assert.assertEquals(0.5f, pointStyle.toMarkerOptions().getInfoWindowAnchorU(), 0);
-        Assert.assertEquals(0.0f, pointStyle.toMarkerOptions().getInfoWindowAnchorV(), 0);
-        Assert.assertEquals(0.0f, pointStyle.toMarkerOptions().getRotation(), 0);
-        Assert.assertNull(pointStyle.toMarkerOptions().getSnippet());
-        Assert.assertNull(pointStyle.toMarkerOptions().getTitle());
-        Assert.assertTrue(pointStyle.toMarkerOptions().isVisible());
+    public void testDefaultGetMarkerOptions() {
+        assertEquals(1.0f, pointStyle.toMarkerOptions().getAlpha(), 0);
+        assertEquals(0.5f, pointStyle.toMarkerOptions().getAnchorU(), 0);
+        assertEquals(1.0f, pointStyle.toMarkerOptions().getAnchorV(), 0);
+        assertFalse(pointStyle.toMarkerOptions().isDraggable());
+        assertFalse(pointStyle.toMarkerOptions().isFlat());
+        assertNull(pointStyle.toMarkerOptions().getIcon());
+        assertEquals(0.5f, pointStyle.toMarkerOptions().getInfoWindowAnchorU(), 0);
+        assertEquals(0.0f, pointStyle.toMarkerOptions().getInfoWindowAnchorV(), 0);
+        assertEquals(0.0f, pointStyle.toMarkerOptions().getRotation(), 0);
+        assertNull(pointStyle.toMarkerOptions().getSnippet());
+        assertNull(pointStyle.toMarkerOptions().getTitle());
+        assertTrue(pointStyle.toMarkerOptions().isVisible());
     }
-
 }

--- a/library/tests/src/com/google/maps/android/data/geojson/GeoJsonPointTest.java
+++ b/library/tests/src/com/google/maps/android/data/geojson/GeoJsonPointTest.java
@@ -3,33 +3,31 @@ package com.google.maps.android.data.geojson;
 import com.google.android.gms.maps.model.LatLng;
 
 import org.junit.Test;
-import org.junit.Assert;
+
+import static org.junit.Assert.*;
 
 public class GeoJsonPointTest {
-
-    GeoJsonPoint p;
-
     @Test
-    public void testGetType() throws Exception {
-        p = new GeoJsonPoint(new LatLng(0, 0));
-        Assert.assertEquals("Point", p.getType());
+    public void testGetType() {
+        GeoJsonPoint p = new GeoJsonPoint(new LatLng(0, 0));
+        assertEquals("Point", p.getType());
     }
 
     @Test
-    public void testGetCoordinates() throws Exception {
-        p = new GeoJsonPoint(new LatLng(0, 0));
-        Assert.assertEquals(new LatLng(0, 0), p.getCoordinates());
+    public void testGetCoordinates() {
+        GeoJsonPoint p = new GeoJsonPoint(new LatLng(0, 0));
+        assertEquals(new LatLng(0, 0), p.getCoordinates());
         try {
-            p = new GeoJsonPoint(null);
-            Assert.fail();
+            new GeoJsonPoint(null);
+            fail();
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("Coordinates cannot be null", e.getMessage());
+            assertEquals("Coordinates cannot be null", e.getMessage());
         }
     }
 
     @Test
-    public void testGetAltitude() throws Exception {
-        p = new GeoJsonPoint(new LatLng(0, 0), new Double(100));
-        Assert.assertEquals(new Double(100), p.getAltitude());
+    public void testGetAltitude() {
+        GeoJsonPoint p = new GeoJsonPoint(new LatLng(0, 0), 100d);
+        assertEquals(new Double(100), p.getAltitude());
     }
 }

--- a/library/tests/src/com/google/maps/android/data/geojson/GeoJsonPolygonStyleTest.java
+++ b/library/tests/src/com/google/maps/android/data/geojson/GeoJsonPolygonStyleTest.java
@@ -1,106 +1,105 @@
 package com.google.maps.android.data.geojson;
 
+import android.graphics.Color;
+
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Assert;
-
-import android.graphics.Color;
 
 import java.util.Arrays;
 
-public class GeoJsonPolygonStyleTest {
+import static org.junit.Assert.*;
 
+public class GeoJsonPolygonStyleTest {
     GeoJsonPolygonStyle polygonStyle;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         polygonStyle = new GeoJsonPolygonStyle();
     }
 
     @Test
-    public void testGetGeometryType() throws Exception {
-        Assert.assertTrue(Arrays.asList(polygonStyle.getGeometryType()).contains("Polygon"));
-        Assert.assertTrue(Arrays.asList(polygonStyle.getGeometryType()).contains("MultiPolygon"));
-        Assert.assertTrue(Arrays.asList(polygonStyle.getGeometryType()).contains("GeometryCollection"));
-        Assert.assertEquals(3, polygonStyle.getGeometryType().length);
+    public void testGetGeometryType() {
+        assertTrue(Arrays.asList(polygonStyle.getGeometryType()).contains("Polygon"));
+        assertTrue(Arrays.asList(polygonStyle.getGeometryType()).contains("MultiPolygon"));
+        assertTrue(Arrays.asList(polygonStyle.getGeometryType()).contains("GeometryCollection"));
+        assertEquals(3, polygonStyle.getGeometryType().length);
     }
 
     @Test
-    public void testFillColor() throws Exception {
+    public void testFillColor() {
         polygonStyle.setFillColor(Color.BLACK);
-        Assert.assertEquals(Color.BLACK, polygonStyle.getFillColor());
-        Assert.assertEquals(Color.BLACK, polygonStyle.toPolygonOptions().getFillColor());
+        assertEquals(Color.BLACK, polygonStyle.getFillColor());
+        assertEquals(Color.BLACK, polygonStyle.toPolygonOptions().getFillColor());
 
         polygonStyle.setFillColor(0xFFFFFF00);
-        Assert.assertEquals(0xFFFFFF00, polygonStyle.getFillColor());
-        Assert.assertEquals(0xFFFFFF00, polygonStyle.toPolygonOptions().getFillColor());
+        assertEquals(0xFFFFFF00, polygonStyle.getFillColor());
+        assertEquals(0xFFFFFF00, polygonStyle.toPolygonOptions().getFillColor());
 
         polygonStyle.setFillColor(Color.parseColor("#FFFFFF"));
-        Assert.assertEquals(Color.parseColor("#FFFFFF"), polygonStyle.getFillColor());
-        Assert.assertEquals(Color.parseColor("#FFFFFF"), polygonStyle.toPolygonOptions().getFillColor());
+        assertEquals(Color.parseColor("#FFFFFF"), polygonStyle.getFillColor());
+        assertEquals(Color.parseColor("#FFFFFF"), polygonStyle.toPolygonOptions().getFillColor());
     }
 
     @Test
-    public void testGeodesic() throws Exception {
+    public void testGeodesic() {
         polygonStyle.setGeodesic(true);
-        Assert.assertTrue(polygonStyle.isGeodesic());
-        Assert.assertTrue(polygonStyle.toPolygonOptions().isGeodesic());
+        assertTrue(polygonStyle.isGeodesic());
+        assertTrue(polygonStyle.toPolygonOptions().isGeodesic());
     }
 
     @Test
-    public void testStrokeColor() throws Exception {
+    public void testStrokeColor() {
         polygonStyle.setStrokeColor(Color.RED);
-        Assert.assertEquals(Color.RED, polygonStyle.getStrokeColor());
-        Assert.assertEquals(Color.RED, polygonStyle.toPolygonOptions().getStrokeColor());
+        assertEquals(Color.RED, polygonStyle.getStrokeColor());
+        assertEquals(Color.RED, polygonStyle.toPolygonOptions().getStrokeColor());
 
         polygonStyle.setStrokeColor(0x01234567);
-        Assert.assertEquals(0x01234567, polygonStyle.getStrokeColor());
-        Assert.assertEquals(0x01234567, polygonStyle.toPolygonOptions().getStrokeColor());
+        assertEquals(0x01234567, polygonStyle.getStrokeColor());
+        assertEquals(0x01234567, polygonStyle.toPolygonOptions().getStrokeColor());
 
         polygonStyle.setStrokeColor(Color.parseColor("#000000"));
-        Assert.assertEquals(Color.parseColor("#000000"), polygonStyle.getStrokeColor());
-        Assert.assertEquals(Color.parseColor("#000000"),
-                polygonStyle.toPolygonOptions().getStrokeColor());
+        assertEquals(Color.parseColor("#000000"), polygonStyle.getStrokeColor());
+        assertEquals(Color.parseColor("#000000"), polygonStyle.toPolygonOptions().getStrokeColor());
     }
 
     @Test
-    public void testStrokeWidth() throws Exception {
+    public void testStrokeWidth() {
         polygonStyle.setStrokeWidth(20.0f);
-        Assert.assertEquals(20.0f, polygonStyle.getStrokeWidth(), 0);
-        Assert.assertEquals(20.0f, polygonStyle.toPolygonOptions().getStrokeWidth(), 0);
+        assertEquals(20.0f, polygonStyle.getStrokeWidth(), 0);
+        assertEquals(20.0f, polygonStyle.toPolygonOptions().getStrokeWidth(), 0);
     }
 
     @Test
-    public void testVisible() throws Exception {
+    public void testVisible() {
         polygonStyle.setVisible(false);
-        Assert.assertFalse(polygonStyle.isVisible());
-        Assert.assertFalse(polygonStyle.toPolygonOptions().isVisible());
+        assertFalse(polygonStyle.isVisible());
+        assertFalse(polygonStyle.toPolygonOptions().isVisible());
     }
 
     @Test
-    public void testZIndex() throws Exception {
+    public void testZIndex() {
         polygonStyle.setZIndex(3.4f);
-        Assert.assertEquals(3.4f, polygonStyle.getZIndex(), 0);
-        Assert.assertEquals(3.4f, polygonStyle.toPolygonOptions().getZIndex(), 0);
+        assertEquals(3.4f, polygonStyle.getZIndex(), 0);
+        assertEquals(3.4f, polygonStyle.toPolygonOptions().getZIndex(), 0);
     }
 
     @Test
-    public void testDefaultPolygonStyle() throws Exception {
-        Assert.assertEquals(Color.TRANSPARENT, polygonStyle.getFillColor());
-        Assert.assertFalse(polygonStyle.isGeodesic());
-        Assert.assertEquals(Color.BLACK, polygonStyle.getStrokeColor());
-        Assert.assertEquals(10.0f, polygonStyle.getStrokeWidth(), 0);
-        Assert.assertTrue(polygonStyle.isVisible());
-        Assert.assertEquals(0.0f, polygonStyle.getZIndex(), 0);
+    public void testDefaultPolygonStyle() {
+        assertEquals(Color.TRANSPARENT, polygonStyle.getFillColor());
+        assertFalse(polygonStyle.isGeodesic());
+        assertEquals(Color.BLACK, polygonStyle.getStrokeColor());
+        assertEquals(10.0f, polygonStyle.getStrokeWidth(), 0);
+        assertTrue(polygonStyle.isVisible());
+        assertEquals(0.0f, polygonStyle.getZIndex(), 0);
     }
 
     @Test
-    public void testDefaultGetPolygonOptions() throws Exception {
-        Assert.assertEquals(Color.TRANSPARENT, polygonStyle.toPolygonOptions().getFillColor());
-        Assert.assertFalse(polygonStyle.toPolygonOptions().isGeodesic());
-        Assert.assertEquals(Color.BLACK, polygonStyle.toPolygonOptions().getStrokeColor());
-        Assert.assertEquals(10.0f, polygonStyle.toPolygonOptions().getStrokeWidth(), 0);
-        Assert.assertTrue(polygonStyle.isVisible());
-        Assert.assertEquals(0.0f, polygonStyle.toPolygonOptions().getZIndex(), 0);
+    public void testDefaultGetPolygonOptions() {
+        assertEquals(Color.TRANSPARENT, polygonStyle.toPolygonOptions().getFillColor());
+        assertFalse(polygonStyle.toPolygonOptions().isGeodesic());
+        assertEquals(Color.BLACK, polygonStyle.toPolygonOptions().getStrokeColor());
+        assertEquals(10.0f, polygonStyle.toPolygonOptions().getStrokeWidth(), 0);
+        assertTrue(polygonStyle.isVisible());
+        assertEquals(0.0f, polygonStyle.toPolygonOptions().getZIndex(), 0);
     }
 }

--- a/library/tests/src/com/google/maps/android/data/geojson/GeoJsonPolygonTest.java
+++ b/library/tests/src/com/google/maps/android/data/geojson/GeoJsonPolygonTest.java
@@ -3,48 +3,59 @@ package com.google.maps.android.data.geojson;
 import com.google.android.gms.maps.model.LatLng;
 
 import org.junit.Test;
-import org.junit.Assert;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 public class GeoJsonPolygonTest {
-
     GeoJsonPolygon p;
 
     @Test
-    public void testGetType() throws Exception {
-        ArrayList<ArrayList<LatLng>> coordinates = new ArrayList<ArrayList<LatLng>>();
-        coordinates.add(new ArrayList<LatLng>(
-                Arrays.asList(new LatLng(0, 0), new LatLng(20, 20), new LatLng(60, 60),
-                        new LatLng(0, 0))));
+    public void testGetType() {
+        List<List<LatLng>> coordinates = new ArrayList<>();
+        coordinates.add(
+                new ArrayList<>(
+                        Arrays.asList(
+                                new LatLng(0, 0),
+                                new LatLng(20, 20),
+                                new LatLng(60, 60),
+                                new LatLng(0, 0))));
         p = new GeoJsonPolygon(coordinates);
-        Assert.assertEquals("Polygon", p.getType());
+        assertEquals("Polygon", p.getType());
     }
 
     @Test
-    public void testGetCoordinates() throws Exception {
+    public void testGetCoordinates() {
         // No holes
-        ArrayList<ArrayList<LatLng>> coordinates = new ArrayList<ArrayList<LatLng>>();
-        coordinates.add(new ArrayList<LatLng>(
-                Arrays.asList(new LatLng(0, 0), new LatLng(20, 20), new LatLng(60, 60),
-                        new LatLng(0, 0))));
+        List<List<LatLng>> coordinates = new ArrayList<>();
+        coordinates.add(
+                new ArrayList<>(
+                        Arrays.asList(
+                                new LatLng(0, 0),
+                                new LatLng(20, 20),
+                                new LatLng(60, 60),
+                                new LatLng(0, 0))));
         p = new GeoJsonPolygon(coordinates);
-        Assert.assertEquals(coordinates, p.getCoordinates());
+        assertEquals(coordinates, p.getCoordinates());
 
         // Holes
-        coordinates.add(new ArrayList<LatLng>(
-                Arrays.asList(new LatLng(0, 0), new LatLng(20, 20), new LatLng(60, 60),
-                        new LatLng(0, 0))));
+        coordinates.add(
+                new ArrayList<>(
+                        Arrays.asList(
+                                new LatLng(0, 0),
+                                new LatLng(20, 20),
+                                new LatLng(60, 60),
+                                new LatLng(0, 0))));
         p = new GeoJsonPolygon(coordinates);
-
 
         try {
             p = new GeoJsonPolygon(null);
-            Assert.fail();
+            fail();
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("Coordinates cannot be null", e.getMessage());
+            assertEquals("Coordinates cannot be null", e.getMessage());
         }
-
     }
 }

--- a/library/tests/src/com/google/maps/android/data/geojson/GeoJsonRendererTest.java
+++ b/library/tests/src/com/google/maps/android/data/geojson/GeoJsonRendererTest.java
@@ -3,11 +3,9 @@ package com.google.maps.android.data.geojson;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.LatLng;
 
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Assert;
-
-import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -15,8 +13,9 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Set;
 
-public class GeoJsonRendererTest {
+import static org.junit.Assert.*;
 
+public class GeoJsonRendererTest {
     GoogleMap mMap1;
     Set<GeoJsonFeature> geoJsonFeaturesSet;
     GeoJsonRenderer mRenderer;
@@ -27,26 +26,23 @@ public class GeoJsonRendererTest {
     @Before
     public void setUp() throws Exception {
         GeoJsonParser parser = new GeoJsonParser(createFeatureCollection());
-        HashMap<GeoJsonFeature, Object> geoJsonFeatures = new HashMap<GeoJsonFeature, Object>();
+        HashMap<GeoJsonFeature, Object> geoJsonFeatures = new HashMap<>();
         for (GeoJsonFeature feature : parser.getFeatures()) {
             geoJsonFeatures.put(feature, null);
         }
         geoJsonFeaturesSet = geoJsonFeatures.keySet();
         mRenderer = new GeoJsonRenderer(mMap1, geoJsonFeatures);
         mLayer = new GeoJsonLayer(mMap1, createFeatureCollection());
-        GeoJsonLineString geoJsonLineString = new GeoJsonLineString(
-                new ArrayList<>(Arrays.asList(new LatLng(0, 100), new LatLng(1, 101))));
+        GeoJsonLineString geoJsonLineString =
+                new GeoJsonLineString(
+                        new ArrayList<>(Arrays.asList(new LatLng(0, 100), new LatLng(1, 101))));
         mGeoJsonFeature = new GeoJsonFeature(geoJsonLineString, null, null, null);
         mValues = geoJsonFeatures.values();
     }
 
-    public void tearDown() throws Exception {
-
-    }
-
     @Test
-    public void testGetMap() throws Exception {
-        Assert.assertEquals(mMap1, mRenderer.getMap());
+    public void testGetMap() {
+        assertEquals(mMap1, mRenderer.getMap());
     }
 
     @Test
@@ -54,39 +50,39 @@ public class GeoJsonRendererTest {
         mLayer = new GeoJsonLayer(mMap1, createFeatureCollection());
         mMap1 = mLayer.getMap();
         mRenderer.setMap(mMap1);
-        Assert.assertEquals(mMap1, mRenderer.getMap());
+        assertEquals(mMap1, mRenderer.getMap());
         mRenderer.setMap(null);
-        Assert.assertNull(mRenderer.getMap());
+        assertNull(mRenderer.getMap());
     }
 
     @Test
-    public void testGetFeatures() throws Exception {
-        Assert.assertEquals(geoJsonFeaturesSet, mRenderer.getFeatures());
+    public void testGetFeatures() {
+        assertEquals(geoJsonFeaturesSet, mRenderer.getFeatures());
     }
 
     @Test
-    public void testAddFeature() throws Exception {
+    public void testAddFeature() {
         mRenderer.addFeature(mGeoJsonFeature);
-        Assert.assertTrue(mRenderer.getFeatures().contains(mGeoJsonFeature));
+        assertTrue(mRenderer.getFeatures().contains(mGeoJsonFeature));
     }
 
     @Test
     public void testGetValues() {
-        Assert.assertEquals(mValues.size(), mRenderer.getValues().size());
+        assertEquals(mValues.size(), mRenderer.getValues().size());
     }
 
     @Test
     public void testRemoveLayerFromMap() throws Exception {
         mLayer = new GeoJsonLayer(mMap1, createFeatureCollection());
         mRenderer.removeLayerFromMap();
-        Assert.assertEquals(mMap1, mRenderer.getMap());
+        assertEquals(mMap1, mRenderer.getMap());
     }
 
     @Test
-    public void testRemoveFeature() throws Exception {
+    public void testRemoveFeature() {
         mRenderer.addFeature(mGeoJsonFeature);
         mRenderer.removeFeature(mGeoJsonFeature);
-        Assert.assertFalse(mRenderer.getFeatures().contains(mGeoJsonFeature));
+        assertFalse(mRenderer.getFeatures().contains(mGeoJsonFeature));
     }
 
     private JSONObject createFeatureCollection() throws Exception {
@@ -94,7 +90,8 @@ public class GeoJsonRendererTest {
                 "{ \"type\": \"FeatureCollection\",\n"
                         + "    \"features\": [\n"
                         + "      { \"type\": \"Feature\",\n"
-                        + "        \"geometry\": {\"type\": \"MultiPoint\", \"coordinates\": [[102.0, 0.5], [100, 0.5]]},\n"
+                        + "        \"geometry\": {\"type\": \"MultiPoint\", \"coordinates\": [[102.0,"
+                        + " 0.5], [100, 0.5]]},\n"
                         + "        \"properties\": {\"title\": \"Test MultiPoint\"}\n"
                         + "        },\n"
                         + "      { \"type\": \"Feature\",\n"
@@ -112,16 +109,18 @@ public class GeoJsonRendererTest {
                         + "         \"geometry\": {\n"
                         + "           \"type\": \"MultiPolygon\",\n"
                         + "           \"coordinates\": [\n"
-                        + "             [[[102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0]]],\n" +
-                        "      [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]],\n" +
-                        "       [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]],\n"
+                        + "             [[[102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0],"
+                        + " [102.0, 2.0]]],\n"
+                        + "      [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0,"
+                        + " 0.0]],\n"
+                        + "       [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2,"
+                        + " 0.2]]],\n"
                         + "             ]\n"
                         + "         },\n"
                         + "         \"properties\": {\n"
                         + "           \"title\": \"Test MultiPolygon\"}\n"
                         + "         }\n"
                         + "       ]\n"
-                        + "     }"
-        );
+                        + "     }");
     }
 }

--- a/library/tests/src/com/google/maps/android/data/kml/KmlContainerParserTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlContainerParserTest.java
@@ -2,20 +2,23 @@ package com.google.maps.android.data.kml;
 
 import androidx.test.platform.app.InstrumentationRegistry;
 
-import org.junit.Test;
-import org.junit.Assert;
-
 import com.google.maps.android.test.R;
 
+import org.junit.Test;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserFactory;
 
 import java.io.InputStream;
 
-public class KmlContainerParserTest {
+import static org.junit.Assert.*;
 
-    public XmlPullParser createParser(int res) throws Exception {
-        InputStream stream = InstrumentationRegistry.getInstrumentation().getTargetContext().getResources().openRawResource(res);
+public class KmlContainerParserTest {
+    private XmlPullParser createParser(int res) throws Exception {
+        InputStream stream =
+                InstrumentationRegistry.getInstrumentation()
+                        .getTargetContext()
+                        .getResources()
+                        .openRawResource(res);
         XmlPullParserFactory factory = XmlPullParserFactory.newInstance();
         factory.setNamespaceAware(true);
         XmlPullParser parser = factory.newPullParser();
@@ -28,50 +31,48 @@ public class KmlContainerParserTest {
     public void testCDataEntity() throws Exception {
         XmlPullParser xmlPullParser = createParser(R.raw.amu_cdata);
         KmlContainer kmlContainer = KmlContainerParser.createContainer(xmlPullParser);
-        Assert.assertEquals(kmlContainer.getProperty("description"), "TELEPORT");
+        assertEquals("TELEPORT", kmlContainer.getProperty("description"));
     }
 
     @Test
     public void testCreateContainerProperty() throws Exception {
         XmlPullParser xmlPullParser = createParser(R.raw.amu_basic_folder);
         KmlContainer kmlContainer = KmlContainerParser.createContainer(xmlPullParser);
-        Assert.assertTrue(kmlContainer.hasProperties());
-        Assert.assertEquals(kmlContainer.getProperty("name"), "Basic Folder");
+        assertTrue(kmlContainer.hasProperties());
+        assertEquals("Basic Folder", kmlContainer.getProperty("name"));
         xmlPullParser = createParser(R.raw.amu_unknown_folder);
         kmlContainer = KmlContainerParser.createContainer(xmlPullParser);
-        Assert.assertTrue(kmlContainer.hasProperty("name"));
+        assertTrue(kmlContainer.hasProperty("name"));
     }
 
     @Test
     public void testCreateContainerPlacemark() throws Exception {
         XmlPullParser xmlPullParser = createParser(R.raw.amu_basic_folder);
         KmlContainer kmlContainer = KmlContainerParser.createContainer(xmlPullParser);
-        Assert.assertTrue(kmlContainer.hasPlacemarks());
-        Assert.assertEquals(kmlContainer.getPlacemarksHashMap().size(), 1);
+        assertTrue(kmlContainer.hasPlacemarks());
+        assertEquals(1, kmlContainer.getPlacemarksHashMap().size());
         xmlPullParser = createParser(R.raw.amu_multiple_placemarks);
         kmlContainer = KmlContainerParser.createContainer(xmlPullParser);
-        Assert.assertTrue(kmlContainer.hasPlacemarks());
-        Assert.assertEquals(kmlContainer.getPlacemarksHashMap().size(), 2);
+        assertTrue(kmlContainer.hasPlacemarks());
+        assertEquals(2, kmlContainer.getPlacemarksHashMap().size());
     }
 
     @Test
     public void testCreateContainerGroundOverlay() throws Exception {
         XmlPullParser xmlPullParser = createParser(R.raw.amu_ground_overlay);
         KmlContainer kmlContainer = KmlContainerParser.createContainer(xmlPullParser);
-        Assert.assertEquals(kmlContainer.getGroundOverlayHashMap().size(), 2);
+        assertEquals(2, kmlContainer.getGroundOverlayHashMap().size());
     }
 
     @Test
     public void testCreateContainerObjects() throws Exception {
         XmlPullParser xmlPullParser = createParser(R.raw.amu_nested_folders);
         KmlContainer kmlContainer = KmlContainerParser.createContainer(xmlPullParser);
-        Assert.assertNotNull(kmlContainer.getContainers());
+        assertNotNull(kmlContainer.getContainers());
         int numberOfNestedContainers = 0;
         for (KmlContainer container : kmlContainer.getContainers()) {
             numberOfNestedContainers++;
         }
-        Assert.assertEquals(numberOfNestedContainers, 2);
+        assertEquals(2, numberOfNestedContainers);
     }
-
-
 }

--- a/library/tests/src/com/google/maps/android/data/kml/KmlFeatureParserTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlFeatureParserTest.java
@@ -2,22 +2,26 @@ package com.google.maps.android.data.kml;
 
 import androidx.test.platform.app.InstrumentationRegistry;
 
-import org.junit.Test;
-import org.junit.Assert;
-
 import com.google.maps.android.data.Geometry;
 import com.google.maps.android.test.R;
 
+import org.junit.Test;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserFactory;
 
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 public class KmlFeatureParserTest {
-
-    public XmlPullParser createParser(int res) throws Exception {
-        InputStream stream = InstrumentationRegistry.getInstrumentation().getTargetContext().getResources().openRawResource(res);
+    private XmlPullParser createParser(int res) throws Exception {
+        InputStream stream =
+                InstrumentationRegistry.getInstrumentation()
+                        .getTargetContext()
+                        .getResources()
+                        .openRawResource(res);
         XmlPullParserFactory factory = XmlPullParserFactory.newInstance();
         factory.setNamespaceAware(true);
         XmlPullParser parser = factory.newPullParser();
@@ -30,69 +34,67 @@ public class KmlFeatureParserTest {
     public void testPolygon() throws Exception {
         XmlPullParser xmlPullParser = createParser(R.raw.amu_basic_placemark);
         KmlPlacemark placemark = KmlFeatureParser.createPlacemark(xmlPullParser);
-        Assert.assertNotNull(placemark);
-        Assert.assertEquals(placemark.getGeometry().getGeometryType(), "Polygon");
+        assertNotNull(placemark);
+        assertEquals(placemark.getGeometry().getGeometryType(), "Polygon");
         KmlPolygon polygon = ((KmlPolygon) placemark.getGeometry());
-        Assert.assertEquals(polygon.getInnerBoundaryCoordinates().size(), 2);
-        Assert.assertEquals(polygon.getOuterBoundaryCoordinates().size(), 5);
+        assertEquals(polygon.getInnerBoundaryCoordinates().size(), 2);
+        assertEquals(polygon.getOuterBoundaryCoordinates().size(), 5);
     }
 
     @Test
     public void testMultiGeometry() throws Exception {
         XmlPullParser xmlPullParser = createParser(R.raw.amu_multigeometry_placemarks);
         KmlPlacemark placemark = KmlFeatureParser.createPlacemark(xmlPullParser);
-        Assert.assertNotNull(placemark);
-        Assert.assertEquals(placemark.getGeometry().getGeometryType(), "MultiGeometry");
+        assertNotNull(placemark);
+        assertEquals(placemark.getGeometry().getGeometryType(), "MultiGeometry");
         KmlMultiGeometry multiGeometry = ((KmlMultiGeometry) placemark.getGeometry());
-        Assert.assertEquals(multiGeometry.getGeometryObject().size(), 3);
+        assertEquals(multiGeometry.getGeometryObject().size(), 3);
     }
 
     @Test
     public void testProperties() throws Exception {
         XmlPullParser xmlPullParser = createParser(R.raw.amu_multigeometry_placemarks);
         KmlPlacemark placemark = KmlFeatureParser.createPlacemark(xmlPullParser);
-        Assert.assertTrue(placemark.hasProperties());
-        Assert.assertEquals(placemark.getProperty("name"), "Placemark Test");
-        Assert.assertNull(placemark.getProperty("description"));
+        assertTrue(placemark.hasProperties());
+        assertEquals(placemark.getProperty("name"), "Placemark Test");
+        assertNull(placemark.getProperty("description"));
     }
 
     @Test
     public void testExtendedData() throws Exception {
         XmlPullParser xmlPullParser = createParser(R.raw.amu_multiple_placemarks);
         KmlPlacemark placemark = KmlFeatureParser.createPlacemark(xmlPullParser);
-        Assert.assertNotNull(placemark.getProperty("holeNumber"));
+        assertNotNull(placemark.getProperty("holeNumber"));
     }
 
     @Test
     public void testGroundOverlay() throws Exception {
         XmlPullParser xmlPullParser = createParser(R.raw.amu_ground_overlay);
         KmlGroundOverlay groundOverlay = KmlFeatureParser.createGroundOverlay(xmlPullParser);
-        Assert.assertNotNull(groundOverlay);
-        Assert.assertEquals(groundOverlay.getProperty("name"), "Sample Ground Overlay");
-        Assert.assertNotNull(groundOverlay.getImageUrl());
-        Assert.assertEquals(groundOverlay.getGroundOverlayOptions().getZIndex(), 99.0f, 0);
-        Assert.assertTrue(groundOverlay.getGroundOverlayOptions().isVisible());
-        Assert.assertNotNull(groundOverlay.getLatLngBox());
+        assertNotNull(groundOverlay);
+        assertEquals(groundOverlay.getProperty("name"), "Sample Ground Overlay");
+        assertNotNull(groundOverlay.getImageUrl());
+        assertEquals(groundOverlay.getGroundOverlayOptions().getZIndex(), 99.0f, 0);
+        assertTrue(groundOverlay.getGroundOverlayOptions().isVisible());
+        assertNotNull(groundOverlay.getLatLngBox());
         xmlPullParser = createParser(R.raw.amu_ground_overlay_color);
         groundOverlay = KmlFeatureParser.createGroundOverlay(xmlPullParser);
-        Assert.assertNotNull(groundOverlay);
+        assertNotNull(groundOverlay);
     }
 
     @Test
     public void testMultiGeometries() throws Exception {
         XmlPullParser xmlPullParser = createParser(R.raw.amu_nested_multigeometry);
         KmlPlacemark feature = KmlFeatureParser.createPlacemark(xmlPullParser);
-        Assert.assertEquals(feature.getProperty("name"), "multiPointLine");
-        Assert.assertEquals(feature.getProperty("description"), "Nested MultiGeometry structure");
-        Assert.assertEquals(feature.getGeometry().getGeometryType(), "MultiGeometry");
-        ArrayList<Geometry> objects = (ArrayList<Geometry>) feature.getGeometry().getGeometryObject();
-        Assert.assertEquals(objects.get(0).getGeometryType(), "Point");
-        Assert.assertEquals(objects.get(1).getGeometryType(), "LineString");
-        Assert.assertEquals(objects.get(2).getGeometryType(), "MultiGeometry");
-        ArrayList<Geometry> subObjects = (ArrayList<Geometry>) objects.get(2).getGeometryObject();
-        Assert.assertEquals(subObjects.get(0).getGeometryType(), "Point");
-        Assert.assertEquals(subObjects.get(1).getGeometryType(), "LineString");
+        assertEquals(feature.getProperty("name"), "multiPointLine");
+        assertEquals(feature.getProperty("description"), "Nested MultiGeometry structure");
+        assertEquals(feature.getGeometry().getGeometryType(), "MultiGeometry");
+        List<Geometry> objects = (ArrayList<Geometry>) feature.getGeometry().getGeometryObject();
+        assertEquals(objects.get(0).getGeometryType(), "Point");
+        assertEquals(objects.get(1).getGeometryType(), "LineString");
+        assertEquals(objects.get(2).getGeometryType(), "MultiGeometry");
+        List<Geometry> subObjects = (ArrayList<Geometry>) objects.get(2).getGeometryObject();
+        assertEquals(subObjects.get(0).getGeometryType(), "Point");
+        assertEquals(subObjects.get(1).getGeometryType(), "LineString");
     }
-
-
 }

--- a/library/tests/src/com/google/maps/android/data/kml/KmlLineStringTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlLineStringTest.java
@@ -3,35 +3,34 @@ package com.google.maps.android.data.kml;
 import com.google.android.gms.maps.model.LatLng;
 
 import org.junit.Test;
-import org.junit.Assert;
 
 import java.util.ArrayList;
 
-public class KmlLineStringTest {
-    KmlLineString kmlLineString;
+import static org.junit.Assert.*;
 
-    public KmlLineString createSimpleLineString() {
-        ArrayList<LatLng> coordinates = new ArrayList<LatLng>();
+public class KmlLineStringTest {
+    private KmlLineString createSimpleLineString() {
+        ArrayList<LatLng> coordinates = new ArrayList<>();
         coordinates.add(new LatLng(0, 0));
         coordinates.add(new LatLng(50, 50));
         coordinates.add(new LatLng(100, 100));
         return new KmlLineString(coordinates);
     }
 
-    public KmlLineString createSimpleLineStringWithAltitudes() {
-        ArrayList<LatLng> coordinates = new ArrayList<LatLng>();
-        ArrayList<Double> altitudes = new ArrayList<Double>();
+    private KmlLineString createSimpleLineStringWithAltitudes() {
+        ArrayList<LatLng> coordinates = new ArrayList<>();
+        ArrayList<Double> altitudes = new ArrayList<>();
         coordinates.add(new LatLng(0, 0));
         coordinates.add(new LatLng(50, 50));
         coordinates.add(new LatLng(100, 100));
-        altitudes.add(new Double(100));
-        altitudes.add(new Double(200));
-        altitudes.add(new Double(300));
+        altitudes.add(100d);
+        altitudes.add(200d);
+        altitudes.add(300d);
         return new KmlLineString(coordinates, altitudes);
     }
 
-    public KmlLineString createLoopedLineString() {
-        ArrayList<LatLng> coordinates = new ArrayList<LatLng>();
+    private KmlLineString createLoopedLineString() {
+        ArrayList<LatLng> coordinates = new ArrayList<>();
         coordinates.add(new LatLng(0, 0));
         coordinates.add(new LatLng(50, 50));
         coordinates.add(new LatLng(0, 0));
@@ -39,49 +38,50 @@ public class KmlLineStringTest {
     }
 
     @Test
-    public void testGetType() throws Exception {
-        kmlLineString = createSimpleLineString();
-        Assert.assertNotNull(kmlLineString);
-        Assert.assertNotNull(kmlLineString.getGeometryType());
-        Assert.assertEquals("LineString", kmlLineString.getGeometryType());
+    public void testGetType() {
+        KmlLineString kmlLineString = createSimpleLineString();
+        assertNotNull(kmlLineString);
+        assertNotNull(kmlLineString.getGeometryType());
+        assertEquals("LineString", kmlLineString.getGeometryType());
+
         kmlLineString = createLoopedLineString();
-        Assert.assertNotNull(kmlLineString);
-        Assert.assertNotNull(kmlLineString.getGeometryType());
-        Assert.assertEquals("LineString", kmlLineString.getGeometryType());
+        assertNotNull(kmlLineString);
+        assertNotNull(kmlLineString.getGeometryType());
+        assertEquals("LineString", kmlLineString.getGeometryType());
     }
 
     @Test
-    public void testGetKmlGeometryObject() throws Exception {
-        kmlLineString = createSimpleLineString();
-        Assert.assertNotNull(kmlLineString);
-        Assert.assertNotNull(kmlLineString.getGeometryObject());
-        Assert.assertEquals(kmlLineString.getGeometryObject().size(), 3);
-        Assert.assertEquals(kmlLineString.getGeometryObject().get(0).latitude, 0.0, 0);
-        Assert.assertEquals(kmlLineString.getGeometryObject().get(1).latitude, 50.0, 0);
-        Assert.assertEquals(kmlLineString.getGeometryObject().get(2).latitude, 90.0, 0);
-        kmlLineString = createLoopedLineString();
-        Assert.assertNotNull(kmlLineString);
-        Assert.assertNotNull(kmlLineString.getGeometryObject());
-        Assert.assertEquals(kmlLineString.getGeometryObject().size(), 3);
-        Assert.assertEquals(kmlLineString.getGeometryObject().get(0).latitude, 0.0, 0);
-        Assert.assertEquals(kmlLineString.getGeometryObject().get(1).latitude, 50.0, 0);
-        Assert.assertEquals(kmlLineString.getGeometryObject().get(2).latitude, 0.0, 0);
+    public void testGetKmlGeometryObject() {
+        KmlLineString kmlLineString = createSimpleLineString();
+        assertNotNull(kmlLineString);
+        assertNotNull(kmlLineString.getGeometryObject());
+        assertEquals(3, kmlLineString.getGeometryObject().size());
+        assertEquals(0.0, kmlLineString.getGeometryObject().get(0).latitude, 0);
+        assertEquals(50.0, kmlLineString.getGeometryObject().get(1).latitude, 0);
+        assertEquals(90.0, kmlLineString.getGeometryObject().get(2).latitude, 0);
 
+        kmlLineString = createLoopedLineString();
+        assertNotNull(kmlLineString);
+        assertNotNull(kmlLineString.getGeometryObject());
+        assertEquals(3, kmlLineString.getGeometryObject().size());
+        assertEquals(0.0, kmlLineString.getGeometryObject().get(0).latitude, 0);
+        assertEquals(50.0, kmlLineString.getGeometryObject().get(1).latitude, 0);
+        assertEquals(0.0, kmlLineString.getGeometryObject().get(2).latitude, 0);
     }
 
     @Test
-    public void testLineStringAltitudes() throws Exception {
-        //test linestring without altitudes
-        kmlLineString = createSimpleLineString();
-        Assert.assertNotNull(kmlLineString);
-        Assert.assertNull(kmlLineString.getAltitudes());
+    public void testLineStringAltitudes() {
+        // test linestring without altitudes
+        KmlLineString kmlLineString = createSimpleLineString();
+        assertNotNull(kmlLineString);
+        assertNull(kmlLineString.getAltitudes());
 
-        //test linestring with altitudes
+        // test linestring with altitudes
         kmlLineString = createSimpleLineStringWithAltitudes();
-        Assert.assertNotNull(kmlLineString);
-        Assert.assertNotNull(kmlLineString.getAltitudes());
-        Assert.assertEquals(kmlLineString.getAltitudes().get(0), 100.0, 0);
-        Assert.assertEquals(kmlLineString.getAltitudes().get(1), 200.0, 0);
-        Assert.assertEquals(kmlLineString.getAltitudes().get(2), 300.0, 0);
+        assertNotNull(kmlLineString);
+        assertNotNull(kmlLineString.getAltitudes());
+        assertEquals(100.0, kmlLineString.getAltitudes().get(0), 0);
+        assertEquals(200.0, kmlLineString.getAltitudes().get(1), 0);
+        assertEquals(300.0, kmlLineString.getAltitudes().get(2), 0);
     }
 }

--- a/library/tests/src/com/google/maps/android/data/kml/KmlMultiGeometryTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlMultiGeometryTest.java
@@ -3,23 +3,15 @@ package com.google.maps.android.data.kml;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.maps.android.data.Geometry;
 
-import org.junit.Before;
-import org.junit.Test;
 import org.junit.Assert;
+import org.junit.Test;
 
 import java.util.ArrayList;
 
 public class KmlMultiGeometryTest {
-    KmlMultiGeometry kmlMultiGeometry;
-
-    @Before
-    public void setUp() throws Exception {
-
-    }
-
     public KmlMultiGeometry createMultiGeometry() {
-        ArrayList<Geometry> kmlGeometries = new ArrayList<Geometry>();
-        ArrayList<LatLng> coordinates = new ArrayList<LatLng>();
+        ArrayList<Geometry> kmlGeometries = new ArrayList<>();
+        ArrayList<LatLng> coordinates = new ArrayList<>();
         coordinates.add(new LatLng(0, 0));
         coordinates.add(new LatLng(50, 50));
         coordinates.add(new LatLng(100, 100));
@@ -29,18 +21,18 @@ public class KmlMultiGeometryTest {
     }
 
     @Test
-    public void testGetKmlGeometryType() throws Exception {
-        kmlMultiGeometry = createMultiGeometry();
+    public void testGetKmlGeometryType() {
+        KmlMultiGeometry kmlMultiGeometry = createMultiGeometry();
         Assert.assertNotNull(kmlMultiGeometry);
         Assert.assertNotNull(kmlMultiGeometry.getGeometryType());
         Assert.assertEquals("MultiGeometry", kmlMultiGeometry.getGeometryType());
     }
 
     @Test
-    public void testGetGeometry() throws Exception {
-        kmlMultiGeometry = createMultiGeometry();
+    public void testGetGeometry() {
+        KmlMultiGeometry kmlMultiGeometry = createMultiGeometry();
         Assert.assertNotNull(kmlMultiGeometry);
-        Assert.assertEquals(kmlMultiGeometry.getGeometryObject().size(), 1);
+        Assert.assertEquals(1, kmlMultiGeometry.getGeometryObject().size());
         KmlLineString lineString = ((KmlLineString) kmlMultiGeometry.getGeometryObject().get(0));
         Assert.assertNotNull(lineString);
     }
@@ -48,7 +40,7 @@ public class KmlMultiGeometryTest {
     @Test
     public void testNullGeometry() {
         try {
-            kmlMultiGeometry = new KmlMultiGeometry(null);
+            new KmlMultiGeometry(null);
             Assert.fail();
         } catch (IllegalArgumentException e) {
             Assert.assertEquals("Geometries cannot be null", e.getMessage());

--- a/library/tests/src/com/google/maps/android/data/kml/KmlMultiTrackTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlMultiTrackTest.java
@@ -2,36 +2,29 @@ package com.google.maps.android.data.kml;
 
 import com.google.android.gms.maps.model.LatLng;
 
-import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 
+import static org.junit.Assert.*;
+
 public class KmlMultiTrackTest {
-    KmlMultiTrack kmlMultiTrack;
-
-    @Before
-    public void setUp() throws Exception {
-
-    }
-
-    public KmlMultiTrack createMultiTrack() {
-        ArrayList<KmlTrack> kmlTracks = new ArrayList<KmlTrack>();
-        ArrayList<LatLng> coordinates = new ArrayList<LatLng>();
-        ArrayList<Double> altitudes = new ArrayList<Double>();
-        ArrayList<Long> timestamps = new ArrayList<Long>();
-        HashMap<String, String> properties = new HashMap<String, String>();
+    private KmlMultiTrack createMultiTrack() {
+        ArrayList<KmlTrack> kmlTracks = new ArrayList<>();
+        ArrayList<LatLng> coordinates = new ArrayList<>();
+        ArrayList<Double> altitudes = new ArrayList<>();
+        ArrayList<Long> timestamps = new ArrayList<>();
+        HashMap<String, String> properties = new HashMap<>();
         coordinates.add(new LatLng(0, 0));
         coordinates.add(new LatLng(50, 50));
         coordinates.add(new LatLng(90, 90));
-        altitudes.add(new Double(100));
-        altitudes.add(new Double(200));
-        altitudes.add(new Double(300));
-        timestamps.add(new Long(1000));
-        timestamps.add(new Long(2000));
-        timestamps.add(new Long(3000));
+        altitudes.add(100d);
+        altitudes.add(200d);
+        altitudes.add(300d);
+        timestamps.add(1000L);
+        timestamps.add(2000L);
+        timestamps.add(3000L);
         properties.put("key", "value");
         KmlTrack kmlTrack = new KmlTrack(coordinates, altitudes, timestamps, properties);
         kmlTracks.add(kmlTrack);
@@ -39,29 +32,29 @@ public class KmlMultiTrackTest {
     }
 
     @Test
-    public void testGetKmlGeometryType() throws Exception {
-        kmlMultiTrack = createMultiTrack();
-        Assert.assertNotNull(kmlMultiTrack);
-        Assert.assertNotNull(kmlMultiTrack.getGeometryType());
-        Assert.assertEquals("MultiGeometry", kmlMultiTrack.getGeometryType());
+    public void testGetKmlGeometryType() {
+        KmlMultiTrack kmlMultiTrack = createMultiTrack();
+        assertNotNull(kmlMultiTrack);
+        assertNotNull(kmlMultiTrack.getGeometryType());
+        assertEquals("MultiGeometry", kmlMultiTrack.getGeometryType());
     }
 
     @Test
-    public void testGetGeometry() throws Exception {
-        kmlMultiTrack = createMultiTrack();
-        Assert.assertNotNull(kmlMultiTrack);
-        Assert.assertEquals(kmlMultiTrack.getGeometryObject().size(), 1);
+    public void testGetGeometry() {
+        KmlMultiTrack kmlMultiTrack = createMultiTrack();
+        assertNotNull(kmlMultiTrack);
+        assertEquals(1, kmlMultiTrack.getGeometryObject().size());
         KmlTrack lineString = ((KmlTrack) kmlMultiTrack.getGeometryObject().get(0));
-        Assert.assertNotNull(lineString);
+        assertNotNull(lineString);
     }
 
     @Test
     public void testNullGeometry() {
         try {
-            kmlMultiTrack = new KmlMultiTrack(null);
-            Assert.fail();
+            new KmlMultiTrack(null);
+            fail();
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("Tracks cannot be null", e.getMessage());
+            assertEquals("Tracks cannot be null", e.getMessage());
         }
     }
 }

--- a/library/tests/src/com/google/maps/android/data/kml/KmlParserTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlParserTest.java
@@ -1,20 +1,26 @@
 package com.google.maps.android.data.kml;
 
-import androidx.test.platform.app.InstrumentationRegistry;
 import android.graphics.Color;
 
+import androidx.test.platform.app.InstrumentationRegistry;
+
 import org.junit.Test;
-import org.junit.Assert;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserFactory;
 
 import java.io.InputStream;
 import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
 
 public class KmlParserTest {
-
-    public XmlPullParser createParser(int res) throws Exception {
-        InputStream stream = InstrumentationRegistry.getInstrumentation().getTargetContext().getResources().openRawResource(res);
+    private XmlPullParser createParser(int res) throws Exception {
+        InputStream stream =
+                InstrumentationRegistry.getInstrumentation()
+                        .getTargetContext()
+                        .getResources()
+                        .openRawResource(res);
         XmlPullParserFactory factory = XmlPullParserFactory.newInstance();
         factory.setNamespaceAware(true);
         XmlPullParser parser = factory.newPullParser();
@@ -28,53 +34,55 @@ public class KmlParserTest {
         XmlPullParser parser = createParser(com.google.maps.android.test.R.raw.amu_inline_style);
         KmlParser mParser = new KmlParser(parser);
         mParser.parseKml();
-        Assert.assertNotNull(mParser.getPlacemarks());
-        Assert.assertEquals(mParser.getPlacemarks().size(), 1);
+        assertNotNull(mParser.getPlacemarks());
+        assertEquals(mParser.getPlacemarks().size(), 1);
         for (KmlPlacemark placemark : mParser.getPlacemarks().keySet()) {
             KmlStyle inlineStyle = placemark.getInlineStyle();
-            Assert.assertNotNull(inlineStyle);
-            Assert.assertEquals(inlineStyle.getPolylineOptions().getColor(),
-                    Color.parseColor("#000000"));
-            Assert.assertEquals(inlineStyle.getPolygonOptions().getFillColor(),
-                    Color.parseColor("#ffffff"));
-            Assert.assertEquals(inlineStyle.getPolylineOptions().getColor(),
+            assertNotNull(inlineStyle);
+            assertEquals(inlineStyle.getPolylineOptions().getColor(), Color.parseColor("#000000"));
+            assertEquals(
+                    inlineStyle.getPolygonOptions().getFillColor(), Color.parseColor("#ffffff"));
+            assertEquals(
+                    inlineStyle.getPolylineOptions().getColor(),
                     inlineStyle.getPolygonOptions().getStrokeColor());
-            Assert.assertEquals(placemark.getGeometry().getGeometryType(), "MultiGeometry");
+            assertEquals(placemark.getGeometry().getGeometryType(), "MultiGeometry");
         }
     }
 
     @Test
     public void testPolyStyleBooleanNumeric() throws Exception {
-        XmlPullParser parser = createParser(com.google.maps.android.test.R.raw.amu_poly_style_boolean_numeric);
+        XmlPullParser parser =
+                createParser(com.google.maps.android.test.R.raw.amu_poly_style_boolean_numeric);
         KmlParser mParser = new KmlParser(parser);
         mParser.parseKml();
-        Assert.assertNotNull(mParser.getPlacemarks());
-        Assert.assertEquals(1, mParser.getContainers().size());
+        assertNotNull(mParser.getPlacemarks());
+        assertEquals(1, mParser.getContainers().size());
         KmlContainer kmlContainer = mParser.getContainers().get(0);
-        Assert.assertTrue(kmlContainer.hasPlacemarks());
+        assertTrue(kmlContainer.hasPlacemarks());
 
         HashMap<String, KmlStyle> styles = kmlContainer.getStyles();
         KmlStyle kmlStyle = styles.get("#fireadvisory");
-        Assert.assertNotNull(kmlStyle);
-        Assert.assertTrue(kmlStyle.hasFill());
-        Assert.assertFalse(kmlStyle.hasOutline());
+        assertNotNull(kmlStyle);
+        assertTrue(kmlStyle.hasFill());
+        assertFalse(kmlStyle.hasOutline());
     }
 
     @Test
     public void testPolyStyleBooleanAlpha() throws Exception {
-        XmlPullParser parser = createParser(com.google.maps.android.test.R.raw.amu_poly_style_boolean_alpha);
+        XmlPullParser parser =
+                createParser(com.google.maps.android.test.R.raw.amu_poly_style_boolean_alpha);
         KmlParser mParser = new KmlParser(parser);
         mParser.parseKml();
-        Assert.assertNotNull(mParser.getPlacemarks());
-        Assert.assertEquals(1, mParser.getContainers().size());
+        assertNotNull(mParser.getPlacemarks());
+        assertEquals(1, mParser.getContainers().size());
         KmlContainer kmlContainer = mParser.getContainers().get(0);
-        Assert.assertTrue(kmlContainer.hasPlacemarks());
+        assertTrue(kmlContainer.hasPlacemarks());
 
-        HashMap<String, KmlStyle> styles = kmlContainer.getStyles();
+        Map<String, KmlStyle> styles = kmlContainer.getStyles();
         KmlStyle kmlStyle = styles.get("#fireadvisory");
-        Assert.assertNotNull(kmlStyle);
-        Assert.assertTrue(kmlStyle.hasFill());
-        Assert.assertFalse(kmlStyle.hasOutline());
+        assertNotNull(kmlStyle);
+        assertTrue(kmlStyle.hasFill());
+        assertFalse(kmlStyle.hasOutline());
     }
 
     @Test
@@ -82,9 +90,9 @@ public class KmlParserTest {
         XmlPullParser parser = createParser(com.google.maps.android.test.R.raw.amu_document_nest);
         KmlParser mParser = new KmlParser(parser);
         mParser.parseKml();
-        Assert.assertEquals(mParser.getContainers().get(0).getContainerId(), "hasId");
-        Assert.assertEquals(mParser.getContainers().size(), 1);
-        Assert.assertTrue(mParser.getContainers().get(0).hasContainers());
+        assertEquals(mParser.getContainers().get(0).getContainerId(), "hasId");
+        assertEquals(mParser.getContainers().size(), 1);
+        assertTrue(mParser.getContainers().get(0).hasContainers());
     }
 
     @Test
@@ -92,6 +100,6 @@ public class KmlParserTest {
         XmlPullParser parser = createParser(com.google.maps.android.test.R.raw.amu_unsupported);
         KmlParser mParser = new KmlParser(parser);
         mParser.parseKml();
-        Assert.assertEquals(1, mParser.getPlacemarks().size());
+        assertEquals(1, mParser.getPlacemarks().size());
     }
 }

--- a/library/tests/src/com/google/maps/android/data/kml/KmlPointTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlPointTest.java
@@ -3,50 +3,49 @@ package com.google.maps.android.data.kml;
 import com.google.android.gms.maps.model.LatLng;
 
 import org.junit.Test;
-import org.junit.Assert;
+
+import static org.junit.Assert.*;
 
 public class KmlPointTest {
-    KmlPoint kmlPoint;
-
-    public KmlPoint createSimplePoint() {
+    private KmlPoint createSimplePoint() {
         LatLng coordinates = new LatLng(0, 50);
         return new KmlPoint(coordinates);
     }
 
-    public KmlPoint createSimplePointWithAltitudes() {
+    private KmlPoint createSimplePointWithAltitudes() {
         LatLng coordinates = new LatLng(0, 50);
-        Double altitude = new Double(100);
+        Double altitude = 100d;
         return new KmlPoint(coordinates, altitude);
     }
 
     @Test
-    public void testGetType() throws Exception {
-        kmlPoint = createSimplePoint();
-        Assert.assertNotNull(kmlPoint);
-        Assert.assertNotNull(kmlPoint.getGeometryType());
-        Assert.assertEquals("Point", kmlPoint.getGeometryType());
+    public void testGetType() {
+        KmlPoint kmlPoint = createSimplePoint();
+        assertNotNull(kmlPoint);
+        assertNotNull(kmlPoint.getGeometryType());
+        assertEquals("Point", kmlPoint.getGeometryType());
     }
 
     @Test
-    public void testGetKmlGeometryObject() throws Exception {
-        kmlPoint = createSimplePoint();
-        Assert.assertNotNull(kmlPoint);
-        Assert.assertNotNull(kmlPoint.getGeometryObject());
-        Assert.assertEquals(kmlPoint.getGeometryObject().latitude, 0.0, 0);
-        Assert.assertEquals(kmlPoint.getGeometryObject().longitude, 50.0, 0);
+    public void testGetKmlGeometryObject() {
+        KmlPoint kmlPoint = createSimplePoint();
+        assertNotNull(kmlPoint);
+        assertNotNull(kmlPoint.getGeometryObject());
+        assertEquals(0.0, kmlPoint.getGeometryObject().latitude, 0);
+        assertEquals(50.0, kmlPoint.getGeometryObject().longitude, 0);
     }
 
     @Test
-    public void testPointAltitude() throws Exception {
-        //test point without altitude
-        kmlPoint = createSimplePoint();
-        Assert.assertNotNull(kmlPoint);
-        Assert.assertNull(kmlPoint.getAltitude());
+    public void testPointAltitude() {
+        // test point without altitude
+        KmlPoint kmlPoint = createSimplePoint();
+        assertNotNull(kmlPoint);
+        assertNull(kmlPoint.getAltitude());
 
-        //test point with altitude
+        // test point with altitude
         kmlPoint = createSimplePointWithAltitudes();
-        Assert.assertNotNull(kmlPoint);
-        Assert.assertNotNull(kmlPoint.getAltitude());
-        Assert.assertEquals(kmlPoint.getAltitude(), 100.0, 0);
+        assertNotNull(kmlPoint);
+        assertNotNull(kmlPoint.getAltitude());
+        assertEquals(100.0, kmlPoint.getAltitude(), 0);
     }
 }

--- a/library/tests/src/com/google/maps/android/data/kml/KmlPolygonTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlPolygonTest.java
@@ -2,30 +2,22 @@ package com.google.maps.android.data.kml;
 
 import com.google.android.gms.maps.model.LatLng;
 
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Assert;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.Assert.*;
+
 public class KmlPolygonTest {
-
-    KmlPolygon kmlPolygon;
-
-    @Before
-    public void setUp() throws Exception {
-
-    }
-
-    public KmlPolygon createRegularPolygon() {
-        ArrayList<LatLng> outerCoordinates = new ArrayList<LatLng>();
+    private KmlPolygon createRegularPolygon() {
+        List<LatLng> outerCoordinates = new ArrayList<>();
         outerCoordinates.add(new LatLng(10, 10));
         outerCoordinates.add(new LatLng(20, 20));
         outerCoordinates.add(new LatLng(30, 30));
         outerCoordinates.add(new LatLng(10, 10));
-        ArrayList<List<LatLng>> innerCoordinates = new ArrayList<List<LatLng>>();
-        ArrayList<LatLng> innerHole = new ArrayList<LatLng>();
+        List<List<LatLng>> innerCoordinates = new ArrayList<>();
+        List<LatLng> innerHole = new ArrayList<>();
         innerHole.add(new LatLng(20, 20));
         innerHole.add(new LatLng(10, 10));
         innerHole.add(new LatLng(20, 20));
@@ -33,8 +25,8 @@ public class KmlPolygonTest {
         return new KmlPolygon(outerCoordinates, innerCoordinates);
     }
 
-    public KmlPolygon createOuterPolygon() {
-        ArrayList<LatLng> outerCoordinates = new ArrayList<LatLng>();
+    private KmlPolygon createOuterPolygon() {
+        ArrayList<LatLng> outerCoordinates = new ArrayList<>();
         outerCoordinates.add(new LatLng(10, 10));
         outerCoordinates.add(new LatLng(20, 20));
         outerCoordinates.add(new LatLng(30, 30));
@@ -43,42 +35,42 @@ public class KmlPolygonTest {
     }
 
     @Test
-    public void testGetType() throws Exception {
-        kmlPolygon = createRegularPolygon();
-        Assert.assertNotNull(kmlPolygon);
-        Assert.assertNotNull(kmlPolygon.getGeometryType());
-        Assert.assertEquals("Polygon", kmlPolygon.getGeometryType());
+    public void testGetType() {
+        KmlPolygon kmlPolygon = createRegularPolygon();
+        assertNotNull(kmlPolygon);
+        assertNotNull(kmlPolygon.getGeometryType());
+        assertEquals("Polygon", kmlPolygon.getGeometryType());
     }
 
     @Test
-    public void testGetOuterBoundaryCoordinates() throws Exception {
-        kmlPolygon = createRegularPolygon();
-        Assert.assertNotNull(kmlPolygon);
-        Assert.assertNotNull(kmlPolygon.getOuterBoundaryCoordinates());
+    public void testGetOuterBoundaryCoordinates() {
+        KmlPolygon kmlPolygon = createRegularPolygon();
+        assertNotNull(kmlPolygon);
+        assertNotNull(kmlPolygon.getOuterBoundaryCoordinates());
         kmlPolygon = createOuterPolygon();
-        Assert.assertNotNull(kmlPolygon);
-        Assert.assertNotNull(kmlPolygon.getOuterBoundaryCoordinates());
+        assertNotNull(kmlPolygon);
+        assertNotNull(kmlPolygon.getOuterBoundaryCoordinates());
     }
 
     @Test
-    public void testGetInnerBoundaryCoordinates() throws Exception {
-        kmlPolygon = createRegularPolygon();
-        Assert.assertNotNull(kmlPolygon);
-        Assert.assertNotNull(kmlPolygon.getInnerBoundaryCoordinates());
+    public void testGetInnerBoundaryCoordinates() {
+        KmlPolygon kmlPolygon = createRegularPolygon();
+        assertNotNull(kmlPolygon);
+        assertNotNull(kmlPolygon.getInnerBoundaryCoordinates());
         kmlPolygon = createOuterPolygon();
-        Assert.assertNotNull(kmlPolygon);
-        Assert.assertNull(kmlPolygon.getInnerBoundaryCoordinates());
+        assertNotNull(kmlPolygon);
+        assertNull(kmlPolygon.getInnerBoundaryCoordinates());
     }
 
     @Test
-    public void testGetKmlGeometryObject() throws Exception {
-        kmlPolygon = createRegularPolygon();
-        Assert.assertNotNull(kmlPolygon);
-        Assert.assertNotNull(kmlPolygon.getGeometryObject());
-        Assert.assertEquals(kmlPolygon.getGeometryObject().size(), 2);
+    public void testGetKmlGeometryObject() {
+        KmlPolygon kmlPolygon = createRegularPolygon();
+        assertNotNull(kmlPolygon);
+        assertNotNull(kmlPolygon.getGeometryObject());
+        assertEquals(2, kmlPolygon.getGeometryObject().size());
         kmlPolygon = createOuterPolygon();
-        Assert.assertNotNull(kmlPolygon);
-        Assert.assertNotNull(kmlPolygon.getGeometryObject());
-        Assert.assertEquals(kmlPolygon.getGeometryObject().size(), 1);
+        assertNotNull(kmlPolygon);
+        assertNotNull(kmlPolygon.getGeometryObject());
+        assertEquals(1, kmlPolygon.getGeometryObject().size());
     }
 }

--- a/library/tests/src/com/google/maps/android/data/kml/KmlRendererTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlRendererTest.java
@@ -1,31 +1,31 @@
 package com.google.maps.android.data.kml;
 
 import org.junit.Test;
-import org.junit.Assert;
 
 import java.util.HashMap;
 
-public class KmlRendererTest {
+import static org.junit.Assert.*;
 
+public class KmlRendererTest {
     @Test
     public void testAssignStyleMap() {
-        HashMap<String, String> styleMap = new HashMap<String, String>();
+        HashMap<String, String> styleMap = new HashMap<>();
         styleMap.put("BlueKey", "BlueValue");
-        HashMap<String, KmlStyle> styles = new HashMap<String, KmlStyle>();
+        HashMap<String, KmlStyle> styles = new HashMap<>();
         KmlStyle blueStyle = new KmlStyle();
         KmlStyle redStyle = new KmlStyle();
         styles.put("BlueValue", blueStyle);
         styles.put("RedValue", redStyle);
         KmlRenderer renderer = new KmlRenderer(null, null);
         renderer.assignStyleMap(styleMap, styles);
-        Assert.assertNotNull(styles.get("BlueKey"));
-        Assert.assertEquals(styles.get("BlueKey"), styles.get("BlueValue"));
+        assertNotNull(styles.get("BlueKey"));
+        assertEquals(styles.get("BlueKey"), styles.get("BlueValue"));
         styles.put("BlueValue", null);
         renderer.assignStyleMap(styleMap, styles);
-        Assert.assertNull(styles.get("BlueKey"));
+        assertNull(styles.get("BlueKey"));
         styleMap.put("BlueKey", "RedValue");
         renderer.assignStyleMap(styleMap, styles);
-        Assert.assertNotNull(styleMap.get("BlueKey"));
-        Assert.assertEquals(styles.get("BlueKey"), redStyle);
+        assertNotNull(styleMap.get("BlueKey"));
+        assertEquals(styles.get("BlueKey"), redStyle);
     }
 }

--- a/library/tests/src/com/google/maps/android/data/kml/KmlStyleTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlStyleTest.java
@@ -3,88 +3,87 @@ package com.google.maps.android.data.kml;
 import android.graphics.Color;
 
 import org.junit.Test;
-import org.junit.Assert;
+
+import static org.junit.Assert.*;
 
 public class KmlStyleTest {
-
     @Test
-    public void testStyleId() throws Exception {
+    public void testStyleId() {
         KmlStyle kmlStyle = new KmlStyle();
         kmlStyle.setStyleId("BlueLine");
-        Assert.assertEquals("BlueLine", kmlStyle.getStyleId());
+        assertEquals("BlueLine", kmlStyle.getStyleId());
     }
 
     @Test
-    public void testFill() throws Exception {
+    public void testFill() {
         KmlStyle kmlStyle = new KmlStyle();
         kmlStyle.setFill(true);
-        Assert.assertTrue(kmlStyle.hasFill());
+        assertTrue(kmlStyle.hasFill());
         kmlStyle.setFill(false);
-        Assert.assertFalse(kmlStyle.hasFill());
+        assertFalse(kmlStyle.hasFill());
     }
 
     @Test
-    public void testFillColor() throws Exception {
+    public void testFillColor() {
         KmlStyle kmlStyle = new KmlStyle();
-        Assert.assertNotNull(kmlStyle);
-        Assert.assertNotNull(kmlStyle.getPolygonOptions());
+        assertNotNull(kmlStyle);
+        assertNotNull(kmlStyle.getPolygonOptions());
         kmlStyle.setFillColor("000000");
         int fillColor = Color.parseColor("#000000");
-        Assert.assertEquals(fillColor, kmlStyle.getPolygonOptions().getFillColor());
+        assertEquals(fillColor, kmlStyle.getPolygonOptions().getFillColor());
     }
 
     @Test
-    public void testColorFormatting() throws Exception {
+    public void testColorFormatting() {
         KmlStyle kmlStyle = new KmlStyle();
         // AABBGGRR -> AARRGGBB.
         kmlStyle.setFillColor("ff579D00");
-        Assert.assertEquals(Color.parseColor("#009D57"), kmlStyle.getPolygonOptions().getFillColor());
+        assertEquals(Color.parseColor("#009D57"), kmlStyle.getPolygonOptions().getFillColor());
         // Alpha w/ missing 0.
         kmlStyle.setFillColor(" D579D00");
-        Assert.assertEquals(Color.parseColor("#0D009D57"), kmlStyle.getPolygonOptions().getFillColor());
+        assertEquals(Color.parseColor("#0D009D57"), kmlStyle.getPolygonOptions().getFillColor());
     }
 
     @Test
-    public void testHeading() throws Exception {
+    public void testHeading() {
         KmlStyle kmlStyle = new KmlStyle();
-        Assert.assertNotNull(kmlStyle);
-        Assert.assertNotNull(kmlStyle.getMarkerOptions());
-        Assert.assertEquals(kmlStyle.getMarkerOptions().getRotation(), 0.0f, 0);
+        assertNotNull(kmlStyle);
+        assertNotNull(kmlStyle.getMarkerOptions());
+        assertEquals(0.0f, kmlStyle.getMarkerOptions().getRotation(), 0);
         kmlStyle.setHeading(3);
-        Assert.assertEquals(kmlStyle.getMarkerOptions().getRotation(), 3.0f, 0);
+        assertEquals(3.0f, kmlStyle.getMarkerOptions().getRotation(), 0);
     }
 
     @Test
-    public void testWidth() throws Exception {
+    public void testWidth() {
         KmlStyle kmlStyle = new KmlStyle();
-        Assert.assertNotNull(kmlStyle);
-        Assert.assertNotNull(kmlStyle.getPolygonOptions());
-        Assert.assertNotNull(kmlStyle.getPolylineOptions());
-        Assert.assertEquals(kmlStyle.getPolylineOptions().getWidth(), 10.0f, 0);
-        Assert.assertEquals(kmlStyle.getPolygonOptions().getStrokeWidth(), 10.0f, 0);
+        assertNotNull(kmlStyle);
+        assertNotNull(kmlStyle.getPolygonOptions());
+        assertNotNull(kmlStyle.getPolylineOptions());
+        assertEquals(10.0f, kmlStyle.getPolylineOptions().getWidth(), 0);
+        assertEquals(10.0f, kmlStyle.getPolygonOptions().getStrokeWidth(), 0);
         kmlStyle.setWidth(11.0f);
-        Assert.assertEquals(kmlStyle.getPolylineOptions().getWidth(), 11.0f, 0);
-        Assert.assertEquals(kmlStyle.getPolygonOptions().getStrokeWidth(), 11.0f, 0);
+        assertEquals(11.0f, kmlStyle.getPolylineOptions().getWidth(), 0);
+        assertEquals(11.0f, kmlStyle.getPolygonOptions().getStrokeWidth(), 0);
     }
 
     @Test
-    public void testLineColor() throws Exception {
+    public void testLineColor() {
         KmlStyle kmlStyle = new KmlStyle();
-        Assert.assertNotNull(kmlStyle);
-        Assert.assertNotNull(kmlStyle.getPolygonOptions());
-        Assert.assertNotNull(kmlStyle.getPolylineOptions());
-        Assert.assertEquals(Color.BLACK, kmlStyle.getPolylineOptions().getColor());
-        Assert.assertEquals(Color.BLACK, kmlStyle.getPolygonOptions().getStrokeColor());
+        assertNotNull(kmlStyle);
+        assertNotNull(kmlStyle.getPolygonOptions());
+        assertNotNull(kmlStyle.getPolylineOptions());
+        assertEquals(Color.BLACK, kmlStyle.getPolylineOptions().getColor());
+        assertEquals(Color.BLACK, kmlStyle.getPolygonOptions().getStrokeColor());
         kmlStyle.setOutlineColor("FFFFFF");
-        Assert.assertEquals(Color.WHITE, kmlStyle.getPolylineOptions().getColor());
-        Assert.assertEquals(Color.WHITE, kmlStyle.getPolygonOptions().getStrokeColor());
+        assertEquals(Color.WHITE, kmlStyle.getPolylineOptions().getColor());
+        assertEquals(Color.WHITE, kmlStyle.getPolygonOptions().getStrokeColor());
     }
 
     @Test
     public void testMarkerColor() {
         KmlStyle kmlStyle = new KmlStyle();
-        Assert.assertNotNull(kmlStyle);
-        Assert.assertNotNull(kmlStyle.getMarkerOptions());
+        assertNotNull(kmlStyle);
+        assertNotNull(kmlStyle.getMarkerOptions());
     }
-
 }

--- a/library/tests/src/com/google/maps/android/data/kml/KmlTrackTest.java
+++ b/library/tests/src/com/google/maps/android/data/kml/KmlTrackTest.java
@@ -3,80 +3,79 @@ package com.google.maps.android.data.kml;
 import com.google.android.gms.maps.model.LatLng;
 
 import org.junit.Test;
-import org.junit.Assert;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 
-public class KmlTrackTest {
-    KmlTrack kmlTrack;
+import static org.junit.Assert.*;
 
-    public KmlTrack createSimpleTrack() {
-        ArrayList<LatLng> coordinates = new ArrayList<LatLng>();
-        ArrayList<Double> altitudes = new ArrayList<Double>();
-        ArrayList<Long> timestamps = new ArrayList<Long>();
-        HashMap<String, String> properties = new HashMap<String, String>();
+public class KmlTrackTest {
+    private KmlTrack createSimpleTrack() {
+        ArrayList<LatLng> coordinates = new ArrayList<>();
+        ArrayList<Double> altitudes = new ArrayList<>();
+        ArrayList<Long> timestamps = new ArrayList<>();
+        HashMap<String, String> properties = new HashMap<>();
         coordinates.add(new LatLng(0, 0));
         coordinates.add(new LatLng(50, 50));
         coordinates.add(new LatLng(90, 90));
-        altitudes.add(new Double(100));
-        altitudes.add(new Double(200));
-        altitudes.add(new Double(300));
-        timestamps.add(new Long(1000));
-        timestamps.add(new Long(2000));
-        timestamps.add(new Long(3000));
+        altitudes.add(100d);
+        altitudes.add(200d);
+        altitudes.add(300d);
+        timestamps.add(1000L);
+        timestamps.add(2000L);
+        timestamps.add(3000L);
         properties.put("key", "value");
         return new KmlTrack(coordinates, altitudes, timestamps, properties);
     }
 
     @Test
-    public void testGetType() throws Exception {
-        kmlTrack = createSimpleTrack();
-        Assert.assertNotNull(kmlTrack);
-        Assert.assertNotNull(kmlTrack.getGeometryType());
-        Assert.assertEquals("LineString", kmlTrack.getGeometryType());
+    public void testGetType() {
+        KmlTrack kmlTrack = createSimpleTrack();
+        assertNotNull(kmlTrack);
+        assertNotNull(kmlTrack.getGeometryType());
+        assertEquals("LineString", kmlTrack.getGeometryType());
     }
 
     @Test
-    public void testGetKmlGeometryObject() throws Exception {
-        kmlTrack = createSimpleTrack();
-        Assert.assertNotNull(kmlTrack);
-        Assert.assertNotNull(kmlTrack.getGeometryObject());
-        Assert.assertEquals(kmlTrack.getGeometryObject().size(), 3);
-        Assert.assertEquals(kmlTrack.getGeometryObject().get(0).latitude, 0.0, 0);
-        Assert.assertEquals(kmlTrack.getGeometryObject().get(1).latitude, 50.0, 0);
-        Assert.assertEquals(kmlTrack.getGeometryObject().get(2).latitude, 90.0, 0);
+    public void testGetKmlGeometryObject() {
+        KmlTrack kmlTrack = createSimpleTrack();
+        assertNotNull(kmlTrack);
+        assertNotNull(kmlTrack.getGeometryObject());
+        assertEquals(kmlTrack.getGeometryObject().size(), 3);
+        assertEquals(kmlTrack.getGeometryObject().get(0).latitude, 0.0, 0);
+        assertEquals(kmlTrack.getGeometryObject().get(1).latitude, 50.0, 0);
+        assertEquals(kmlTrack.getGeometryObject().get(2).latitude, 90.0, 0);
     }
 
     @Test
-    public void testAltitudes() throws Exception {
-        kmlTrack = createSimpleTrack();
-        Assert.assertNotNull(kmlTrack);
-        Assert.assertNotNull(kmlTrack.getAltitudes());
-        Assert.assertEquals(kmlTrack.getAltitudes().size(), 3);
-        Assert.assertEquals(kmlTrack.getAltitudes().get(0), 100.0, 0);
-        Assert.assertEquals(kmlTrack.getAltitudes().get(1), 200.0, 0);
-        Assert.assertEquals(kmlTrack.getAltitudes().get(2), 300.0, 0);
+    public void testAltitudes() {
+        KmlTrack kmlTrack = createSimpleTrack();
+        assertNotNull(kmlTrack);
+        assertNotNull(kmlTrack.getAltitudes());
+        assertEquals(kmlTrack.getAltitudes().size(), 3);
+        assertEquals(kmlTrack.getAltitudes().get(0), 100.0, 0);
+        assertEquals(kmlTrack.getAltitudes().get(1), 200.0, 0);
+        assertEquals(kmlTrack.getAltitudes().get(2), 300.0, 0);
     }
 
     @Test
-    public void testTimestamps() throws Exception {
-        kmlTrack = createSimpleTrack();
-        Assert.assertNotNull(kmlTrack);
-        Assert.assertNotNull(kmlTrack.getTimestamps());
-        Assert.assertEquals(kmlTrack.getTimestamps().size(), 3);
-        Assert.assertEquals(kmlTrack.getTimestamps().get(0), Long.valueOf(1000L));
-        Assert.assertEquals(kmlTrack.getTimestamps().get(1), Long.valueOf(2000L));
-        Assert.assertEquals(kmlTrack.getTimestamps().get(2), Long.valueOf(3000L));
+    public void testTimestamps() {
+        KmlTrack kmlTrack = createSimpleTrack();
+        assertNotNull(kmlTrack);
+        assertNotNull(kmlTrack.getTimestamps());
+        assertEquals(kmlTrack.getTimestamps().size(), 3);
+        assertEquals(kmlTrack.getTimestamps().get(0), Long.valueOf(1000L));
+        assertEquals(kmlTrack.getTimestamps().get(1), Long.valueOf(2000L));
+        assertEquals(kmlTrack.getTimestamps().get(2), Long.valueOf(3000L));
     }
 
     @Test
-    public void testProperties() throws Exception {
-        kmlTrack = createSimpleTrack();
-        Assert.assertNotNull(kmlTrack);
-        Assert.assertNotNull(kmlTrack.getProperties());
-        Assert.assertEquals(kmlTrack.getProperties().size(), 1);
-        Assert.assertEquals(kmlTrack.getProperties().get("key"), "value");
-        Assert.assertNull(kmlTrack.getProperties().get("missingKey"));
+    public void testProperties() {
+        KmlTrack kmlTrack = createSimpleTrack();
+        assertNotNull(kmlTrack);
+        assertNotNull(kmlTrack.getProperties());
+        assertEquals(kmlTrack.getProperties().size(), 1);
+        assertEquals(kmlTrack.getProperties().get("key"), "value");
+        assertNull(kmlTrack.getProperties().get("missingKey"));
     }
 }

--- a/library/tests/src/com/google/maps/android/heatmaps/GradientTest.java
+++ b/library/tests/src/com/google/maps/android/heatmaps/GradientTest.java
@@ -19,113 +19,99 @@ package com.google.maps.android.heatmaps;
 import android.graphics.Color;
 
 import org.junit.Test;
-import org.junit.Assert;
+
+import static android.graphics.Color.*;
+import static org.junit.Assert.assertEquals;
 
 public class GradientTest {
-
     @Test
     public void testInterpolateColor() {
-        int red = Color.RED;
-        int blue = Color.BLUE;
-        int green = Color.GREEN;
-
-
         // Expect itself
-        Assert.assertEquals(red, Gradient.interpolateColor(red, red, 0.5f));
-        Assert.assertEquals(blue, Gradient.interpolateColor(blue, blue, 0.5f));
-        Assert.assertEquals(green, Gradient.interpolateColor(green, green, 0.5f));
+        assertEquals(RED, Gradient.interpolateColor(RED, RED, 0.5f));
+        assertEquals(BLUE, Gradient.interpolateColor(BLUE, BLUE, 0.5f));
+        assertEquals(GREEN, Gradient.interpolateColor(GREEN, GREEN, 0.5f));
 
         // Expect first to be returned
-        int result = Gradient.interpolateColor(red, blue, 0);
-        Assert.assertEquals(red, result);
+        int result = Gradient.interpolateColor(RED, BLUE, 0);
+        assertEquals(RED, result);
 
         // Expect second to be returned
-        result = Gradient.interpolateColor(red, blue, 1);
-        Assert.assertEquals(blue, result);
+        result = Gradient.interpolateColor(RED, BLUE, 1);
+        assertEquals(BLUE, result);
 
         // Expect same value (should wraparound correctly, shortest path both times)
-        Assert.assertEquals(Gradient.interpolateColor(red, blue, 0.5f),
-                Gradient.interpolateColor(blue, red, 0.5f));
-        Assert.assertEquals(Gradient.interpolateColor(red, blue, 0.2f),
-                Gradient.interpolateColor(blue, red, 0.8f));
-        Assert.assertEquals(Gradient.interpolateColor(red, blue, 0.8f),
-                Gradient.interpolateColor(blue, red, 0.2f));
+        assertEquals(
+                Gradient.interpolateColor(BLUE, RED, 0.5f),
+                Gradient.interpolateColor(RED, BLUE, 0.5f));
+        assertEquals(
+                Gradient.interpolateColor(BLUE, RED, 0.8f),
+                Gradient.interpolateColor(RED, BLUE, 0.2f));
+        assertEquals(
+                Gradient.interpolateColor(BLUE, RED, 0.2f),
+                Gradient.interpolateColor(RED, BLUE, 0.8f));
 
         // Testing actual values now
-        Assert.assertEquals(Gradient.interpolateColor(red, blue, 0.2f), -65434);
-        Assert.assertEquals(Gradient.interpolateColor(red, blue, 0.5f), Color.MAGENTA);
-        Assert.assertEquals(Gradient.interpolateColor(red, blue, 0.8f), -10092289);
-        Assert.assertEquals(Gradient.interpolateColor(red, green, 0.5f), Color.YELLOW);
-        Assert.assertEquals(Gradient.interpolateColor(blue, green, 0.5f), Color.CYAN);
+        assertEquals(-65434, Gradient.interpolateColor(RED, BLUE, 0.2f));
+        assertEquals(Color.MAGENTA, Gradient.interpolateColor(RED, BLUE, 0.5f));
+        assertEquals(-10092289, Gradient.interpolateColor(RED, BLUE, 0.8f));
+        assertEquals(Color.YELLOW, Gradient.interpolateColor(RED, GREEN, 0.5f));
+        assertEquals(Color.CYAN, Gradient.interpolateColor(BLUE, GREEN, 0.5f));
     }
 
     @Test
     public void testSimpleColorMap() {
-        int[] colors = {Color.RED, Color.BLUE};
+        int[] colors = {RED, BLUE};
         float[] startPoints = {0f, 1.0f};
 
         Gradient g = new Gradient(colors, startPoints, 2);
         int[] colorMap = g.generateColorMap(1.0);
-        Assert.assertEquals(colorMap[0], Color.RED);
-        Assert.assertEquals(colorMap[1], Gradient.interpolateColor(Color.RED, Color.BLUE, 0.5f));
+        assertEquals(RED, colorMap[0]);
+        assertEquals(Gradient.interpolateColor(RED, BLUE, 0.5f), colorMap[1]);
     }
 
     @Test
     public void testLargerColorMap() {
-        int[] colors = {Color.RED, Color.GREEN};
+        int[] colors = {RED, GREEN};
         float[] startPoints = {0f, 1.0f};
 
         Gradient g = new Gradient(colors, startPoints, 10);
         int[] colorMap = g.generateColorMap(1.0);
-        Assert.assertEquals(colorMap[0], Color.RED);
+        assertEquals(RED, colorMap[0]);
         for (int i = 1; i < 10; i++) {
-            Assert.assertEquals(colorMap[i], Gradient.interpolateColor(Color.RED, Color.GREEN, (i * 0.1f)));
+            assertEquals(Gradient.interpolateColor(RED, GREEN, (i * 0.1f)), colorMap[i]);
         }
     }
 
     @Test
     public void testOpacityInterpolation() {
-        int[] colors = {
-                Color.argb(0, 0, 255, 0),
-                Color.GREEN,
-                Color.RED
-        };
-        float[] startPoints = {
-                0f, 0.2f, 1f
-        };
+        int[] colors = {Color.argb(0, 0, 255, 0), GREEN, RED};
+        float[] startPoints = {0f, 0.2f, 1f};
         Gradient g = new Gradient(colors, startPoints, 10);
         int[] colorMap = g.generateColorMap(1.0);
-        Assert.assertEquals(colorMap[0], Color.argb(0, 0, 255, 0));
-        Assert.assertEquals(colorMap[1], Color.argb(127, 0, 255, 0));
-        Assert.assertEquals(colorMap[2], Color.GREEN);
-        Assert.assertEquals(colorMap[3], Gradient.interpolateColor(Color.GREEN, Color.RED, 0.125f));
-        Assert.assertEquals(colorMap[4], Gradient.interpolateColor(Color.GREEN, Color.RED, 0.25f));
-        Assert.assertEquals(colorMap[5], Gradient.interpolateColor(Color.GREEN, Color.RED, 0.375f));
-        Assert.assertEquals(colorMap[6], Gradient.interpolateColor(Color.GREEN, Color.RED, 0.5f));
-        Assert.assertEquals(colorMap[7], Gradient.interpolateColor(Color.GREEN, Color.RED, 0.625f));
-        Assert.assertEquals(colorMap[8], Gradient.interpolateColor(Color.GREEN, Color.RED, 0.75f));
-        Assert.assertEquals(colorMap[9], Gradient.interpolateColor(Color.GREEN, Color.RED, 0.875f));
+        assertEquals(Color.argb(0, 0, 255, 0), colorMap[0]);
+        assertEquals(Color.argb(127, 0, 255, 0), colorMap[1]);
+        assertEquals(GREEN, colorMap[2]);
+        assertEquals(Gradient.interpolateColor(GREEN, RED, 0.125f), colorMap[3]);
+        assertEquals(Gradient.interpolateColor(GREEN, RED, 0.25f), colorMap[4]);
+        assertEquals(Gradient.interpolateColor(GREEN, RED, 0.375f), colorMap[5]);
+        assertEquals(Gradient.interpolateColor(GREEN, RED, 0.5f), colorMap[6]);
+        assertEquals(Gradient.interpolateColor(GREEN, RED, 0.625f), colorMap[7]);
+        assertEquals(Gradient.interpolateColor(GREEN, RED, 0.75f), colorMap[8]);
+        assertEquals(Gradient.interpolateColor(GREEN, RED, 0.875f), colorMap[9]);
 
         colorMap = g.generateColorMap(0.5);
-        Assert.assertEquals(colorMap[0], Color.argb(0, 0, 255, 0));
-        Assert.assertEquals(colorMap[1], Color.argb(63, 0, 255, 0));
-        Assert.assertEquals(colorMap[2], Color.argb(127, 0, 255, 0));
+        assertEquals(Color.argb(0, 0, 255, 0), colorMap[0]);
+        assertEquals(Color.argb(63, 0, 255, 0), colorMap[1]);
+        assertEquals(Color.argb(127, 0, 255, 0), colorMap[2]);
     }
 
     @Test
     public void testMoreColorsThanColorMap() {
-        int[] colors = {
-                Color.argb(0, 0, 255, 0),
-                Color.GREEN,
-                Color.RED,
-                Color.BLUE
-        };
-        float[] startPoints = {
-                0f, 0.2f, 0.5f, 1f
-        };
+        int[] colors = {Color.argb(0, 0, 255, 0), GREEN, RED, BLUE};
+        float[] startPoints = {0f, 0.2f, 0.5f, 1f};
         Gradient g = new Gradient(colors, startPoints, 2);
         int[] colorMap = g.generateColorMap(1.0);
-        Assert.assertEquals(colorMap[0], Color.GREEN);
-        Assert.assertEquals(colorMap[1], Color.RED);
+        assertEquals(GREEN, colorMap[0]);
+        assertEquals(RED, colorMap[1]);
     }
 }

--- a/library/tests/src/com/google/maps/android/heatmaps/UtilTest.java
+++ b/library/tests/src/com/google/maps/android/heatmaps/UtilTest.java
@@ -20,37 +20,44 @@ import com.google.android.gms.maps.model.LatLng;
 import com.google.maps.android.geometry.Bounds;
 
 import org.junit.Test;
-import org.junit.Assert;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 
+import static org.junit.Assert.*;
 
 /**
  * Tests for heatmap utility functions
  */
 public class UtilTest {
-
     @Test
     public void testGenerateKernel() {
         double[] testKernel = HeatmapTileProvider.generateKernel(5, 1.5);
-        double[] expectedKernel = {0.0038659201394728076, 0.028565500784550377, 0.1353352832366127,
-                0.41111229050718745, 0.8007374029168081, 1.0, 0.8007374029168081,
-                0.41111229050718745, 0.1353352832366127, 0.028565500784550377,
-                0.0038659201394728076};
+        double[] expectedKernel = {
+                0.0038659201394728076,
+                0.028565500784550377,
+                0.1353352832366127,
+                0.41111229050718745,
+                0.8007374029168081,
+                1.0,
+                0.8007374029168081,
+                0.41111229050718745,
+                0.1353352832366127,
+                0.028565500784550377,
+                0.0038659201394728076
+        };
 
-        Assert.assertArrayEquals(testKernel, expectedKernel, 0.0);
+        assertArrayEquals(expectedKernel, testKernel, 0.0);
     }
 
     @Test
     public void testConvolveCorners() {
         /*
-         1 0 0 0 1
-         0 0 0 0 0
-         0 0 0 0 0
-         0 0 0 0 0
-         1 0 0 0 1
-         */
+        1 0 0 0 1
+        0 0 0 0 0
+        0 0 0 0 0
+        0 0 0 0 0
+        1 0 0 0 1
+        */
         double[][] grid = new double[5][5];
         grid[0][0] = 1;
         grid[4][4] = 1;
@@ -59,18 +66,18 @@ public class UtilTest {
         double[] testKernel = {0.5, 1, 0.5};
         double[][] convolved = HeatmapTileProvider.convolve(grid, testKernel);
         double[][] expected = {{0.25, 0, 0.25}, {0, 0, 0}, {0.25, 0, 0.25}};
-        Assert.assertTrue(Arrays.deepEquals(convolved, expected));
+        assertArrayEquals(expected, convolved);
     }
 
     @Test
     public void testConvolveEdges() {
         /*
-         0 0 1 0 0
-         0 0 0 0 0
-         1 0 0 0 1
-         0 0 0 0 0
-         0 0 1 0 0
-         */
+        0 0 1 0 0
+        0 0 0 0 0
+        1 0 0 0 1
+        0 0 0 0 0
+        0 0 1 0 0
+        */
         double[][] grid = new double[5][5];
         grid[0][2] = 1;
         grid[2][0] = 1;
@@ -79,18 +86,18 @@ public class UtilTest {
         double[] testKernel = {0.5, 1, 0.5};
         double[][] convolved = HeatmapTileProvider.convolve(grid, testKernel);
         double[][] expected = {{0.5, 0.5, 0.5}, {0.5, 0, 0.5}, {0.5, 0.5, 0.5}};
-        Assert.assertTrue(Arrays.deepEquals(convolved, expected));
+        assertArrayEquals(expected, convolved);
     }
 
     @Test
     public void testConvolveCentre() {
         /*
-         0 0 0 0 0
-         0 0 1 0 0
-         0 1 2 1 0
-         0 0 1 0 0
-         0 0 0 0 0
-         */
+        0 0 0 0 0
+        0 0 1 0 0
+        0 1 2 1 0
+        0 0 1 0 0
+        0 0 0 0 0
+        */
         double[][] grid = new double[5][5];
         grid[2][2] = 2;
         grid[2][1] = 1;
@@ -100,7 +107,7 @@ public class UtilTest {
         double[] testKernel = {0.5, 1, 0.5};
         double[][] convolved = HeatmapTileProvider.convolve(grid, testKernel);
         double[][] expected = {{1.5, 2.5, 1.5}, {2.5, 4.0, 2.5}, {1.5, 2.5, 1.5}};
-        Assert.assertTrue(Arrays.deepEquals(convolved, expected));
+        assertArrayEquals(expected, convolved);
     }
 
     @Test
@@ -115,7 +122,7 @@ public class UtilTest {
         ------------> x
          */
 
-        ArrayList<WeightedLatLng> data = new ArrayList<WeightedLatLng>();
+        ArrayList<WeightedLatLng> data = new ArrayList<>();
         WeightedLatLng first = new WeightedLatLng(new LatLng(10, 20));
         data.add(first);
         double x1 = first.getPoint().x;
@@ -124,7 +131,7 @@ public class UtilTest {
         Bounds bounds = HeatmapTileProvider.getBounds(data);
         Bounds expected = new Bounds(x1, x1, y1, y1);
 
-        Assert.assertTrue(bounds.contains(expected) && expected.contains(bounds));
+        assertTrue(bounds.contains(expected) && expected.contains(bounds));
 
         WeightedLatLng second = new WeightedLatLng(new LatLng(20, 30));
         data.add(second);
@@ -134,7 +141,7 @@ public class UtilTest {
         bounds = HeatmapTileProvider.getBounds(data);
         expected = new Bounds(x1, x2, y2, y1);
 
-        Assert.assertTrue(bounds.contains(expected) && expected.contains(bounds));
+        assertTrue(bounds.contains(expected) && expected.contains(bounds));
 
         WeightedLatLng third = new WeightedLatLng(new LatLng(5, 10));
         data.add(third);
@@ -143,6 +150,6 @@ public class UtilTest {
 
         bounds = HeatmapTileProvider.getBounds(data);
         expected = new Bounds(x3, x2, y2, y3);
-        Assert.assertTrue(bounds.contains(expected) && expected.contains(bounds));
+        assertTrue(bounds.contains(expected) && expected.contains(bounds));
     }
 }

--- a/library/tests/src/com/google/maps/android/quadtree/PointQuadTreeTest.java
+++ b/library/tests/src/com/google/maps/android/quadtree/PointQuadTreeTest.java
@@ -19,9 +19,9 @@ package com.google.maps.android.quadtree;
 import com.google.maps.android.geometry.Bounds;
 import com.google.maps.android.geometry.Point;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Assert;
 
 import java.util.Collection;
 import java.util.Random;
@@ -32,7 +32,7 @@ public class PointQuadTreeTest {
 
     @Before
     public void setUp() {
-        mTree = new PointQuadTree<Item>(0, 1, 0, 1);
+        mTree = new PointQuadTree<>(0, 1, 0, 1);
     }
 
     @Test
@@ -110,7 +110,8 @@ public class PointQuadTreeTest {
         }
 
         Assert.assertEquals(10000, searchAll().size());
-        Assert.assertEquals(1, mTree.search(new Bounds((double) 0, 0.00001, (double) 0, 0.00001)).size());
+        Assert.assertEquals(
+                1, mTree.search(new Bounds((double) 0, 0.00001, (double) 0, 0.00001)).size());
         Assert.assertEquals(0, mTree.search(new Bounds(.7, .8, .7, .8)).size());
     }
 
@@ -125,8 +126,7 @@ public class PointQuadTreeTest {
     }
 
     /**
-     * Tests 30,000 items at the same point.
-     * Timing results are averaged.
+     * Tests 30,000 items at the same point. Timing results are averaged.
      */
     @Test
     public void testVeryDeepTree() {
@@ -142,8 +142,8 @@ public class PointQuadTreeTest {
     }
 
     /**
-     * Tests 400,000 points relatively uniformly distributed across the space.
-     * Timing results are averaged.
+     * Tests 400,000 points relatively uniformly distributed across the space. Timing results are
+     * averaged.
      */
     @Test
     public void testManyPoints() {
@@ -177,8 +177,7 @@ public class PointQuadTreeTest {
     }
 
     /**
-     * Runs a test with 100,000 points.
-     * Timing results are averaged.
+     * Runs a test with 100,000 points. Timing results are averaged.
      */
     @Test
     public void testRandomPoints() {


### PR DESCRIPTION
This is a major cleanup of all test code. It's a follow-up to the nice changes and already merged #555 by @ming13, and also includes a few lines from #556 (which will _only_ contain the visibility fixes after rebasing it on top of this PR).

Since there are a lot of lines changes, I'll summarize it here:

The PR:

- Does NOT affect any production code (no changes in `src`)
- Does NOT move the test files or change the test setup (yet) - tests _still_ have to be run in instrumented mode

The most important points this PR addresses:

- Shorter, more idiomatic assert usage (e.g. `assertEquals` instead of `Assert.assertEquals`)
- Fixed the order of all assertion parameters: The expected value is the first parameter, but in most assertions were written the opposite way
- Minor (automatic) formatting cleanups
- Java language simplifications (e.g. "Explicit type can be replaced with <>")

I have local wip branch that allows me to run the tests on the JVM, and I'll open a PR _after_ this one.