### PR TITLE
docs: Add gradle task to generate docs.

### DIFF
--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -20,9 +20,20 @@ apply plugin: 'signing'
 archivesBaseName = 'android-maps-utils'
 group = 'com.google.maps.android'
 
+task javadoc(type: Javadoc) {
+    failOnError false
+    source = android.sourceSets.main.java.sourceFiles
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    classpath += configurations.compile
+}
+
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
 }
 
 publishing {
@@ -65,6 +76,8 @@ publishing {
             version '1.0.0'
             afterEvaluate {
                 artifact bundleReleaseAar
+                artifact sourcesJar
+                artifact javadocJar
             }
         }
     }


### PR DESCRIPTION
A couple of things:
* adds task to generate docs i.e. `./gradlew javadoc`
* uploads `sources.jar` and `javadoc.jar` whenever we publish a new version of the lib

Updating http://googlemaps.github.io/android-maps-utils/javadoc/ is not yet automated. 

Relates to #643