### PR TITLE
refactor(cluster): Default item rendering to onBeforeClusterItemRendered()

### DIFF
--- a/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
@@ -736,7 +736,10 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
     }
 
     /**
-     * Called before the marker for a ClusterItem is added to the map.
+     * Called before the marker for a ClusterItem is added to the map. The default implementation
+     * sets the marker and snippet text based on the respective item text if they are both
+     * available, otherwise it will set the title if available, and if not it will set the marker
+     * title to the item snippet text if that is available.
      *
      * The first time {@link ClusterManager#cluster()} is invoked on a set of items
      * {@link #onBeforeClusterItemRendered(ClusterItem, MarkerOptions)} will be called and
@@ -749,6 +752,14 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
      * @param markerOptions the markerOptions representing the provided item
      */
     protected void onBeforeClusterItemRendered(T item, MarkerOptions markerOptions) {
+        if (item.getTitle() != null && item.getSnippet() != null) {
+            markerOptions.title(item.getTitle());
+            markerOptions.snippet(item.getSnippet());
+        } else if (item.getTitle() != null) {
+            markerOptions.title(item.getTitle());
+        } else if (item.getSnippet() != null) {
+            markerOptions.title(item.getSnippet());
+        }
     }
 
     /**
@@ -951,14 +962,6 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
                             markerOptions.position(animateFrom);
                         } else {
                             markerOptions.position(item.getPosition());
-                        }
-                        if (!(item.getTitle() == null) && !(item.getSnippet() == null)) {
-                            markerOptions.title(item.getTitle());
-                            markerOptions.snippet(item.getSnippet());
-                        } else if (!(item.getSnippet() == null)) {
-                            markerOptions.title(item.getSnippet());
-                        } else if (!(item.getTitle() == null)) {
-                            markerOptions.title(item.getTitle());
                         }
                         onBeforeClusterItemRendered(item, markerOptions);
                         marker = mClusterManager.getMarkerCollection().addMarker(markerOptions);


### PR DESCRIPTION
As discussed in https://github.com/googlemaps/android-maps-utils/issues/630, refactor the default cluster item rendering implementation from a private method into the protected method `onBeforeClusterItemRendered()`. This allows apps that extend `DefaultClusterRenderer` to easily override the default behavior.

I also made the following style changes to the rendering code to make it easier to read (but doesn't change function):
* Change format of `!(item.getTitle() == null)` to `item.getTitle() != null`.
* Re-order 2nd and 3rd clause of IF to make it clearer that the marker title is set to the snippet if the title text isn't available and the snippet is.

Refs: 630

Fixes #630
