### PR TITLE
chore: Release 1.3.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ You can view the generated [reference docs][javadoc] for a full list of classes 
 ```groovy
 dependencies {
     // Utilities for Maps SDK for Android
-    implementation 'com.google.maps.android:android-maps-utils:1.3.0'
+    implementation 'com.google.maps.android:android-maps-utils:1.3.1'
 
     // Alternately - Utilities for Maps SDK for Android V3 BETA
-    implementation 'com.google.maps.android:android-maps-utils-v3:1.3.0'
+    implementation 'com.google.maps.android:android-maps-utils-v3:1.3.1'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ ext.projectArtifactId = { project ->
 
 allprojects {
     group = 'com.google.maps.android'
-    version = '1.3.0'
+    version = '1.3.1'
     project.ext.artifactId = rootProject.ext.projectArtifactId(project)
 }
 


### PR DESCRIPTION
Making another release as release 1.3.0 had a missing aar. See https://github.com/googlemaps/android-maps-utils/pull/724#issuecomment-631004556

I verified that the publishing workflow works just fine and I'm able to see the two .aar files in the Nexus Repository Manager. Unclear what caused the aar to be missing. To help catch & debug this in the future,I'd like to merge in #723 before this PR so that publishing logs can be accessed
(1.3.0 was released by running `./gradlew publish` locally on my machine). Once this PR is merged, I'll push a tag to kick off the publishing workflow.