### PR TITLE
feat(ktx): GeoJson and Kml KTX

### DIFF
--- a/android-maps-utils-ktx/src/main/java/com/google/maps/ktx/LatLng.kt
+++ b/android-maps-utils-ktx/src/main/java/com/google/maps/ktx/LatLng.kt
@@ -13,7 +13,7 @@ import com.google.maps.android.SphericalUtil
  *
  * @see PolyUtil.simplify
  */
-fun List<LatLng>.simplify(tolerance: Double): List<LatLng> = PolyUtil.simplify(this, tolerance)
+inline fun List<LatLng>.simplify(tolerance: Double): List<LatLng> = PolyUtil.simplify(this, tolerance)
 
 /**
  * Decodes this encoded string into a [LatLng] list.
@@ -22,7 +22,7 @@ fun List<LatLng>.simplify(tolerance: Double): List<LatLng> = PolyUtil.simplify(t
  *
  * @see [Polyline Algorithm Format](https://developers.google.com/maps/documentation/utilities/polylinealgorithm)
  */
-fun String.toLatLngList(): List<LatLng> = PolyUtil.decode(this)
+inline fun String.toLatLngList(): List<LatLng> = PolyUtil.decode(this)
 
 /**
  * Encodes this [LatLng] list in a String using the
@@ -33,7 +33,7 @@ fun String.toLatLngList(): List<LatLng> = PolyUtil.decode(this)
  * @see [Polyline Algorithm Format](https://developers.google.com/maps/documentation/utilities/polylinealgorithm)
  *
  */
-fun List<LatLng>.latLngListEncode(): String = PolyUtil.encode(this)
+inline fun List<LatLng>.latLngListEncode(): String = PolyUtil.encode(this)
 
 /**
  * Checks whether or not this [LatLng] list is a closed Polygon.
@@ -42,21 +42,21 @@ fun List<LatLng>.latLngListEncode(): String = PolyUtil.encode(this)
  *
  * @see PolyUtil.isClosedPolygon
  */
-fun List<LatLng>.isClosedPolygon(): Boolean = PolyUtil.isClosedPolygon(this)
+inline fun List<LatLng>.isClosedPolygon(): Boolean = PolyUtil.isClosedPolygon(this)
 
 /**
  * Computes the length of this path on Earth.
  *
  * @return the length of this path in meters
  */
-fun List<LatLng>.sphericalPathLength(): Double = SphericalUtil.computeLength(this)
+inline fun List<LatLng>.sphericalPathLength(): Double = SphericalUtil.computeLength(this)
 
 /**
  * Computes the area under a closed path on Earth.
  *
  * @return the area in square meters
  */
-fun List<LatLng>.sphericalPolygonArea(): Double = SphericalUtil.computeArea(this)
+inline fun List<LatLng>.sphericalPolygonArea(): Double = SphericalUtil.computeArea(this)
 
 
 /**
@@ -65,7 +65,7 @@ fun List<LatLng>.sphericalPolygonArea(): Double = SphericalUtil.computeArea(this
  *
  * @return the signed area in square meters
  */
-fun List<LatLng>.sphericalPolygonSignedArea(): Double = SphericalUtil.computeSignedArea(this)
+inline fun List<LatLng>.sphericalPolygonSignedArea(): Double = SphericalUtil.computeSignedArea(this)
 
 /**
  * Computes the heading from this LatLng to [toLatLng].
@@ -75,7 +75,7 @@ fun List<LatLng>.sphericalPolygonSignedArea(): Double = SphericalUtil.computeSig
  *
  * @see SphericalUtil.computeHeading
  */
-fun LatLng.sphericalHeading(toLatLng: LatLng): Double =
+inline fun LatLng.sphericalHeading(toLatLng: LatLng): Double =
     SphericalUtil.computeHeading(this, toLatLng)
 
 /**
@@ -87,7 +87,7 @@ fun LatLng.sphericalHeading(toLatLng: LatLng): Double =
  *
  * @see SphericalUtil.computeOffset
  */
-fun LatLng.withSphericalOffset(distance: Double, heading: Double): LatLng =
+inline fun LatLng.withSphericalOffset(distance: Double, heading: Double): LatLng =
     SphericalUtil.computeOffset(this, distance, heading)
 
 /**
@@ -100,7 +100,7 @@ fun LatLng.withSphericalOffset(distance: Double, heading: Double): LatLng =
  *
  * @see SphericalUtil.computeOffsetOrigin
  */
