### PR TITLE
Fix #530 - Check for empty KML Style <hotspot> element before parsing

### DIFF
--- a/library/src/androidTest/java/com/google/maps/android/data/kml/KmlParserTest.java
+++ b/library/src/androidTest/java/com/google/maps/android/data/kml/KmlParserTest.java
@@ -1,18 +1,21 @@
 package com.google.maps.android.data.kml;
 
-import android.graphics.Color;
-
-import androidx.test.platform.app.InstrumentationRegistry;
-
 import org.junit.Test;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserFactory;
+
+import android.graphics.Color;
 
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class KmlParserTest {
     private XmlPullParser createParser(int res) throws Exception {
@@ -47,6 +50,15 @@ public class KmlParserTest {
                     inlineStyle.getPolygonOptions().getStrokeColor());
             assertEquals(placemark.getGeometry().getGeometryType(), "MultiGeometry");
         }
+    }
+
+    @Test
+    public void testEmptyHotSpotStyle() throws Exception {
+        XmlPullParser parser = createParser(com.google.maps.android.test.R.raw.amu_empty_hotspot);
+        KmlParser mParser = new KmlParser(parser);
+        mParser.parseKml();
+        assertNotNull(mParser.getPlacemarks());
+        assertEquals(1, mParser.getPlacemarks().size());
     }
 
     @Test

--- a/library/src/androidTest/res/raw/amu_empty_hotspot.kml
+++ b/library/src/androidTest/res/raw/amu_empty_hotspot.kml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml>
+    <Style x="20" y="2" xunits="pixels" yunits="pixels" id="shp_centerpoint">
+      <IconStyle>
+        <scale>0.8</scale>
+        <Icon>
+          <href>http://maps.google.com/mapfiles/kml/pal4/icon57.png</href>
+        </Icon>
+        <hotSpot />
+      </IconStyle>
+      <LabelStyle>
+        <scale>1</scale>
+        <color>FFFFFFFF</color>
+      </LabelStyle>
+    </Style>
+      <Placemark>
+        <name>60A</name>
+        <description>Test</description>
+        <visibility>1</visibility>
+        <Point>
+          <extrude>0</extrude>
+          <tessellate>1</tessellate>
+          <altitudeMode>0</altitudeMode>
+          <coordinates>-111.957935372607,44.0811954480368,0</coordinates>
+        </Point>
+        <styleUrl>#shp_centerpoint</styleUrl>
+      </Placemark>
+</kml>

--- a/library/src/main/java/com/google/maps/android/data/kml/KmlStyleParser.java
+++ b/library/src/main/java/com/google/maps/android/data/kml/KmlStyleParser.java
@@ -3,8 +3,6 @@ package com.google.maps.android.data.kml;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
-import android.text.TextUtils;
-
 import java.io.IOException;
 import java.util.HashMap;
 
@@ -171,13 +169,13 @@ import static org.xmlpull.v1.XmlPullParser.START_TAG;
      *
      * @param style Style object to apply hotspot properties to
      */
-    private static void setIconHotSpot(XmlPullParser parser, KmlStyle style) {
-        float xValue, yValue;
-        String xUnits, yUnits;
-        if (TextUtils.isEmpty(parser.getAttributeValue(null, "x")) ||
-                TextUtils.isEmpty(parser.getAttributeValue(null, "y"))) {
+    private static void setIconHotSpot(XmlPullParser parser, KmlStyle style)
+            throws XmlPullParserException {
+        if (parser.isEmptyElementTag()) {
             return;
         }
+        float xValue, yValue;
+        String xUnits, yUnits;
         xValue = Float.parseFloat(parser.getAttributeValue(null, "x"));
         yValue = Float.parseFloat(parser.getAttributeValue(null, "y"));
         xUnits = parser.getAttributeValue(null, "xunits");

--- a/library/src/main/java/com/google/maps/android/data/kml/KmlStyleParser.java
+++ b/library/src/main/java/com/google/maps/android/data/kml/KmlStyleParser.java
@@ -3,6 +3,8 @@ package com.google.maps.android.data.kml;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
+import android.text.TextUtils;
+
 import java.io.IOException;
 import java.util.HashMap;
 
@@ -172,6 +174,10 @@ import static org.xmlpull.v1.XmlPullParser.START_TAG;
     private static void setIconHotSpot(XmlPullParser parser, KmlStyle style) {
         float xValue, yValue;
         String xUnits, yUnits;
+        if (TextUtils.isEmpty(parser.getAttributeValue(null, "x")) ||
+                TextUtils.isEmpty(parser.getAttributeValue(null, "y"))) {
+            return;
+        }
         xValue = Float.parseFloat(parser.getAttributeValue(null, "x"));
         yValue = Float.parseFloat(parser.getAttributeValue(null, "y"));
         xUnits = parser.getAttributeValue(null, "xunits");


### PR DESCRIPTION
This prevents a crash due to NPE when parsing `<hotSpot />` within KML styles.  Test file snippet and new unit test are included.