### PR TITLE
Update Android Gradle plugin to 3.6.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,8 @@ buildscript {
         google()
         jcenter()
     }
-
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.2'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
     }
 }
@@ -31,6 +30,10 @@ allprojects {
         google()
         jcenter()
     }
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }
 
 /**


### PR DESCRIPTION
Android Studio 3.6.2 is now available:

https://androidstudio.googleblog.com/2020/03/android-studio-362-available.html