### PR TITLE
fix: Fix including sources in release

### DIFF
--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -29,6 +29,7 @@ task javadoc(type: Javadoc) {
 
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {


### PR DESCRIPTION
Reverts part of https://github.com/googlemaps/android-maps-utils/commit/7bbc3c7f9fb91e65264f6968f67dda17e78abc82.

Hopefully fixes #668 (?)

Also, going forward we should probably bump the demo app dependency immediately after publishing the library release artifact to potentially catch issues like this.