-fun LatLng.computeSphericalOffsetOrigin(distance: Double, heading: Double): LatLng? =
+inline fun LatLng.computeSphericalOffsetOrigin(distance: Double, heading: Double): LatLng? =
     SphericalUtil.computeOffsetOrigin(this, distance, heading)
 
 /**
@@ -113,7 +113,7 @@ fun LatLng.computeSphericalOffsetOrigin(distance: Double, heading: Double): LatL
  *
  * @see [Slerp](http://en.wikipedia.org/wiki/Slerp)
  */
-fun LatLng.withSphericalLinearInterpolation(to: LatLng, fraction: Double): LatLng =
+inline fun LatLng.withSphericalLinearInterpolation(to: LatLng, fraction: Double): LatLng =
     SphericalUtil.interpolate(this, to, fraction)
 
 /**
@@ -122,5 +122,5 @@ fun LatLng.withSphericalLinearInterpolation(to: LatLng, fraction: Double): LatLn
  * @param to the LatLng to compute the distance to
  * @return the distance between this and [to] in meters
  */
-fun LatLng.sphericalDistance(to: LatLng): Double =
+inline fun LatLng.sphericalDistance(to: LatLng): Double =
     SphericalUtil.computeDistanceBetween(this, to)

--- a/android-maps-utils-ktx/src/main/java/com/google/maps/ktx/Polygon.kt
+++ b/android-maps-utils-ktx/src/main/java/com/google/maps/ktx/Polygon.kt
@@ -13,7 +13,7 @@ import com.google.maps.android.SphericalUtil
  *
  * @see PolyUtil.containsLocation
  */
-fun Polygon.contains(latLng: LatLng): Boolean =
+inline fun Polygon.contains(latLng: LatLng): Boolean =
     PolyUtil.containsLocation(latLng, this.points, this.isGeodesic)
 
 /**
@@ -26,18 +26,18 @@ fun Polygon.contains(latLng: LatLng): Boolean =
  *
  * @see PolyUtil.isLocationOnEdge
  */
-fun Polygon.isOnEdge(latLng: LatLng, tolerance: Double = PolyUtil.DEFAULT_TOLERANCE): Boolean =
+inline fun Polygon.isOnEdge(latLng: LatLng, tolerance: Double = PolyUtil.DEFAULT_TOLERANCE): Boolean =
     PolyUtil.isLocationOnEdge(latLng, this.points, this.isGeodesic, tolerance)
 
 /**
  * The area of this Polygon on Earth in square meters.
  */
-val Polygon.area: Double
+inline val Polygon.area: Double
     get() = SphericalUtil.computeArea(this.points)
 
 /**
  * Computes the signed area under a closed path on Earth. The sign of the area may be used to
  * determine the orientation of the path.
  */
-val Polygon.signedArea: Double
+inline val Polygon.signedArea: Double
     get() = SphericalUtil.computeSignedArea(this.points)

--- a/android-maps-utils-ktx/src/main/java/com/google/maps/ktx/Polyline.kt
+++ b/android-maps-utils-ktx/src/main/java/com/google/maps/ktx/Polyline.kt
@@ -9,11 +9,11 @@ import com.google.maps.android.SphericalUtil
  * Computes where the given [latLng] is contained on or near this Polyline within a specified
  * tolerance in meters.
  */
-fun Polyline.contains(latLng: LatLng, tolerance: Double = PolyUtil.DEFAULT_TOLERANCE): Boolean =
+inline fun Polyline.contains(latLng: LatLng, tolerance: Double = PolyUtil.DEFAULT_TOLERANCE): Boolean =
     PolyUtil.isLocationOnPath(latLng, this.points, this.isGeodesic, tolerance)
 
 /**
  * The spherical length of this Polyline on Earth as measured in meters.
  */
-val Polyline.sphericalPathLength: Double
+inline val Polyline.sphericalPathLength: Double
     get() = SphericalUtil.computeLength(this.points)

--- a/android-maps-utils-ktx/src/main/java/com/google/maps/ktx/core/PolygonOptions.kt
+++ b/android-maps-utils-ktx/src/main/java/com/google/maps/ktx/core/PolygonOptions.kt
@@ -8,3 +8,4 @@ import com.google.android.gms.maps.model.PolygonOptions
  */
 inline fun buildPolygonOptions(optionsActions: PolygonOptions.() -> Unit): PolygonOptions =
     PolygonOptions().apply(optionsActions)
