### PR TITLE
Use MarkerCache for cluster markers

### DIFF
--- a/library/src/main/java/com/google/maps/android/clustering/ClusterManager.java
+++ b/library/src/main/java/com/google/maps/android/clustering/ClusterManager.java
@@ -93,13 +93,13 @@ public class ClusterManager<T extends ClusterItem> implements
         return mMarkerManager;
     }
 
-    public void setRenderer(ClusterRenderer<T> view) {
+    public void setRenderer(ClusterRenderer<T> renderer) {
         mRenderer.setOnClusterClickListener(null);
         mRenderer.setOnClusterItemClickListener(null);
         mClusterMarkers.clear();
         mMarkers.clear();
         mRenderer.onRemove();
-        mRenderer = view;
+        mRenderer = renderer;
         mRenderer.onAdd();
         mRenderer.setOnClusterClickListener(mOnClusterClickListener);
         mRenderer.setOnClusterInfoWindowClickListener(mOnClusterInfoWindowClickListener);


### PR DESCRIPTION
Use MarkerCache for two-way lookup between Markers and Clusters, same as used for ClusterItem marker cache. MarkerCache encapsulates the logic for managing two HashMaps independently.

Other changes just resolve lint warnings.