### PR TITLE
docs: Call out adding manager objects for constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Click events originate in the layer-specific object that added the marker/ground
 
 ```java
 // Clustering
-ClusterManager<ClusterItem> clusterManager = // Initialize ClusterManager
+ClusterManager<ClusterItem> clusterManager = // Initialize ClusterManager - if you're using multiple maps features, use the constructor that passes in Manager objects (see next section)
 clusterManager.setOnClusterItemClickListener(item -> {
     // Listen for clicks on a cluster item here
     return false;
@@ -81,13 +81,13 @@ clusterManager.setOnClusterClickListener(item -> {
 });
 
 // GeoJson
-GeoJsonLayer geoJsonLayer = // Initialize GeoJsonLayer
+GeoJsonLayer geoJsonLayer = // Initialize GeoJsonLayer - if you're using multiple maps features, use the constructor that passes in Manager objects (see next section)
 geoJsonLayer.setOnFeatureClickListener(feature -> {
     // Listen for clicks on GeoJson features here
 });
 
 // KML
-KmlLayer kmlLayer = // Initialize KmlLayer
+KmlLayer kmlLayer = // Initialize KmlLayer - if you're using multiple maps features, use the constructor that passes in Manager objects (see next section)
 kmlLayer.setOnFeatureClickListener(feature -> {
     // Listen for clicks on KML features here
 });


### PR DESCRIPTION
Based on user feedback (https://github.com/googlemaps/android-maps-utils/issues/747), I'd like to call out the manager objects more explicitly in the README for instantiating the cluster, GeoJSON, and KML layers.