### PR TITLE
Make QuadItem protected

### DIFF
--- a/library/src/main/java/com/google/maps/android/clustering/algo/NonHierarchicalDistanceBasedAlgorithm.java
+++ b/library/src/main/java/com/google/maps/android/clustering/algo/NonHierarchicalDistanceBasedAlgorithm.java
@@ -201,7 +201,7 @@ public class NonHierarchicalDistanceBasedAlgorithm<T extends ClusterItem> extend
                 p.y - halfSpan, p.y + halfSpan);
     }
 
-    static class QuadItem<T extends ClusterItem> implements PointQuadTree.Item, Cluster<T> {
+    public static class QuadItem<T extends ClusterItem> implements PointQuadTree.Item, Cluster<T> {
         private final T mClusterItem;
         private final Point mPoint;
         private final LatLng mPosition;

--- a/library/src/main/java/com/google/maps/android/clustering/algo/NonHierarchicalDistanceBasedAlgorithm.java
+++ b/library/src/main/java/com/google/maps/android/clustering/algo/NonHierarchicalDistanceBasedAlgorithm.java
@@ -201,7 +201,7 @@ public class NonHierarchicalDistanceBasedAlgorithm<T extends ClusterItem> extend
                 p.y - halfSpan, p.y + halfSpan);
     }
 
-    public static class QuadItem<T extends ClusterItem> implements PointQuadTree.Item, Cluster<T> {
+    protected static class QuadItem<T extends ClusterItem> implements PointQuadTree.Item, Cluster<T> {
         private final T mClusterItem;
         private final Point mPoint;
         private final LatLng mPosition;


### PR DESCRIPTION
Allow overriding getClusteringItems() in NonHierarchicalDistanceBasedAlgorithm subclass outside package.

Fixes https://github.com/googlemaps/android-maps-utils/issues/577