### PR TITLE
feat(cluster): Support updating existing items

### DIFF
--- a/library/src/main/java/com/google/maps/android/clustering/ClusterManager.java
+++ b/library/src/main/java/com/google/maps/android/clustering/ClusterManager.java
@@ -16,13 +16,9 @@
 
 package com.google.maps.android.clustering;
 
-import android.content.Context;
-import android.os.AsyncTask;
-
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.Marker;
-import com.google.maps.android.collections.MarkerManager;
 import com.google.maps.android.clustering.algo.Algorithm;
 import com.google.maps.android.clustering.algo.NonHierarchicalDistanceBasedAlgorithm;
 import com.google.maps.android.clustering.algo.PreCachingAlgorithmDecorator;
@@ -30,6 +26,10 @@ import com.google.maps.android.clustering.algo.ScreenBasedAlgorithm;
 import com.google.maps.android.clustering.algo.ScreenBasedAlgorithmAdapter;
 import com.google.maps.android.clustering.view.ClusterRenderer;
 import com.google.maps.android.clustering.view.DefaultClusterRenderer;
+import com.google.maps.android.collections.MarkerManager;
+
+import android.content.Context;
+import android.os.AsyncTask;
 
 import java.util.Collection;
 import java.util.Set;
@@ -147,6 +147,10 @@ public class ClusterManager<T extends ClusterItem> implements
         return mAlgorithm;
     }
 
+    /**
+     * Removes all items from the cluster manager. After calling this method you must invoke
+     * cluster() for the map to be cleared.
+     */
     public void clearItems() {
         mAlgorithm.lock();
         try {
@@ -156,6 +160,11 @@ public class ClusterManager<T extends ClusterItem> implements
         }
     }
 
+    /**
+     * Adds items to clusters. After calling this method you must invoke cluster() for the state
+     * of the clusters to be updated on the map.
+     * @param items items to add to clusters
+     */
     public void addItems(Collection<T> items) {
         mAlgorithm.lock();
         try {
@@ -165,6 +174,11 @@ public class ClusterManager<T extends ClusterItem> implements
         }
     }
 
+    /**
+     * Adds an item to a cluster. After calling this method you must invoke cluster() for the state
+     * of the clusters to be updated on the map.
+     * @param myItem item to add to clusters
+     */
     public void addItem(T myItem) {
         mAlgorithm.lock();
         try {
@@ -174,6 +188,11 @@ public class ClusterManager<T extends ClusterItem> implements
         }
     }
 
+    /**
+     * Removes items from clusters. After calling this method you must invoke cluster() for the state
+     * of the clusters to be updated on the map.
+     * @param items items to remove from clusters
+     */
     public void removeItems(Collection<T> items) {
         mAlgorithm.lock();
         try {
@@ -183,6 +202,11 @@ public class ClusterManager<T extends ClusterItem> implements
         }
     }
 
