### PR TITLE
build: Add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,13 @@
+version: 1
+update_configs:
+    - package_manager: "java:gradle"
+      directory: "./library/"
+      update_schedule: "daily"
+      commit_message:
+          prefix: "chore(deps)"
+
+    - package_manager: "java:gradle"
+      directory: "./demo/"
+      update_schedule: "daily"
+      commit_message:
+          prefix: "chore(deps)"


### PR DESCRIPTION
Adding dependabot config which checks the demo and library modules' dependencies on a daily basis. If a new version is found, a PR will be created by @dependabot.
