### PR TITLE
build(CodeCov): Enable CodeCov.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ install:
   - source ~/.install-jdk-travis.sh
 
 script:
-  - if [ "$API" != "NONE" ]; then ./gradlew test check connectedCheck -x lint --stacktrace; fi
+  - if [ "$API" != "NONE" ]; then ./gradlew test check jacocoTestReport connectedCheck -x lint --stacktrace; fi
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -117,3 +117,6 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -15,6 +15,7 @@
  */
 
 apply plugin: 'com.android.library'
+apply plugin: 'jacoco-android'
 
 android {
     dexOptions {
@@ -52,6 +53,14 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+}
+
+jacoco {
+    toolVersion = "0.8.4"
+}
+
+tasks.withType(Test) {
+  jacoco.includeNoLocationClasses = true
 }
 
 task instrumentTest(dependsOn: connectedCheck)


### PR DESCRIPTION
Enabling [CodeCov](https://codecov.io) on Travis so that code coverage reports can be generated and evaluated on a per-PR basis.