### PR TITLE
feat: Supporting Both StrokeJointType and StrokePattern in GeoJsonPol…

### DIFF
--- a/library/src/main/java/com/google/maps/android/data/geojson/GeoJsonPolygonStyle.java
+++ b/library/src/main/java/com/google/maps/android/data/geojson/GeoJsonPolygonStyle.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2020 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,10 +15,12 @@
  */
 package com.google.maps.android.data.geojson;
 
+import com.google.android.gms.maps.model.PatternItem;
 import com.google.android.gms.maps.model.PolygonOptions;
 import com.google.maps.android.data.Style;
 
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * A class that allows for GeoJsonPolygon objects to be styled and for these styles to be
@@ -104,6 +106,44 @@ public class GeoJsonPolygonStyle extends Style implements GeoJsonStyle {
     }
 
     /**
+     * Gets the stroke joint type of the GeoJsonPolygon
+     *
+     * @return stroke joint type of the GeoJsonPolygon
+     */
+    public int getStrokeJointType() {
+        return mPolygonOptions.getStrokeJointType();
+    }
+
+    /**
+     * Sets the stroke joint type of the GeoJsonPolygon
+     *
+     * @param strokeJointType stroke joint type value of the GeoJsonPolygon
+     */
+    public void setStrokeJointType(int strokeJointType) {
+        mPolygonOptions.strokeJointType(strokeJointType);
+        styleChanged();
+    }
+
+    /**
+     * Gets the stroke pattern of the GeoJsonPolygon as a list of pattern items
+     *
+     * @return stroke pattern of the GeoJsonPolygon
+     */
+    public List<PatternItem> getStrokePattern() {
+        return mPolygonOptions.getStrokePattern();
+    }
+
+    /**
+     * Sets the stroke pattern of the GeoJsonPolygon as a list of pattern items
+     *
+     * @param strokePattern stroke pattern value of the GeoJsonPolygon
+     */
+    public void setStrokePattern(List<PatternItem> strokePattern) {
+        mPolygonOptions.strokePattern(strokePattern);
+        styleChanged();
+    }
+
+    /**
      * Gets the stroke width of the GeoJsonPolygon in screen pixels
      *
      * @return stroke width of the GeoJsonPolygon
@@ -181,6 +221,8 @@ public class GeoJsonPolygonStyle extends Style implements GeoJsonStyle {
         polygonOptions.fillColor(mPolygonOptions.getFillColor());
         polygonOptions.geodesic(mPolygonOptions.isGeodesic());
         polygonOptions.strokeColor(mPolygonOptions.getStrokeColor());
+        polygonOptions.strokeJointType(mPolygonOptions.getStrokeJointType());
+        polygonOptions.strokePattern(mPolygonOptions.getStrokePattern());
         polygonOptions.strokeWidth(mPolygonOptions.getStrokeWidth());
         polygonOptions.visible(mPolygonOptions.isVisible());
         polygonOptions.zIndex(mPolygonOptions.getZIndex());
@@ -195,6 +237,8 @@ public class GeoJsonPolygonStyle extends Style implements GeoJsonStyle {
         sb.append(",\n fill color=").append(getFillColor());
         sb.append(",\n geodesic=").append(isGeodesic());
         sb.append(",\n stroke color=").append(getStrokeColor());
+        sb.append(",\n stroke joint type=").append(getStrokeJointType());
+        sb.append(",\n stroke pattern=").append(getStrokePattern());
         sb.append(",\n stroke width=").append(getStrokeWidth());
         sb.append(",\n visible=").append(isVisible());
         sb.append(",\n z index=").append(getZIndex());

--- a/library/src/test/java/com/google/maps/android/data/geojson/GeoJsonPolygonStyleTest.java
+++ b/library/src/test/java/com/google/maps/android/data/geojson/GeoJsonPolygonStyleTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2020 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,6 +15,10 @@
  */
 package com.google.maps.android.data.geojson;
 
+import com.google.android.gms.maps.model.Dot;
+import com.google.android.gms.maps.model.JointType;
+import com.google.android.gms.maps.model.PatternItem;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,10 +26,13 @@ import org.robolectric.RobolectricTestRunner;
 
 import android.graphics.Color;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
@@ -83,6 +90,23 @@ public class GeoJsonPolygonStyleTest {
     }
 
     @Test
+    public void testStrokeJointType() {
+        polygonStyle.setStrokeJointType(JointType.ROUND);
+        assertEquals(JointType.ROUND, polygonStyle.getStrokeJointType());
+        assertEquals(JointType.ROUND, polygonStyle.toPolygonOptions().getStrokeJointType());
+    }
+
+    @Test
+    public void testStrokePattern() {
+        List<PatternItem> strokePatternItems = new ArrayList<>();
+        strokePatternItems.add(new Dot());
+
+        polygonStyle.setStrokePattern(strokePatternItems);
+        assertEquals(strokePatternItems, polygonStyle.getStrokePattern());
+        assertEquals(strokePatternItems, polygonStyle.toPolygonOptions().getStrokePattern());
+    }
+
+    @Test
     public void testStrokeWidth() {
         polygonStyle.setStrokeWidth(20.0f);
         assertEquals(20.0f, polygonStyle.getStrokeWidth(), 0);
@@ -108,6 +132,8 @@ public class GeoJsonPolygonStyleTest {
         assertEquals(Color.TRANSPARENT, polygonStyle.getFillColor());
         assertFalse(polygonStyle.isGeodesic());
         assertEquals(Color.BLACK, polygonStyle.getStrokeColor());
+        assertEquals(JointType.DEFAULT, polygonStyle.getStrokeJointType());
+        assertNull(polygonStyle.getStrokePattern());
         assertEquals(10.0f, polygonStyle.getStrokeWidth(), 0);
         assertTrue(polygonStyle.isVisible());
         assertEquals(0.0f, polygonStyle.getZIndex(), 0);
@@ -119,6 +145,8 @@ public class GeoJsonPolygonStyleTest {
         assertEquals(Color.TRANSPARENT, polygonStyle.toPolygonOptions().getFillColor());
         assertFalse(polygonStyle.toPolygonOptions().isGeodesic());
         assertEquals(Color.BLACK, polygonStyle.toPolygonOptions().getStrokeColor());
+        assertEquals(JointType.DEFAULT, polygonStyle.toPolygonOptions().getStrokeJointType());
+        assertNull(polygonStyle.toPolygonOptions().getStrokePattern());
         assertEquals(10.0f, polygonStyle.toPolygonOptions().getStrokeWidth(), 0);
         assertTrue(polygonStyle.toPolygonOptions().isVisible());
         assertEquals(0.0f, polygonStyle.toPolygonOptions().getZIndex(), 0);


### PR DESCRIPTION
Hi

As commented here https://github.com/googlemaps/android-maps-utils/issues/683 
I wanted to customize the `StrokePattern` of the polygons that it is not accesible from 
`GeoJsonPolygonStyle`

just adding the necessary getters/setters 