### PR TITLE
fix(KmlLayer): Update constructor to take in a Context instead

### DIFF
--- a/demo/src/main/java/com/google/maps/android/utils/demo/MultiLayerDemoActivity.java
+++ b/demo/src/main/java/com/google/maps/android/utils/demo/MultiLayerDemoActivity.java
@@ -128,7 +128,7 @@ public class MultiLayerDemoActivity extends BaseDemoActivity {
         KmlLayer kmlPolygonLayer;
         try {
             // KML Polyline
-            kmlPolylineLayer = new KmlLayer(getMap(), R.raw.south_london_line_kml, this, markerManager, polygonManager, polylineManager, groundOverlayManager);
+            kmlPolylineLayer = new KmlLayer(getMap(), R.raw.south_london_line_kml, this, markerManager, polygonManager, polylineManager, groundOverlayManager, null);
             kmlPolylineLayer.addLayerToMap();
             kmlPolylineLayer.setOnFeatureClickListener(new KmlLayer.OnFeatureClickListener() {
                 @Override
@@ -140,7 +140,7 @@ public class MultiLayerDemoActivity extends BaseDemoActivity {
             });
 
             // KML Polygon
-            kmlPolygonLayer = new KmlLayer(getMap(), R.raw.south_london_square_kml, this, markerManager, polygonManager, polylineManager, groundOverlayManager);
+            kmlPolygonLayer = new KmlLayer(getMap(), R.raw.south_london_square_kml, this, markerManager, polygonManager, polylineManager, groundOverlayManager, null);
             kmlPolygonLayer.addLayerToMap();
             kmlPolygonLayer.setOnFeatureClickListener(new KmlLayer.OnFeatureClickListener() {
                 @Override

--- a/library/src/androidTest/java/com/google/maps/android/data/kml/KmlRendererTest.java
+++ b/library/src/androidTest/java/com/google/maps/android/data/kml/KmlRendererTest.java
@@ -36,7 +36,7 @@ public class KmlRendererTest {
         mParser = new KmlParser(parser);
         mParser.parseKml();
 
-        mRenderer = new KmlRenderer(mMap1, null, null, null, null, null);
+        mRenderer = new KmlRenderer(mMap1, null, null, null, null, null, null);
         mRenderer.storeKmlData(mParser.getStyles(), mParser.getStyleMaps(), mParser.getPlacemarks(),
                 mParser.getContainers(), mParser.getGroundOverlays());
     }

--- a/library/src/main/java/com/google/maps/android/data/Renderer.java
+++ b/library/src/main/java/com/google/maps/android/data/Renderer.java
@@ -134,6 +134,7 @@ public class Renderer {
      * @param polygonManager polygon manager to create polygon collection from
      * @param polylineManager polyline manager to create polyline collection from
      * @param groundOverlayManager ground overlay manager to create ground overlay collection from
+     * @param imagesCache an optional ImagesCache to be used for caching images fetched
      */
     public Renderer(GoogleMap map,
                     Context context,

--- a/library/src/main/java/com/google/maps/android/data/Renderer.java
+++ b/library/src/main/java/com/google/maps/android/data/Renderer.java
@@ -70,6 +70,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
@@ -103,7 +104,7 @@ public class Renderer {
 
     private final Set<String> mMarkerIconUrls;
 
-    private ImagesCache mImagesCache = new ImagesCache();
+    private ImagesCache mImagesCache;
 
     private int mNumActiveDownloads = 0;
 
@@ -134,10 +135,17 @@ public class Renderer {
      * @param polylineManager polyline manager to create polyline collection from
      * @param groundOverlayManager ground overlay manager to create ground overlay collection from
      */
-    public Renderer(GoogleMap map, Context context, MarkerManager markerManager, PolygonManager polygonManager, PolylineManager polylineManager, GroundOverlayManager groundOverlayManager) {
+    public Renderer(GoogleMap map,
+                    Context context,
+                    MarkerManager markerManager,
+                    PolygonManager polygonManager,
+                    PolylineManager polylineManager,
+                    GroundOverlayManager groundOverlayManager,
+                    @Nullable ImagesCache imagesCache) {
         this(map, new HashSet<String>(), null, null, null, new BiMultiMap<Feature>(), markerManager, polygonManager, polylineManager, groundOverlayManager);
         mContext = context;
         mStylesRenderer = new HashMap<>();
+        mImagesCache = (imagesCache == null) ? new ImagesCache() : imagesCache;
     }
 
     /**
@@ -221,17 +229,6 @@ public class Renderer {
          * This cache is cleared once all icon URLs are loaded, scaled, and cached as BitmapDescriptors.
          */
         final Map<String, Bitmap> bitmapCache = new HashMap<>();
-    }
-
-    /**
-     * Sets the {@link ImagesCache} to be used by this Renderer for images that are fetched. Calling
-     * this method is a mechanism to reuse an existing cache across multiple Renderer instance which
-     * may be desirable to handle configuration changes.
-     *
-     * @param cache the ImagesCache to use for this Renderer
-     */
-    public void setImagesCache(ImagesCache cache) {
-        this.mImagesCache = cache;
     }
 
     /**

--- a/library/src/main/java/com/google/maps/android/data/kml/KmlLayer.java
+++ b/library/src/main/java/com/google/maps/android/data/kml/KmlLayer.java
@@ -29,6 +29,7 @@ import com.google.maps.android.data.Layer;
 import com.google.maps.android.collections.MarkerManager;
 import com.google.maps.android.collections.PolygonManager;
 import com.google.maps.android.collections.PolylineManager;
+import com.google.maps.android.data.Renderer;
 
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
@@ -59,7 +60,7 @@ public class KmlLayer extends Layer {
      */
     public KmlLayer(GoogleMap map, int resourceId, Context context)
             throws XmlPullParserException, IOException {
-        this(map, context.getResources().openRawResource(resourceId), context, new MarkerManager(map), new PolygonManager(map), new PolylineManager(map), new GroundOverlayManager(map));
+        this(map, context.getResources().openRawResource(resourceId), context, new MarkerManager(map), new PolygonManager(map), new PolylineManager(map), new GroundOverlayManager(map), null);
     }
 
     /**
@@ -75,7 +76,7 @@ public class KmlLayer extends Layer {
      */
     public KmlLayer(GoogleMap map, InputStream stream, Context context)
             throws XmlPullParserException, IOException {
-        this(map, stream, context, new MarkerManager(map), new PolygonManager(map), new PolylineManager(map), new GroundOverlayManager(map));
+        this(map, stream, context, new MarkerManager(map), new PolygonManager(map), new PolylineManager(map), new GroundOverlayManager(map), null);
     }
 
     /**
@@ -93,12 +94,20 @@ public class KmlLayer extends Layer {
      * @param polygonManager polygon manager to create polygon collection from
      * @param polylineManager polyline manager to create polyline collection from
      * @param groundOverlayManager ground overlay manager to create ground overlay collection from
+     * @param cache cache to be used for fetched images
      * @throws XmlPullParserException if file cannot be parsed
      * @throws IOException if I/O error
      */
-    public KmlLayer(GoogleMap map, @RawRes int resourceId, Context context, MarkerManager markerManager, PolygonManager polygonManager, PolylineManager polylineManager, GroundOverlayManager groundOverlayManager)
+    public KmlLayer(GoogleMap map,
+                    @RawRes int resourceId,
+                    Context context,
+                    MarkerManager markerManager,
+                    PolygonManager polygonManager,
+                    PolylineManager polylineManager,
+                    GroundOverlayManager groundOverlayManager,
+                    Renderer.ImagesCache cache)
             throws XmlPullParserException, IOException {
-        this(map, context.getResources().openRawResource(resourceId), context, markerManager, polygonManager, polylineManager, groundOverlayManager);
+        this(map, context.getResources().openRawResource(resourceId), context, markerManager, polygonManager, polylineManager, groundOverlayManager, cache);
     }
 
     /**
@@ -116,15 +125,23 @@ public class KmlLayer extends Layer {
      * @param polygonManager polygon manager to create polygon collection from
      * @param polylineManager polyline manager to create polyline collection from
      * @param groundOverlayManager ground overlay manager to create ground overlay collection from
+     * @param cache cache to be used for fetched images
      * @throws XmlPullParserException if file cannot be parsed
      * @throws IOException if I/O error
      */
-    public KmlLayer(GoogleMap map, InputStream stream, Context context, MarkerManager markerManager, PolygonManager polygonManager, PolylineManager polylineManager, GroundOverlayManager groundOverlayManager)
+    public KmlLayer(GoogleMap map,
+                    InputStream stream,
+                    Context context,
+                    MarkerManager markerManager,
+                    PolygonManager polygonManager,
+                    PolylineManager polylineManager,
+                    GroundOverlayManager groundOverlayManager,
+                    Renderer.ImagesCache cache)
             throws XmlPullParserException, IOException {
         if (stream == null) {
             throw new IllegalArgumentException("KML InputStream cannot be null");
         }
-        KmlRenderer renderer = new KmlRenderer(map, context, markerManager, polygonManager, polylineManager, groundOverlayManager);
+        KmlRenderer renderer = new KmlRenderer(map, context, markerManager, polygonManager, polylineManager, groundOverlayManager, cache);
 
         BufferedInputStream bis = new BufferedInputStream(stream);
         bis.mark(1024);

--- a/library/src/main/java/com/google/maps/android/data/kml/KmlLayer.java
+++ b/library/src/main/java/com/google/maps/android/data/kml/KmlLayer.java
@@ -15,10 +15,12 @@
  */
 package com.google.maps.android.data.kml;
 
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.util.Log;
 
+import androidx.annotation.RawRes;
 import androidx.fragment.app.FragmentActivity;
 
 import com.google.android.gms.maps.GoogleMap;
@@ -51,13 +53,13 @@ public class KmlLayer extends Layer {
      *
      * @param map        GoogleMap object
      * @param resourceId Raw resource KML or KMZ file
-     * @param activity   Activity object
+     * @param context The Context
      * @throws XmlPullParserException if file cannot be parsed
      * @throws IOException if I/O error
      */
-    public KmlLayer(GoogleMap map, int resourceId, FragmentActivity activity)
+    public KmlLayer(GoogleMap map, int resourceId, Context context)
             throws XmlPullParserException, IOException {
-        this(map, activity.getResources().openRawResource(resourceId), activity, new MarkerManager(map), new PolygonManager(map), new PolylineManager(map), new GroundOverlayManager(map));
+        this(map, context.getResources().openRawResource(resourceId), context, new MarkerManager(map), new PolygonManager(map), new PolylineManager(map), new GroundOverlayManager(map));
     }
 
     /**
@@ -67,13 +69,13 @@ public class KmlLayer extends Layer {
      *
      * @param map    GoogleMap object
      * @param stream InputStream containing KML or KMZ file
-     * @param activity   Activity object
+     * @param context The Context
      * @throws XmlPullParserException if file cannot be parsed
      * @throws IOException if I/O error
      */
-    public KmlLayer(GoogleMap map, InputStream stream, FragmentActivity activity)
+    public KmlLayer(GoogleMap map, InputStream stream, Context context)
             throws XmlPullParserException, IOException {
-        this(map, stream, activity, new MarkerManager(map), new PolygonManager(map), new PolylineManager(map), new GroundOverlayManager(map));
+        this(map, stream, context, new MarkerManager(map), new PolygonManager(map), new PolylineManager(map), new GroundOverlayManager(map));
     }
 
     /**
@@ -86,7 +88,7 @@ public class KmlLayer extends Layer {
      *
      * @param map        GoogleMap object
      * @param resourceId Raw resource KML or KMZ file
-     * @param activity   Activity object
+     * @param context The Context
      * @param markerManager marker manager to create marker collection from
      * @param polygonManager polygon manager to create polygon collection from
      * @param polylineManager polyline manager to create polyline collection from
@@ -94,9 +96,9 @@ public class KmlLayer extends Layer {
      * @throws XmlPullParserException if file cannot be parsed
      * @throws IOException if I/O error
      */
-    public KmlLayer(GoogleMap map, int resourceId, FragmentActivity activity, MarkerManager markerManager, PolygonManager polygonManager, PolylineManager polylineManager, GroundOverlayManager groundOverlayManager)
+    public KmlLayer(GoogleMap map, @RawRes int resourceId, Context context, MarkerManager markerManager, PolygonManager polygonManager, PolylineManager polylineManager, GroundOverlayManager groundOverlayManager)
             throws XmlPullParserException, IOException {
-        this(map, activity.getResources().openRawResource(resourceId), activity, markerManager, polygonManager, polylineManager, groundOverlayManager);
+        this(map, context.getResources().openRawResource(resourceId), context, markerManager, polygonManager, polylineManager, groundOverlayManager);
     }
 
     /**
@@ -109,7 +111,7 @@ public class KmlLayer extends Layer {
      *
      * @param map    GoogleMap object
      * @param stream InputStream containing KML or KMZ file
-     * @param activity   Activity object
+     * @param context The Context
      * @param markerManager marker manager to create marker collection from
      * @param polygonManager polygon manager to create polygon collection from
      * @param polylineManager polyline manager to create polyline collection from
@@ -117,12 +119,12 @@ public class KmlLayer extends Layer {
      * @throws XmlPullParserException if file cannot be parsed
      * @throws IOException if I/O error
      */
-    public KmlLayer(GoogleMap map, InputStream stream, FragmentActivity activity, MarkerManager markerManager, PolygonManager polygonManager, PolylineManager polylineManager, GroundOverlayManager groundOverlayManager)
+    public KmlLayer(GoogleMap map, InputStream stream, Context context, MarkerManager markerManager, PolygonManager polygonManager, PolylineManager polylineManager, GroundOverlayManager groundOverlayManager)
             throws XmlPullParserException, IOException {
         if (stream == null) {
             throw new IllegalArgumentException("KML InputStream cannot be null");
         }
-        KmlRenderer renderer = new KmlRenderer(map, activity, markerManager, polygonManager, polylineManager, groundOverlayManager);
+        KmlRenderer renderer = new KmlRenderer(map, context, markerManager, polygonManager, polylineManager, groundOverlayManager);
 
         BufferedInputStream bis = new BufferedInputStream(stream);
         bis.mark(1024);

--- a/library/src/main/java/com/google/maps/android/data/kml/KmlRenderer.java
+++ b/library/src/main/java/com/google/maps/android/data/kml/KmlRenderer.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2020 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,7 @@ import android.graphics.BitmapFactory;
 import android.os.AsyncTask;
 import android.util.Log;
 
+import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 
 import com.google.android.gms.maps.GoogleMap;
@@ -67,8 +68,14 @@ public class KmlRenderer extends Renderer {
 
     private ArrayList<KmlContainer> mContainers;
 
-    /* package */ KmlRenderer(GoogleMap map, Context context, MarkerManager markerManager, PolygonManager polygonManager, PolylineManager polylineManager, GroundOverlayManager groundOverlayManager) {
-        super(map, context, markerManager, polygonManager, polylineManager, groundOverlayManager);
+    /* package */ KmlRenderer(GoogleMap map,
+                              Context context,
+                              MarkerManager markerManager,
+                              PolygonManager polygonManager,
+                              PolylineManager polylineManager,
+                              GroundOverlayManager groundOverlayManager,
+                              @Nullable ImagesCache imagesCache) {
+        super(map, context, markerManager, polygonManager, polylineManager, groundOverlayManager, imagesCache);
         mGroundOverlayUrls = new HashSet<>();
         mMarkerIconsDownloaded = false;
         mGroundOverlayImagesDownloaded = false;

--- a/library/src/main/java/com/google/maps/android/data/kml/KmlRenderer.java
+++ b/library/src/main/java/com/google/maps/android/data/kml/KmlRenderer.java
@@ -15,6 +15,7 @@
  */
 package com.google.maps.android.data.kml;
 
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.AsyncTask;
@@ -66,8 +67,8 @@ public class KmlRenderer extends Renderer {
 
     private ArrayList<KmlContainer> mContainers;
 
-    /* package */ KmlRenderer(GoogleMap map, FragmentActivity activity, MarkerManager markerManager, PolygonManager polygonManager, PolylineManager polylineManager, GroundOverlayManager groundOverlayManager) {
-        super(map, activity, markerManager, polygonManager, polylineManager, groundOverlayManager);
+    /* package */ KmlRenderer(GoogleMap map, Context context, MarkerManager markerManager, PolygonManager polygonManager, PolylineManager polylineManager, GroundOverlayManager groundOverlayManager) {
+        super(map, context, markerManager, polygonManager, polylineManager, groundOverlayManager);
         mGroundOverlayUrls = new HashSet<>();
         mMarkerIconsDownloaded = false;
         mGroundOverlayImagesDownloaded = false;

--- a/library/src/main/java/com/google/maps/android/data/kml/KmlRenderer.java
+++ b/library/src/main/java/com/google/maps/android/data/kml/KmlRenderer.java
@@ -22,7 +22,6 @@ import android.os.AsyncTask;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
-import androidx.fragment.app.FragmentActivity;
 
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.BitmapDescriptor;

--- a/library/src/test/java/com/google/maps/android/data/kml/KmlRendererTest.java
+++ b/library/src/test/java/com/google/maps/android/data/kml/KmlRendererTest.java
@@ -33,7 +33,7 @@ public class KmlRendererTest {
         KmlStyle redStyle = new KmlStyle();
         styles.put("BlueValue", blueStyle);
         styles.put("RedValue", redStyle);
-        KmlRenderer renderer = new KmlRenderer(null, null, null, null, null, null);
+        KmlRenderer renderer = new KmlRenderer(null, null, null, null, null, null, null);
         renderer.assignStyleMap(styleMap, styles);
         assertNotNull(styles.get("BlueKey"));
         assertEquals(styles.get("BlueKey"), styles.get("BlueValue"));


### PR DESCRIPTION
Updating `KmlLayer`, `KmlRenderer`, and `Renderer`, to accept a `Context` instead of a `FragmentActivity`. The former signature and solution presents a couple of issues mentioned in #629.

This change does break configuration change handling for caching images in a way that
retaining state across these changes is now handled by the caller (i.e. by passing in
an `ImagesCache` instance via `KmlLayer` constructor).

- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #629 🦕