+    /**
+     * Removes an item from clusters. After calling this method you must invoke cluster() for the state
+     * of the clusters to be updated on the map.
+     * @param item item to remove from clusters
+     */
     public void removeItem(T item) {
         mAlgorithm.lock();
         try {
@@ -193,7 +217,22 @@ public class ClusterManager<T extends ClusterItem> implements
     }
 
     /**
-     * Force a re-cluster. You may want to call this after adding new item(s).
+     * Updates an item in clusters. After calling this method you must invoke cluster() for the state
+     * of the clusters to be updated on the map.
+     * @param item item to update in clusters
+     */
+    public void updateItem(T item) {
+        mAlgorithm.lock();
+        try {
+            mAlgorithm.updateItem(item);
+        } finally {
+            mAlgorithm.unlock();
+        }
+    }
+
+    /**
+     * Force a re-cluster on the map. You should call this after adding, removing, updating,
+     * or clearing item(s).
      */
     public void cluster() {
         mClusterTaskLock.writeLock().lock();

--- a/library/src/main/java/com/google/maps/android/clustering/ClusterManager.java
+++ b/library/src/main/java/com/google/maps/android/clustering/ClusterManager.java
@@ -149,7 +149,7 @@ public class ClusterManager<T extends ClusterItem> implements
 
     /**
      * Removes all items from the cluster manager. After calling this method you must invoke
-     * cluster() for the map to be cleared.
+     * {@link #cluster()} for the map to be cleared.
      */
     public void clearItems() {
         mAlgorithm.lock();
@@ -161,8 +161,8 @@ public class ClusterManager<T extends ClusterItem> implements
     }
 
     /**
-     * Adds items to clusters. After calling this method you must invoke cluster() for the state
-     * of the clusters to be updated on the map.
+     * Adds items to clusters. After calling this method you must invoke {@link #cluster()} for the
+     * state of the clusters to be updated on the map.
      * @param items items to add to clusters
      */
     public void addItems(Collection<T> items) {
@@ -175,8 +175,8 @@ public class ClusterManager<T extends ClusterItem> implements
     }
 
     /**
-     * Adds an item to a cluster. After calling this method you must invoke cluster() for the state
-     * of the clusters to be updated on the map.
+     * Adds an item to a cluster. After calling this method you must invoke {@link #cluster()} for
+     * the state of the clusters to be updated on the map.
      * @param myItem item to add to clusters
      */
     public void addItem(T myItem) {
@@ -189,8 +189,8 @@ public class ClusterManager<T extends ClusterItem> implements
     }
 
     /**
-     * Removes items from clusters. After calling this method you must invoke cluster() for the state
-     * of the clusters to be updated on the map.
+     * Removes items from clusters. After calling this method you must invoke {@link #cluster()} for
+     * the state of the clusters to be updated on the map.
      * @param items items to remove from clusters
      */
     public void removeItems(Collection<T> items) {
@@ -203,8 +203,8 @@ public class ClusterManager<T extends ClusterItem> implements
     }
 
     /**
-     * Removes an item from clusters. After calling this method you must invoke cluster() for the state
-     * of the clusters to be updated on the map.
+     * Removes an item from clusters. After calling this method you must invoke {@link #cluster()}
+     * for the state of the clusters to be updated on the map.
      * @param item item to remove from clusters
      */
     public void removeItem(T item) {
@@ -217,8 +217,8 @@ public class ClusterManager<T extends ClusterItem> implements
     }
 
     /**
-     * Updates an item in clusters. After calling this method you must invoke cluster() for the state
-     * of the clusters to be updated on the map.
+     * Updates an item in clusters. After calling this method you must invoke {@link #cluster()} for
+     * the state of the clusters to be updated on the map.
      * @param item item to update in clusters
      */
     public void updateItem(T item) {

--- a/library/src/main/java/com/google/maps/android/clustering/ClusterManager.java
+++ b/library/src/main/java/com/google/maps/android/clustering/ClusterManager.java
@@ -167,14 +167,12 @@ public class ClusterManager<T extends ClusterItem> implements
      * @return true if the cluster manager contents changed as a result of the call
      */
     public boolean addItems(Collection<T> items) {
-        boolean result;
         mAlgorithm.lock();
         try {
-            result = mAlgorithm.addItems(items);
+            return mAlgorithm.addItems(items);
         } finally {
             mAlgorithm.unlock();
         }
-        return result;
     }
 
     /**
@@ -184,14 +182,12 @@ public class ClusterManager<T extends ClusterItem> implements
      * @return true if the cluster manager contents changed as a result of the call
      */
     public boolean addItem(T myItem) {
-        boolean result;
         mAlgorithm.lock();
         try {
-            result = mAlgorithm.addItem(myItem);
+            return mAlgorithm.addItem(myItem);
         } finally {
             mAlgorithm.unlock();
         }
-        return result;
     }
 
     /**
@@ -201,14 +197,12 @@ public class ClusterManager<T extends ClusterItem> implements
      * @return true if the cluster manager contents changed as a result of the call
      */
     public boolean removeItems(Collection<T> items) {
-        boolean result;
         mAlgorithm.lock();
         try {
-            result = mAlgorithm.removeItems(items);
+            return mAlgorithm.removeItems(items);
         } finally {
             mAlgorithm.unlock();
         }
-        return result;
     }
 
     /**
@@ -218,14 +212,12 @@ public class ClusterManager<T extends ClusterItem> implements
      * @return true if the item was removed from the cluster manager as a result of this call
      */
     public boolean removeItem(T item) {
-        boolean result;
         mAlgorithm.lock();
         try {
-            result = mAlgorithm.removeItem(item);
+            return mAlgorithm.removeItem(item);
         } finally {
             mAlgorithm.unlock();
         }
-        return result;
     }
 
     /**
@@ -236,14 +228,12 @@ public class ClusterManager<T extends ClusterItem> implements
      * contained within the cluster manager and the cluster manager contents are unchanged
      */
     public boolean updateItem(T item) {
-        boolean result;
         mAlgorithm.lock();
         try {
-            result = mAlgorithm.updateItem(item);
+            return mAlgorithm.updateItem(item);
         } finally {
             mAlgorithm.unlock();
         }
-        return result;
     }
 
     /**

--- a/library/src/main/java/com/google/maps/android/clustering/ClusterManager.java
+++ b/library/src/main/java/com/google/maps/android/clustering/ClusterManager.java
@@ -164,70 +164,86 @@ public class ClusterManager<T extends ClusterItem> implements
      * Adds items to clusters. After calling this method you must invoke {@link #cluster()} for the
      * state of the clusters to be updated on the map.
      * @param items items to add to clusters
+     * @return true if the cluster manager contents changed as a result of the call
      */
-    public void addItems(Collection<T> items) {
+    public boolean addItems(Collection<T> items) {
+        boolean result;
         mAlgorithm.lock();
         try {
-            mAlgorithm.addItems(items);
+            result = mAlgorithm.addItems(items);
         } finally {
             mAlgorithm.unlock();
         }
+        return result;
     }
 
     /**
      * Adds an item to a cluster. After calling this method you must invoke {@link #cluster()} for
      * the state of the clusters to be updated on the map.
      * @param myItem item to add to clusters
+     * @return true if the cluster manager contents changed as a result of the call
      */
-    public void addItem(T myItem) {
+    public boolean addItem(T myItem) {
+        boolean result;
         mAlgorithm.lock();
         try {
-            mAlgorithm.addItem(myItem);
+            result = mAlgorithm.addItem(myItem);
         } finally {
             mAlgorithm.unlock();
         }
+        return result;
     }
 
     /**
      * Removes items from clusters. After calling this method you must invoke {@link #cluster()} for
      * the state of the clusters to be updated on the map.
      * @param items items to remove from clusters
+     * @return true if the cluster manager contents changed as a result of the call
      */
-    public void removeItems(Collection<T> items) {
+    public boolean removeItems(Collection<T> items) {
+        boolean result;
         mAlgorithm.lock();
         try {
-            mAlgorithm.removeItems(items);
+            result = mAlgorithm.removeItems(items);
         } finally {
             mAlgorithm.unlock();
         }
+        return result;
     }
 
     /**
      * Removes an item from clusters. After calling this method you must invoke {@link #cluster()}
      * for the state of the clusters to be updated on the map.
      * @param item item to remove from clusters
+     * @return true if the item was removed from the cluster manager as a result of this call
      */
-    public void removeItem(T item) {
+    public boolean removeItem(T item) {
+        boolean result;
         mAlgorithm.lock();
         try {
-            mAlgorithm.removeItem(item);
+            result = mAlgorithm.removeItem(item);
         } finally {
             mAlgorithm.unlock();
         }
+        return result;
     }
 
     /**
      * Updates an item in clusters. After calling this method you must invoke {@link #cluster()} for
      * the state of the clusters to be updated on the map.
      * @param item item to update in clusters
+     * @return true if the item was updated in the cluster manager, false if the item is not
+     * contained within the cluster manager and the cluster manager contents are unchanged
      */
-    public void updateItem(T item) {
+    public boolean updateItem(T item) {
+        boolean result;
         mAlgorithm.lock();
         try {
-            mAlgorithm.updateItem(item);
+            result = mAlgorithm.updateItem(item);
         } finally {
             mAlgorithm.unlock();
         }
+        return result;
     }
 
     /**

--- a/library/src/main/java/com/google/maps/android/clustering/algo/Algorithm.java
+++ b/library/src/main/java/com/google/maps/android/clustering/algo/Algorithm.java
@@ -35,6 +35,8 @@ public interface Algorithm<T extends ClusterItem> {
 
     void removeItem(T item);
 
+    void updateItem(T item);
+
     void removeItems(Collection<T> items);
 
     Set<? extends Cluster<T>> getClusters(float zoom);

--- a/library/src/main/java/com/google/maps/android/clustering/algo/Algorithm.java
+++ b/library/src/main/java/com/google/maps/android/clustering/algo/Algorithm.java
@@ -27,17 +27,44 @@ import java.util.Set;
  */
 public interface Algorithm<T extends ClusterItem> {
 
-    void addItem(T item);
+    /**
+     * Adds an item to the algorithm
+     * @param item the item to be added
+     * @return true if the algorithm contents changed as a result of the call
+     */
+    boolean addItem(T item);
 
-    void addItems(Collection<T> items);
+    /**
+     * Adds a collection of items to the algorithm
+     * @param items the items to be added
+     * @return true if the algorithm contents changed as a result of the call
+     */
+    boolean addItems(Collection<T> items);
 
     void clearItems();
 
-    void removeItem(T item);
+    /**
+     * Removes an item from the algorithm
+     * @param item the item to be removed
+     * @return true if this algorithm contained the specified element (or equivalently, if this
+     * algorithm changed as a result of the call).
+     */
+    boolean removeItem(T item);
 
-    void updateItem(T item);
+    /**
+     * Updates the provided item in the algorithm
+     * @param item the item to be updated
+     * @return true if the item existed in the algorithm and was updated, or false if the item did
+     * not exist in the algorithm and the algorithm contents remain unchanged.
+     */
+    boolean updateItem(T item);
 
-    void removeItems(Collection<T> items);
+    /**
+     * Removes a collection of items from the algorithm
+     * @param items the items to be removed
+     * @return true if this algorithm contents changed as a result of the call
+     */
+    boolean removeItems(Collection<T> items);
 
     Set<? extends Cluster<T>> getClusters(float zoom);
 

--- a/library/src/main/java/com/google/maps/android/clustering/algo/GridBasedAlgorithm.java
+++ b/library/src/main/java/com/google/maps/android/clustering/algo/GridBasedAlgorithm.java
@@ -38,14 +38,24 @@ public class GridBasedAlgorithm<T extends ClusterItem> extends AbstractAlgorithm
 
     private final Set<T> mItems = Collections.synchronizedSet(new HashSet<T>());
 
+    /**
+     * Adds an item to the algorithm
+     * @param item the item to be added
+     * @return true if the algorithm contents changed as a result of the call
+     */
     @Override
-    public void addItem(T item) {
-        mItems.add(item);
+    public boolean addItem(T item) {
+        return mItems.add(item);
     }
 
+    /**
+     * Adds a collection of items to the algorithm
+     * @param items the items to be added
+     * @return true if the algorithm contents changed as a result of the call
+     */
     @Override
-    public void addItems(Collection<T> items) {
-        mItems.addAll(items);
+    public boolean addItems(Collection<T> items) {
+        return mItems.addAll(items);
     }
 
     @Override
@@ -53,20 +63,44 @@ public class GridBasedAlgorithm<T extends ClusterItem> extends AbstractAlgorithm
         mItems.clear();
     }
 
+    /**
+     * Removes an item from the algorithm
+     * @param item the item to be removed
+     * @return true if this algorithm contained the specified element (or equivalently, if this
+     * algorithm changed as a result of the call).
+     */
     @Override
-    public void removeItem(T item) {
-        mItems.remove(item);
+    public boolean removeItem(T item) {
+        return mItems.remove(item);
     }
 
+    /**
+     * Removes a collection of items from the algorithm
+     * @param items the items to be removed
+     * @return true if this algorithm contents changed as a result of the call
+     */
     @Override
-    public void removeItems(Collection<T> items) {
-        mItems.removeAll(items);
+    public boolean removeItems(Collection<T> items) {
+        return mItems.removeAll(items);
     }
 
+    /**
+     * Updates the provided item in the algorithm
+     * @param item the item to be updated
+     * @return true if the item existed in the algorithm and was updated, or false if the item did
+     * not exist in the algorithm and the algorithm contents remain unchanged.
+     */
     @Override
-    public void updateItem(T item) {
-        removeItem(item);
-        addItem(item);
+    public boolean updateItem(T item) {
+        boolean result;
+        synchronized (mItems) {
+            result = removeItem(item);
+            if (result) {
+                // Only add the item if it was removed (to help prevent accidental duplicates on map)
+                result = addItem(item);
+            }
+        }
+        return result;
     }
 
     @Override

--- a/library/src/main/java/com/google/maps/android/clustering/algo/GridBasedAlgorithm.java
+++ b/library/src/main/java/com/google/maps/android/clustering/algo/GridBasedAlgorithm.java
@@ -16,8 +16,6 @@
 
 package com.google.maps.android.clustering.algo;
 
-import androidx.collection.LongSparseArray;
-
 import com.google.maps.android.clustering.Cluster;
 import com.google.maps.android.clustering.ClusterItem;
 import com.google.maps.android.geometry.Point;
@@ -27,6 +25,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+
+import androidx.collection.LongSparseArray;
 
 /**
  * Groups markers into a grid.
@@ -61,6 +61,12 @@ public class GridBasedAlgorithm<T extends ClusterItem> extends AbstractAlgorithm
     @Override
     public void removeItems(Collection<T> items) {
         mItems.removeAll(items);
+    }
+
+    @Override
+    public void updateItem(T item) {
+        removeItem(item);
+        addItem(item);
     }
 
     @Override

--- a/library/src/main/java/com/google/maps/android/clustering/algo/NonHierarchicalDistanceBasedAlgorithm.java
+++ b/library/src/main/java/com/google/maps/android/clustering/algo/NonHierarchicalDistanceBasedAlgorithm.java
@@ -111,6 +111,13 @@ public class NonHierarchicalDistanceBasedAlgorithm<T extends ClusterItem> extend
     }
 
     @Override
+    public void updateItem(T item) {
+        // TODO - Can this be optimized to update the item in-place if the location hasn't changed?
+        removeItem(item);
+        addItem(item);
+    }
+
+    @Override
     public Set<? extends Cluster<T>> getClusters(float zoom) {
         final int discreteZoom = (int) zoom;
 

--- a/library/src/main/java/com/google/maps/android/clustering/algo/NonHierarchicalDistanceBasedAlgorithm.java
+++ b/library/src/main/java/com/google/maps/android/clustering/algo/NonHierarchicalDistanceBasedAlgorithm.java
@@ -62,20 +62,39 @@ public class NonHierarchicalDistanceBasedAlgorithm<T extends ClusterItem> extend
 
     private static final SphericalMercatorProjection PROJECTION = new SphericalMercatorProjection(1);
 
+    /**
+     * Adds an item to the algorithm
+     * @param item the item to be added
+     * @return true if the algorithm contents changed as a result of the call
+     */
     @Override
-    public void addItem(T item) {
+    public boolean addItem(T item) {
+        boolean result;
         final QuadItem<T> quadItem = new QuadItem<>(item);
         synchronized (mQuadTree) {
-            mItems.add(quadItem);
-            mQuadTree.add(quadItem);
+            result = mItems.add(quadItem);
+            if (result) {
+                mQuadTree.add(quadItem);
+            }
         }
+        return result;
     }
 
+    /**
+     * Adds a collection of items to the algorithm
+     * @param items the items to be added
+     * @return true if the algorithm contents changed as a result of the call
+     */
     @Override
-    public void addItems(Collection<T> items) {
+    public boolean addItems(Collection<T> items) {
+        boolean result = false;
         for (T item : items) {
-            addItem(item);
+            boolean individualResult = addItem(item);
+            if (individualResult) {
+                result = true;
+            }
         }
+        return result;
     }
 
     @Override
@@ -86,35 +105,68 @@ public class NonHierarchicalDistanceBasedAlgorithm<T extends ClusterItem> extend
         }
     }
 
+    /**
+     * Removes an item from the algorithm
+     * @param item the item to be removed
+     * @return true if this algorithm contained the specified element (or equivalently, if this
+     * algorithm changed as a result of the call).
+     */
     @Override
-    public void removeItem(T item) {
+    public boolean removeItem(T item) {
+        boolean result;
         // QuadItem delegates hashcode() and equals() to its item so,
         //   removing any QuadItem to that item will remove the item
         final QuadItem<T> quadItem = new QuadItem<>(item);
         synchronized (mQuadTree) {
-            mItems.remove(quadItem);
-            mQuadTree.remove(quadItem);
+            result = mItems.remove(quadItem);
+            if (result) {
+                mQuadTree.remove(quadItem);
+            }
         }
+        return result;
     }
 
+    /**
+     * Removes a collection of items from the algorithm
+     * @param items the items to be removed
+     * @return true if this algorithm contents changed as a result of the call
+     */
     @Override
-    public void removeItems(Collection<T> items) {
+    public boolean removeItems(Collection<T> items) {
+        boolean result = false;
         synchronized (mQuadTree) {
             for (T item : items) {
                 // QuadItem delegates hashcode() and equals() to its item so,
                 //   removing any QuadItem to that item will remove the item
                 final QuadItem<T> quadItem = new QuadItem<>(item);
-                mItems.remove(quadItem);
-                mQuadTree.remove(quadItem);
+                boolean individualResult = mItems.remove(quadItem);
+                if (individualResult) {
+                    mQuadTree.remove(quadItem);
+                    result = true;
+                }
             }
         }
+        return result;
     }
 
+    /**
+     * Updates the provided item in the algorithm
+     * @param item the item to be updated
+     * @return true if the item existed in the algorithm and was updated, or false if the item did
+     * not exist in the algorithm and the algorithm contents remain unchanged.
+     */
     @Override
-    public void updateItem(T item) {
+    public boolean updateItem(T item) {
         // TODO - Can this be optimized to update the item in-place if the location hasn't changed?
-        removeItem(item);
-        addItem(item);
+        boolean result;
+        synchronized (mQuadTree) {
+            result = removeItem(item);
+            if (result) {
+                // Only add the item if it was removed (to help prevent accidental duplicates on map)
+                result = addItem(item);
+            }
+        }
+        return result;
     }
 
     @Override

--- a/library/src/main/java/com/google/maps/android/clustering/algo/PreCachingAlgorithmDecorator.java
+++ b/library/src/main/java/com/google/maps/android/clustering/algo/PreCachingAlgorithmDecorator.java
@@ -44,15 +44,21 @@ public class PreCachingAlgorithmDecorator<T extends ClusterItem> extends Abstrac
     }
 
     @Override
-    public void addItem(T item) {
-        mAlgorithm.addItem(item);
-        clearCache();
+    public boolean addItem(T item) {
+        boolean result = mAlgorithm.addItem(item);
+        if (result) {
+            clearCache();
+        }
+        return result;
     }
 
     @Override
-    public void addItems(Collection<T> items) {
-        mAlgorithm.addItems(items);
-        clearCache();
+    public boolean addItems(Collection<T> items) {
+        boolean result = mAlgorithm.addItems(items);
+        if (result) {
+            clearCache();
+        }
+        return result;
     }
 
     @Override
@@ -62,21 +68,30 @@ public class PreCachingAlgorithmDecorator<T extends ClusterItem> extends Abstrac
     }
 
     @Override
-    public void removeItem(T item) {
-        mAlgorithm.removeItem(item);
-        clearCache();
+    public boolean removeItem(T item) {
+        boolean result = mAlgorithm.removeItem(item);
+        if (result) {
+            clearCache();
+        }
+        return result;
     }
 
     @Override
-    public void removeItems(Collection<T> items) {
-        mAlgorithm.removeItems(items);
-        clearCache();
+    public boolean removeItems(Collection<T> items) {
+        boolean result = mAlgorithm.removeItems(items);
+        if (result) {
+            clearCache();
+        }
+        return result;
     }
 
     @Override
-    public void updateItem(T item) {
-        mAlgorithm.updateItem(item);
-        clearCache();
+    public boolean updateItem(T item) {
+        boolean result = mAlgorithm.updateItem(item);
+        if (result) {
+            clearCache();
+        }
+        return result;
     }
 
     private void clearCache() {

--- a/library/src/main/java/com/google/maps/android/clustering/algo/PreCachingAlgorithmDecorator.java
+++ b/library/src/main/java/com/google/maps/android/clustering/algo/PreCachingAlgorithmDecorator.java
@@ -16,8 +16,6 @@
 
 package com.google.maps.android.clustering.algo;
 
-import androidx.collection.LruCache;
-
 import com.google.maps.android.clustering.Cluster;
 import com.google.maps.android.clustering.ClusterItem;
 
@@ -27,6 +25,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import androidx.collection.LruCache;
 
 /**
  * Optimistically fetch clusters for adjacent zoom levels, caching them as necessary.
@@ -70,6 +70,12 @@ public class PreCachingAlgorithmDecorator<T extends ClusterItem> extends Abstrac
     @Override
     public void removeItems(Collection<T> items) {
         mAlgorithm.removeItems(items);
+        clearCache();
+    }
+
+    @Override
+    public void updateItem(T item) {
+        mAlgorithm.updateItem(item);
         clearCache();
     }
 

--- a/library/src/main/java/com/google/maps/android/clustering/algo/ScreenBasedAlgorithmAdapter.java
+++ b/library/src/main/java/com/google/maps/android/clustering/algo/ScreenBasedAlgorithmAdapter.java
@@ -62,6 +62,11 @@ public class ScreenBasedAlgorithmAdapter<T extends ClusterItem> extends Abstract
     }
 
     @Override
+    public void updateItem(T item) {
+        mAlgorithm.updateItem(item);
+    }
+
+    @Override
     public Set<? extends Cluster<T>> getClusters(float zoom) {
         return mAlgorithm.getClusters(zoom);
     }

--- a/library/src/main/java/com/google/maps/android/clustering/algo/ScreenBasedAlgorithmAdapter.java
+++ b/library/src/main/java/com/google/maps/android/clustering/algo/ScreenBasedAlgorithmAdapter.java
@@ -37,13 +37,13 @@ public class ScreenBasedAlgorithmAdapter<T extends ClusterItem> extends Abstract
     }
 
     @Override
-    public void addItem(T item) {
-        mAlgorithm.addItem(item);
+    public boolean addItem(T item) {
+        return mAlgorithm.addItem(item);
     }
 
     @Override
-    public void addItems(Collection<T> items) {
-        mAlgorithm.addItems(items);
+    public boolean addItems(Collection<T> items) {
+        return mAlgorithm.addItems(items);
     }
 
     @Override
@@ -52,18 +52,18 @@ public class ScreenBasedAlgorithmAdapter<T extends ClusterItem> extends Abstract
     }
 
     @Override
-    public void removeItem(T item) {
-        mAlgorithm.removeItem(item);
+    public boolean removeItem(T item) {
+        return mAlgorithm.removeItem(item);
     }
 
     @Override
-    public void removeItems(Collection<T> items) {
-        mAlgorithm.removeItems(items);
+    public boolean removeItems(Collection<T> items) {
+        return mAlgorithm.removeItems(items);
     }
 
     @Override
-    public void updateItem(T item) {
-        mAlgorithm.updateItem(item);
+    public boolean updateItem(T item) {
+        return mAlgorithm.updateItem(item);
     }
 
     @Override

--- a/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
@@ -952,7 +952,6 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
                         } else {
                             markerOptions.position(item.getPosition());
                         }
-                        // TODO (?) - Refactor set marker text into onBeforeClusterItemRendered()
                         if (!(item.getTitle() == null) && !(item.getSnippet() == null)) {
                             markerOptions.title(item.getTitle());
                             markerOptions.snippet(item.getSnippet());

--- a/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
@@ -738,11 +738,12 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
     /**
      * Called before the marker for a ClusterItem is added to the map.
      *
-     * The first time ClusterManager.cluster() is invoked on a set of items
-     * onBeforeClusterItemRendered() will be called and onClusterItemUpdated() will not be called.
-     * If an item is removed and re-added (or updated) and ClusterManager.cluster() is invoked
-     * again, then onClusterItemUpdated() will be called and onBeforeClusterItemRendered() will not
-     * be called.
+     * The first time {@link ClusterManager#cluster()} is invoked on a set of items
+     * {@link #onBeforeClusterItemRendered(ClusterItem, MarkerOptions)} will be called and
+     * {@link #onClusterItemUpdated(ClusterItem, Marker)} will not be called.
+     * If an item is removed and re-added (or updated) and {@link ClusterManager#cluster()} is
+     * invoked again, then {@link #onClusterItemUpdated(ClusterItem, Marker)} will be called and
+     * {@link #onBeforeClusterItemRendered(ClusterItem, MarkerOptions)} will not be called.
      *
      * @param item item to be rendered
      * @param markerOptions the markerOptions representing the provided item
@@ -758,11 +759,12 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
      * implementations of this method are responsible for checking if something changed (if that
      * matters to the implementation).
      *
-     * The first time ClusterManager.cluster() is invoked on a set of items
-     * onBeforeClusterItemRendered() will be called and onClusterItemUpdated() will not be called.
-     * If an item is removed and re-added (or updated) and ClusterManager.cluster() is invoked
-     * again, then onClusterItemUpdated() will be called and onBeforeClusterItemRendered() will not
-     * be called.
+     * The first time {@link ClusterManager#cluster()} is invoked on a set of items
+     * {@link #onBeforeClusterItemRendered(ClusterItem, MarkerOptions)} will be called and
+     * {@link #onClusterItemUpdated(ClusterItem, Marker)} will not be called.
+     * If an item is removed and re-added (or updated) and {@link ClusterManager#cluster()} is
+     * invoked again, then {@link #onClusterItemUpdated(ClusterItem, Marker)} will be called and
+     * {@link #onBeforeClusterItemRendered(ClusterItem, MarkerOptions)} will not be called.
      *
      * @param item item being updated
      * @param marker cached marker that contains a potentially previous state of the item.
@@ -801,11 +803,12 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
      * Called before the marker for a Cluster is added to the map.
      * The default implementation draws a circle with a rough count of the number of items.
      *
-     * The first time ClusterManager.cluster() is invoked on a set of items
-     * onBeforeClusterRendered() will be called and onClusterUpdated() will not be called.
-     * If an item is removed and re-added (or updated) and ClusterManager.cluster() is invoked
-     * again, then onClusterUpdated() will be called and onBeforeClusterRendered() will not be
-     * called.
+     * The first time {@link ClusterManager#cluster()} is invoked on a set of items
+     * {@link #onBeforeClusterRendered(Cluster, MarkerOptions)} will be called and
+     * {@link #onClusterUpdated(Cluster, Marker)} will not be called. If an item is removed and
+     * re-added (or updated) and {@link ClusterManager#cluster()} is invoked
+     * again, then {@link #onClusterUpdated(Cluster, Marker)} will be called and
+     * {@link #onBeforeClusterRendered(Cluster, MarkerOptions)} will not be called.
      *
      * @param cluster cluster to be rendered
      * @param markerOptions markerOptions representing the provided cluster
@@ -818,7 +821,8 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
     /**
      * Gets a BitmapDescriptor for the given cluster that contains a rough count of the number of
      * items. Used to set the cluster marker icon in the default implementations of
-     * onBeforeClusterRendered() and onClusterUpdated().
+     * {@link #onBeforeClusterRendered(Cluster, MarkerOptions)} and
+     * {@link #onClusterUpdated(Cluster, Marker)}.
      *
      * @param cluster cluster to get BitmapDescriptor for
      * @return a BitmapDescriptor for the marker icon for the given cluster that contains a rough
@@ -851,11 +855,12 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
      * not have changed since the cached marker was created - implementations of this method are
      * responsible for checking if something changed (if that matters to the implementation).
      *
-     * The first time ClusterManager.cluster() is invoked on a set of items
-     * onBeforeClusterRendered() will be called and onClusterUpdated() will not be called.
-     * If an item is removed and re-added (or updated) and ClusterManager.cluster() is invoked
-     * again, then onClusterUpdated() will be called and onBeforeClusterRendered() will not be
-     * called.
+     * The first time {@link ClusterManager#cluster()} is invoked on a set of items
+     * {@link #onBeforeClusterRendered(Cluster, MarkerOptions)} will be called and
+     * {@link #onClusterUpdated(Cluster, Marker)} will not be called. If an item is removed and
+     * re-added (or updated) and {@link ClusterManager#cluster()} is invoked
+     * again, then {@link #onClusterUpdated(Cluster, Marker)} will be called and
+     * {@link #onBeforeClusterRendered(Cluster, MarkerOptions)} will not be called.
      *
      * @param cluster cluster being updated
      * @param marker cached marker that contains a potentially previous state of the cluster
@@ -995,7 +1000,7 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
     }
 
     /**
-     * A Marker and its position. Marker.getPosition() must be called from the UI thread, so this
+     * A Marker and its position. {@link Marker#getPosition()} must be called from the UI thread, so this
      * object allows lookup from other threads.
      */
     private static class MarkerWithPosition {

--- a/library/src/test/java/com/google/maps/android/clustering/QuadItemTest.java
+++ b/library/src/test/java/com/google/maps/android/clustering/QuadItemTest.java
@@ -21,7 +21,9 @@ import com.google.maps.android.clustering.algo.NonHierarchicalDistanceBasedAlgor
 
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -30,23 +32,48 @@ import static org.junit.Assert.assertTrue;
 public class QuadItemTest {
 
     @Test
-    public void testRemoval() {
-        TestingItem item_1_5 = new TestingItem(0.1, 0.5);
-        TestingItem item_2_3 = new TestingItem(0.2, 0.3);
+    public void testAddRemoveUpdateClear() {
+        ClusterItem item_1_5 = new TestingItem("title1", 0.1, 0.5);
+        ClusterItem item_2_3 = new TestingItem("title2", 0.2, 0.3);
 
         NonHierarchicalDistanceBasedAlgorithm<ClusterItem> algo =
                 new NonHierarchicalDistanceBasedAlgorithm<>();
-        algo.addItem(item_1_5);
-        algo.addItem(item_2_3);
+        assertTrue(algo.addItem(item_1_5));
+        assertTrue(algo.addItem(item_2_3));
 
         assertEquals(2, algo.getItems().size());
 
-        algo.removeItem(item_1_5);
+        assertTrue(algo.removeItem(item_1_5));
 
         assertEquals(1, algo.getItems().size());
 
         assertFalse(algo.getItems().contains(item_1_5));
         assertTrue(algo.getItems().contains(item_2_3));
+
+        // Update the item still in the algorithm
+        ((TestingItem) item_2_3).setTitle("newTitle");
+        assertTrue(algo.updateItem(item_2_3));
+
+        // Try to remove the item that was already removed
+        assertFalse(algo.removeItem(item_1_5));
+
+        // Try to update the item that was already removed
+        assertFalse(algo.updateItem(item_1_5));
+
+        algo.clearItems();
+        assertEquals(0, algo.getItems().size());
+
+        // Test bulk operations
+        List<ClusterItem> items = Arrays.asList(item_1_5, item_2_3);
+        assertTrue(algo.addItems(items));
+
+        // Try to bulk add items that were already added
+        assertFalse(algo.addItems(items));
+
+        assertTrue(algo.removeItems(items));
+
+        // Try to bulk remove items that were already removed
+        assertFalse(algo.removeItems(items));
     }
 
     /**
@@ -73,7 +100,7 @@ public class QuadItemTest {
 
     private class TestingItem implements ClusterItem {
         private final LatLng mPosition;
-        private final String mTitle;
+        private String mTitle;
 
         TestingItem(String title, double lat, double lng) {
             mTitle = title;
@@ -98,6 +125,10 @@ public class QuadItemTest {
         @Override
         public String getSnippet() {
             return null;
+        }
+
+        public void setTitle(String title) {
+            mTitle = title;
         }
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/googlemaps/android-maps-utils/issues/90, when an item instance is removed, updated, and re-added the `ClusterManager`, the updated item state wouldn't be reflected on the map.

The reason for this is that `DefaultClusterRenderer.CreateMarkerTask.perform()` was using a marker from its own `mMarkerCache` associated with that item to display that item on the map (even if `ClusterManager.clearItems()` was previously called). This resulted in the updated item contents not being reflected on the map, because the cached marker was not updated.

This PR does the following:
* Add new protected methods in `DefaultClusterRenderer` - `onClusterItemUpdated()` and `onClusterUpdated()` - which are called when an existing cached marker is found for an item/cluster when that item/cluster is being added back into the `ClusterManager`. The default implementation of these methods update the marker contents on the map, but then can also be overridden by applications for custom behavior (similar to `onBeforeClusterItemRendered()` and `onBeforeClusterRendered()`).  Following this change, you can now do `ClusterManager.clearItems()` and re-add the same list instance (or `remove()` and then `add()` the same item) and then call `cluster()` and the map markers will be updated with the new item model contents.
* Add a new `ClusterManager.updateItem()` helper method for updating the `ClusterManager` and algorithms with an existing item. The current implementation in `NonHierarchicalDistanceBasedAlgorithm` is a wrapper for `remove()` and then `add()`.
* Add more descriptive Javadocs to `ClusterManager`, `DefaultClusterRenderer`, and `NonHierarchicalDistanceBasedAlgorithm` to describe expected behavior, especially that `cluster()` should be invoked after any changes to `ClusterManager` to see changes on the map.

One new TODO I added that could potentially be addressed - it seems like the code to set the marker text when creating the item marker should be refactored into `onBeforeClusterItemRendered()` to match the implementation of clusters (`onBeforeClusterRendered()`), and to allow applications extending `DefaultClusterRenderer` to inherit this default behavior via a call to `super.onBeforeClusterItemRendered()`. However, moving this code would change the behavior of the library for apps already extending `DefaultClusterRenderer` that aren't calling `super.onBeforeClusterItemRendered()` - the marker title and snippet would no longer be updated. Thoughts on this are welcome!

Fixes #90