### PR TITLE
Fix #575 - Use API 26 emulator instead of API 28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ env:
     # - API=23 # Emulator runs, but GradientTest.testInterpolateColor[test(AVD) - 7.1.1] fails with java.lang.AssertionError: expected:<-65434> but was:<-65433>
     # - API=24 # Emulator runs, but GradientTest.testInterpolateColor[test(AVD) - 7.1.1] fails with java.lang.AssertionError: expected:<-65434> but was:<-65433>
     # - API=25 # Emulator runs, but GradientTest.testInterpolateColor[test(AVD) - 7.1.1] fails with java.lang.AssertionError: expected:<-65434> but was:<-65433>
-    # - API=26 ABI=x86_64 # Works
+    - API=26 ABI=x86_64 # Works
     # - API=27 ABI=x86_64 # Works
-    - API=28 ABI=x86_64 # Works
+    # - API=28 ABI=x86_64 # Occasionally fails with "No compatible devices connected.[TestRunner] FAILED" (see #575)
     # - API=29 # ERROR: Emulator startup stalls, ends with "emulator: got message from guest system fingerprint HAL"
 
 android:


### PR DESCRIPTION
Let's see if API 26 is any better. I used API 26 for a lot of testing of Travis on a separate branch and didn't see any failures then :crossed_fingers:.