### PR TITLE
Fix #532 - Use ContextCompat to load drawable resources for scaling

### DIFF
--- a/library/src/main/java/com/google/maps/android/ui/BubbleDrawable.java
+++ b/library/src/main/java/com/google/maps/android/ui/BubbleDrawable.java
@@ -16,6 +16,7 @@
 
 package com.google.maps.android.ui;
 
+import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -27,6 +28,8 @@ import android.graphics.drawable.Drawable;
 
 import com.google.maps.android.R;
 
+import androidx.core.content.ContextCompat;
+
 /**
  * Draws a bubble with a shadow, filled with any color.
  */
@@ -36,9 +39,9 @@ class BubbleDrawable extends Drawable {
     private final Drawable mMask;
     private int mColor = Color.WHITE;
 
-    public BubbleDrawable(Resources res) {
-        mMask = res.getDrawable(R.drawable.amu_bubble_mask);
-        mShadow = res.getDrawable(R.drawable.amu_bubble_shadow);
+    public BubbleDrawable(Context context) {
+        mMask = ContextCompat.getDrawable(context, R.drawable.amu_bubble_mask);
+        mShadow = ContextCompat.getDrawable(context, R.drawable.amu_bubble_shadow);
     }
 
     public void setColor(int color) {

--- a/library/src/main/java/com/google/maps/android/ui/IconGenerator.java
+++ b/library/src/main/java/com/google/maps/android/ui/IconGenerator.java
@@ -57,7 +57,7 @@ public class IconGenerator {
      */
     public IconGenerator(Context context) {
         mContext = context;
-        mBackground = new BubbleDrawable(mContext.getResources());
+        mBackground = new BubbleDrawable(mContext);
         mContainer = (ViewGroup) LayoutInflater.from(mContext).inflate(R.layout.amu_text_bubble, null);
         mRotationLayout = (RotationLayout) mContainer.getChildAt(0);
         mContentView = mTextView = (TextView) mRotationLayout.findViewById(R.id.amu_text);


### PR DESCRIPTION
As discussed in https://github.com/googlemaps/android-maps-utils/issues/532#issuecomment-548398116, it seems the deprecated `Drawable getDrawable (int id)` implementation isn't properly handling drawable resource scaling in all cases,

This PR replaces the deprecated `Drawable getDrawable (int id)` with `ContextCompat.getDrawable()` to hopefully fix the intermittent `Resources$NotFoundException` crashes during clustering setup.