+

--- a/android-maps-utils-ktx/src/main/java/com/google/maps/ktx/core/SupportMapFragment.kt
+++ b/android-maps-utils-ktx/src/main/java/com/google/maps/ktx/core/SupportMapFragment.kt
@@ -8,7 +8,7 @@ import kotlin.coroutines.suspendCoroutine
 /**
  * CORE
  */
-suspend fun SupportMapFragment.awaitMap(): GoogleMap =
+suspend inline fun SupportMapFragment.awaitMap(): GoogleMap =
     suspendCoroutine { continuation ->
         getMapAsync {
             continuation.resume(it)

--- a/android-maps-utils-ktx/src/main/java/com/google/maps/ktx/geojson/GeoJson.kt
+++ b/android-maps-utils-ktx/src/main/java/com/google/maps/ktx/geojson/GeoJson.kt
@@ -1,0 +1,29 @@
+package com.google.maps.ktx.geojson
+
+import com.google.android.gms.maps.GoogleMap
+import com.google.maps.android.collections.GroundOverlayManager
+import com.google.maps.android.collections.MarkerManager
+import com.google.maps.android.collections.PolygonManager
+import com.google.maps.android.collections.PolylineManager
+import com.google.maps.android.data.geojson.GeoJsonLayer
+import org.json.JSONObject
+
+/**
+ * Alias for the [GeoJsonLayer] constructor that provides Kotlin named parameters and default
+ * values.
+ */
+inline fun GeoJsonLayer(
+    map: GoogleMap,
+    geoJsonFile: JSONObject,
+    markerManager: MarkerManager? = null,
+    polygonManager: PolygonManager? = null,
+    polylineManager: PolylineManager? = null,
+    groundOverlayManager: GroundOverlayManager? = null
+): GeoJsonLayer = GeoJsonLayer(
+    map,
+    geoJsonFile,
+    markerManager,
+    polygonManager,
+    polylineManager,
+    groundOverlayManager
+)

--- a/android-maps-utils-ktx/src/main/java/com/google/maps/ktx/geojson/GeoJson.kt
+++ b/android-maps-utils-ktx/src/main/java/com/google/maps/ktx/geojson/GeoJson.kt
@@ -12,7 +12,7 @@ import org.json.JSONObject
  * Alias for the [GeoJsonLayer] constructor that provides Kotlin named parameters and default
  * values.
  */
-inline fun GeoJsonLayer(
+inline fun geoJsonLayer(
     map: GoogleMap,
     geoJsonFile: JSONObject,
     markerManager: MarkerManager? = null,

--- a/android-maps-utils-ktx/src/main/java/com/google/maps/ktx/kml/Kml.kt
+++ b/android-maps-utils-ktx/src/main/java/com/google/maps/ktx/kml/Kml.kt
@@ -1,12 +1,13 @@
 package com.google.maps.ktx.kml
 
+import android.content.Context
 import androidx.annotation.RawRes
-import androidx.fragment.app.FragmentActivity
 import com.google.android.gms.maps.GoogleMap
 import com.google.maps.android.collections.GroundOverlayManager
 import com.google.maps.android.collections.MarkerManager
 import com.google.maps.android.collections.PolygonManager
 import com.google.maps.android.collections.PolylineManager
+import com.google.maps.android.data.Renderer
 import com.google.maps.android.data.kml.KmlLayer
 import java.io.InputStream
 
@@ -16,19 +17,21 @@ import java.io.InputStream
 inline fun kmlLayer(
     map: GoogleMap,
     @RawRes resourceId: Int,
-    activity: FragmentActivity,
+    context: Context,
     markerManager: MarkerManager = MarkerManager(map),
     polygonManager: PolygonManager = PolygonManager(map),
     polylineManager: PolylineManager = PolylineManager(map),
-    groundOverlayManager: GroundOverlayManager = GroundOverlayManager(map)
+    groundOverlayManager: GroundOverlayManager = GroundOverlayManager(map),
+    imagesCache: Renderer.ImagesCache? = null
 ) : KmlLayer = KmlLayer(
     map,
     resourceId,
-    activity,
+    context,
     markerManager,
     polygonManager,
     polylineManager,
-    groundOverlayManager
+    groundOverlayManager,
+    imagesCache
 )
 
 /**
@@ -37,17 +40,19 @@ inline fun kmlLayer(
 inline fun kmlLayer(
     map: GoogleMap,
     stream: InputStream,
-    activity: FragmentActivity,
+    context: Context,
     markerManager: MarkerManager = MarkerManager(map),
     polygonManager: PolygonManager = PolygonManager(map),
     polylineManager: PolylineManager = PolylineManager(map),
-    groundOverlayManager: GroundOverlayManager = GroundOverlayManager(map)
+    groundOverlayManager: GroundOverlayManager = GroundOverlayManager(map),
+    imagesCache: Renderer.ImagesCache? = null
 ) : KmlLayer = KmlLayer(
     map,
     stream,
-    activity,
+    context,
     markerManager,
     polygonManager,
     polylineManager,
-    groundOverlayManager
+    groundOverlayManager,
+    imagesCache
 )

--- a/android-maps-utils-ktx/src/main/java/com/google/maps/ktx/kml/Kml.kt
+++ b/android-maps-utils-ktx/src/main/java/com/google/maps/ktx/kml/Kml.kt
@@ -1,0 +1,53 @@
+package com.google.maps.ktx.kml
+
+import androidx.annotation.RawRes
+import androidx.fragment.app.FragmentActivity
+import com.google.android.gms.maps.GoogleMap
+import com.google.maps.android.collections.GroundOverlayManager
+import com.google.maps.android.collections.MarkerManager
+import com.google.maps.android.collections.PolygonManager
+import com.google.maps.android.collections.PolylineManager
+import com.google.maps.android.data.kml.KmlLayer
+import java.io.InputStream
+
+/**
+ * Alias for the [KmlLayer] constructor that provides Kotlin named parameters and default values.
+ */
+inline fun kmlLayer(
+    map: GoogleMap,
+    @RawRes resourceId: Int,
+    activity: FragmentActivity,
+    markerManager: MarkerManager = MarkerManager(map),
+    polygonManager: PolygonManager = PolygonManager(map),
+    polylineManager: PolylineManager = PolylineManager(map),
+    groundOverlayManager: GroundOverlayManager = GroundOverlayManager(map)
+) : KmlLayer = KmlLayer(
+    map,
+    resourceId,
+    activity,
+    markerManager,
+    polygonManager,
+    polylineManager,
+    groundOverlayManager
+)
+
+/**
+ * Alias for the [KmlLayer] constructor that provides Kotlin named parameters and default values.
+ */
+inline fun kmlLayer(
+    map: GoogleMap,
+    stream: InputStream,
+    activity: FragmentActivity,
+    markerManager: MarkerManager = MarkerManager(map),
+    polygonManager: PolygonManager = PolygonManager(map),
+    polylineManager: PolylineManager = PolylineManager(map),
+    groundOverlayManager: GroundOverlayManager = GroundOverlayManager(map)
+) : KmlLayer = KmlLayer(
+    map,
+    stream,
+    activity,
+    markerManager,
+    polygonManager,
+    polylineManager,
+    groundOverlayManager
+)

--- a/library/src/main/java/com/google/maps/android/data/Layer.java
+++ b/library/src/main/java/com/google/maps/android/data/Layer.java
@@ -17,9 +17,6 @@
 package com.google.maps.android.data;
 
 import com.google.android.gms.maps.GoogleMap;
-import com.google.android.gms.maps.model.Marker;
-import com.google.android.gms.maps.model.Polygon;
-import com.google.android.gms.maps.model.Polyline;
 import com.google.maps.android.data.geojson.GeoJsonLineStringStyle;
 import com.google.maps.android.data.geojson.GeoJsonPointStyle;
 import com.google.maps.android.data.geojson.GeoJsonPolygonStyle;
@@ -27,11 +24,6 @@ import com.google.maps.android.data.geojson.GeoJsonRenderer;
 import com.google.maps.android.data.kml.KmlContainer;
 import com.google.maps.android.data.kml.KmlGroundOverlay;
 import com.google.maps.android.data.kml.KmlRenderer;
-
-import org.xmlpull.v1.XmlPullParserException;
-
-import java.io.IOException;
-import java.util.ArrayList;
 
 /**
  * An abstraction that shares the common properties of

--- a/library/src/main/java/com/google/maps/android/data/geojson/GeoJsonLineStringStyle.java
+++ b/library/src/main/java/com/google/maps/android/data/geojson/GeoJsonLineStringStyle.java
@@ -15,6 +15,8 @@
  */
 package com.google.maps.android.data.geojson;
 
+import androidx.annotation.ColorInt;
+
 import com.google.android.gms.maps.model.PatternItem;
 import com.google.android.gms.maps.model.PolylineOptions;
 import com.google.maps.android.data.Style;
@@ -63,7 +65,7 @@ public class GeoJsonLineStringStyle extends Style implements GeoJsonStyle {
      *
      * @param color color value of the GeoJsonLineString
      */
-    public void setColor(int color) {
+    public void setColor(@ColorInt int color) {
         mPolylineOptions.color(color);
         styleChanged();
     }

--- a/library/src/main/java/com/google/maps/android/data/geojson/GeoJsonPolygonStyle.java
+++ b/library/src/main/java/com/google/maps/android/data/geojson/GeoJsonPolygonStyle.java
@@ -15,6 +15,8 @@
  */
 package com.google.maps.android.data.geojson;
 
+import androidx.annotation.ColorInt;
+
 import com.google.android.gms.maps.model.PolygonOptions;
 import com.google.maps.android.data.Style;
 
@@ -60,7 +62,7 @@ public class GeoJsonPolygonStyle extends Style implements GeoJsonStyle {
      *
      * @param fillColor fill color value of the GeoJsonPolygon
      */
-    public void setFillColor(int fillColor) {
+    public void setFillColor(@ColorInt int fillColor) {
         setPolygonFillColor(fillColor);
         styleChanged();
     }
@@ -98,7 +100,7 @@ public class GeoJsonPolygonStyle extends Style implements GeoJsonStyle {
      *
      * @param strokeColor stroke color value of the GeoJsonPolygon
      */
-    public void setStrokeColor(int strokeColor) {
+    public void setStrokeColor(@ColorInt int strokeColor) {
         mPolygonOptions.strokeColor(strokeColor);
         styleChanged();
     }

--- a/library/src/main/java/com/google/maps/android/data/kml/KmlLayer.java
+++ b/library/src/main/java/com/google/maps/android/data/kml/KmlLayer.java
@@ -19,6 +19,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.util.Log;
 
+import androidx.annotation.RawRes;
 import androidx.fragment.app.FragmentActivity;
 
 import com.google.android.gms.maps.GoogleMap;
@@ -94,7 +95,7 @@ public class KmlLayer extends Layer {
      * @throws XmlPullParserException if file cannot be parsed
      * @throws IOException if I/O error
      */
-    public KmlLayer(GoogleMap map, int resourceId, FragmentActivity activity, MarkerManager markerManager, PolygonManager polygonManager, PolylineManager polylineManager, GroundOverlayManager groundOverlayManager)
+    public KmlLayer(GoogleMap map, @RawRes int resourceId, FragmentActivity activity, MarkerManager markerManager, PolygonManager polygonManager, PolylineManager polylineManager, GroundOverlayManager groundOverlayManager)
             throws XmlPullParserException, IOException {
         this(map, activity.getResources().openRawResource(resourceId), activity, markerManager, polygonManager, polylineManager, groundOverlayManager);
     }


### PR DESCRIPTION
Took a pass in the `geojson` and `kml` packages to see what we can make Kotlin friendly. The only method I could find that we can improve is the constructor for `GeoJsonLayer` and `KmlLayer`.

_Before_:
```java
GeoJsonLayer layer = new GeoJsonLayer(map, geoJsonFile, null, polygonManager, null, groundOverlayManager);
```

_After_:
```kotlin
val layer = GeoJsonLayer(
    map = map,
    geoJsonFile = geoJsonFile,
    polygonManager = polygonManager,
    groundOverlayManager = groundOverlayManager
)
```

Other changes:
* making all extension functions and properties in the kx library `inline` to avoid overhead of new memory allocations when using the ktx aliases vs. using the method/properties directly
* Added `@ColorInt` annotations in `geojson` classes where I found it to be helpful
* Added `@RawRes` annotation in `kml` class
* Noticed an improvement that we can make in `KmlLayer`. Issue filed here #629 