### PR TITLE
fix: NPE on onClusterItemUpdated

### DIFF
--- a/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
@@ -782,11 +782,11 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
         boolean changed = false;
         // Update marker text if the item text changed - same logic as adding marker in CreateMarkerTask.perform()
         if (item.getTitle() != null && item.getSnippet() != null) {
-            if (!marker.getTitle().equals(item.getTitle())) {
+            if (!item.getTitle().equals(marker.getTitle())) {
                 marker.setTitle(item.getTitle());
                 changed = true;
             }
-            if (!marker.getSnippet().equals(item.getSnippet())) {
+            if (!item.getSnippet().equals(marker.getSnippet())) {
                 marker.setSnippet(item.getSnippet());
                 changed = true;
             }


### PR DESCRIPTION
Attempt to fix NPE in onClusterItemUpdated by swapping the method invocation on the ClusterItem vs. the Marker.
This should work since a null check was performed prior to invoking methods on it.

I couldn't quite repro the crash myself (I was modifying `ClusteringDemoActivity` locally to try to repro) though.

@barbeau if you have any ideas how to repro this I'm happy to check that.

Fixes #673
