### PR TITLE
Remove apklib publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ android:
 script:
 - "./gradlew check"
 - "./gradlew clean assembleDebug -x library:signAarPublication -PdisablePreDex"
-- "./gradlew clean assembleDebug -x library:signApkLibPublication -PdisablePreDex"
 deploy:
   provider: script
   script:

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -4,19 +4,6 @@ apply plugin: 'signing'
 archivesBaseName = 'android-maps-utils'
 group = 'com.google.maps.android'
 
-task apklib(type: Zip) {
-    dependsOn 'check'
-    appendix = extension = 'apklib'
-
-    from 'AndroidManifest.xml'
-    into('res') {
-        from 'src/main/res'
-    }
-    into('src') {
-        from 'src/main/java'
-    }
-}
-
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
     classifier = 'sources'
@@ -64,44 +51,6 @@ publishing {
                 artifact bundleReleaseAar
             }
         }
-        apkLib(MavenPublication) {
-            pom {
-                name = 'Google Maps Android API utility library'
-                description = 'Handy extensions to the Google Maps Android API.'
-                url = 'https://github.com/googlemaps/android-maps-utils'
-
-                scm {
-                    url = 'scm:git@github.com:googlemaps/android-maps-utils.git'
-                    connection = 'scm:git@github.com:googlemaps/android-maps-utils.git'
-                    developerConnection = 'scm:git@github.com:googlemaps/android-maps-utils.git'
-                }
-
-                licenses {
-                    license {
-                        name = 'The Apache Software License, Version 2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                        distribution = 'repo'
-                    }
-                }
-
-                organization {
-                    name = 'Google Inc'
-                    url = 'http://developers.google.com/maps'
-                }
-
-                developers {
-                    developer {
-                        id = 'broady'
-                        name = 'Chris Broadfoot'
-                        url = 'http://google.com/+ChristopherBroadfoot'
-                    }
-                }
-            }
-            groupId group
-            artifactId 'android-maps-utils-apklib'
-            version '0.6.1'
-            artifact(apklib)
-        }
     }
     repositories {
         maven {
@@ -116,5 +65,4 @@ publishing {
 
 signing {
     sign publishing.publications.aar
-    sign publishing.publications.apkLib
 }


### PR DESCRIPTION
The `apklib` format is an old format (used 5+ years ago?) that predates the `aar` format. It was community driven and used with the Maven tooling. It's not supported by Gradle or Android Studio and I highly doubt that anyone is still using it. This PR removes the related sections from the Gradle scripts.

https://stackoverflow.com/questions/22657466/android-dependencies-apklib-vs-aar-files