### PR TITLE
feat!: Add support for setOnInfoWindowLongClickListener() for Markers

### DIFF
--- a/library/src/main/java/com/google/maps/android/clustering/ClusterManager.java
+++ b/library/src/main/java/com/google/maps/android/clustering/ClusterManager.java
@@ -16,6 +16,9 @@
 
 package com.google.maps.android.clustering;
 
+import android.content.Context;
+import android.os.AsyncTask;
+
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.Marker;
@@ -27,9 +30,6 @@ import com.google.maps.android.clustering.algo.ScreenBasedAlgorithmAdapter;
 import com.google.maps.android.clustering.view.ClusterRenderer;
 import com.google.maps.android.clustering.view.DefaultClusterRenderer;
 import com.google.maps.android.collections.MarkerManager;
-
-import android.content.Context;
-import android.os.AsyncTask;
 
 import java.util.Collection;
 import java.util.Set;
@@ -61,7 +61,9 @@ public class ClusterManager<T extends ClusterItem> implements
 
     private OnClusterItemClickListener<T> mOnClusterItemClickListener;
     private OnClusterInfoWindowClickListener<T> mOnClusterInfoWindowClickListener;
+    private OnClusterInfoWindowLongClickListener<T> mOnClusterInfoWindowLongClickListener;
     private OnClusterItemInfoWindowClickListener<T> mOnClusterItemInfoWindowClickListener;
+    private OnClusterItemInfoWindowLongClickListener<T> mOnClusterItemInfoWindowLongClickListener;
     private OnClusterClickListener<T> mOnClusterClickListener;
 
     public ClusterManager(Context context, GoogleMap map) {
@@ -103,8 +105,10 @@ public class ClusterManager<T extends ClusterItem> implements
         mRenderer.onAdd();
         mRenderer.setOnClusterClickListener(mOnClusterClickListener);
         mRenderer.setOnClusterInfoWindowClickListener(mOnClusterInfoWindowClickListener);
+        mRenderer.setOnClusterInfoWindowLongClickListener(mOnClusterInfoWindowLongClickListener);
         mRenderer.setOnClusterItemClickListener(mOnClusterItemClickListener);
         mRenderer.setOnClusterItemInfoWindowClickListener(mOnClusterItemInfoWindowClickListener);
+        mRenderer.setOnClusterItemInfoWindowLongClickListener(mOnClusterItemInfoWindowLongClickListener);
         cluster();
     }
 
@@ -314,12 +318,21 @@ public class ClusterManager<T extends ClusterItem> implements
     }
 
     /**
-     * Sets a callback that's invoked when a Cluster is tapped. Note: For this listener to function,
+     * Sets a callback that's invoked when a Cluster info window is tapped. Note: For this listener to function,
      * the ClusterManager must be added as a info window click listener to the map.
      */
     public void setOnClusterInfoWindowClickListener(OnClusterInfoWindowClickListener<T> listener) {
         mOnClusterInfoWindowClickListener = listener;
         mRenderer.setOnClusterInfoWindowClickListener(listener);
+    }
+
+    /**
+     * Sets a callback that's invoked when a Cluster info window is long-pressed. Note: For this listener to function,
+     * the ClusterManager must be added as a info window click listener to the map.
+     */
+    public void setOnClusterInfoWindowLongClickListener(OnClusterInfoWindowLongClickListener<T> listener) {
+        mOnClusterInfoWindowLongClickListener = listener;
+        mRenderer.setOnClusterInfoWindowLongClickListener(listener);
     }
 
     /**
@@ -341,6 +354,15 @@ public class ClusterManager<T extends ClusterItem> implements
     }
 
     /**
+     * Sets a callback that's invoked when an individual ClusterItem's Info Window is long-pressed. Note: For this
+     * listener to function, the ClusterManager must be added as a info window click listener to the map.
+     */
+    public void setOnClusterItemInfoWindowLongClickListener(OnClusterItemInfoWindowLongClickListener<T> listener) {
+        mOnClusterItemInfoWindowLongClickListener = listener;
+        mRenderer.setOnClusterItemInfoWindowLongClickListener(listener);
+    }
+
+    /**
      * Called when a Cluster is clicked.
      */
     public interface OnClusterClickListener<T extends ClusterItem> {
@@ -357,6 +379,13 @@ public class ClusterManager<T extends ClusterItem> implements
      */
     public interface OnClusterInfoWindowClickListener<T extends ClusterItem> {
         void onClusterInfoWindowClick(Cluster<T> cluster);
+    }
+
+    /**
+     * Called when a Cluster's Info Window is long clicked.
+     */
+    public interface OnClusterInfoWindowLongClickListener<T extends ClusterItem> {
+        void onClusterInfoWindowLongClick(Cluster<T> cluster);
     }
 
     /**
@@ -381,5 +410,12 @@ public class ClusterManager<T extends ClusterItem> implements
      */
     public interface OnClusterItemInfoWindowClickListener<T extends ClusterItem> {
         void onClusterItemInfoWindowClick(T item);
+    }
+
+    /**
+     * Called when an individual ClusterItem's Info Window is long clicked.
+     */
+    public interface OnClusterItemInfoWindowLongClickListener<T extends ClusterItem> {
+        void onClusterItemInfoWindowLongClick(T item);
     }
 }

--- a/library/src/main/java/com/google/maps/android/clustering/view/ClusterRenderer.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/ClusterRenderer.java
@@ -38,9 +38,13 @@ public interface ClusterRenderer<T extends ClusterItem> {
 
     void setOnClusterInfoWindowClickListener(ClusterManager.OnClusterInfoWindowClickListener<T> listener);
 
+    void setOnClusterInfoWindowLongClickListener(ClusterManager.OnClusterInfoWindowLongClickListener<T> listener);
+
     void setOnClusterItemClickListener(ClusterManager.OnClusterItemClickListener<T> listener);
 
     void setOnClusterItemInfoWindowClickListener(ClusterManager.OnClusterItemInfoWindowClickListener<T> listener);
+
+    void setOnClusterItemInfoWindowLongClickListener(ClusterManager.OnClusterItemInfoWindowLongClickListener<T> listener);
 
     /**
      * Called to set animation on or off

--- a/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
@@ -123,8 +123,10 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
 
     private ClusterManager.OnClusterClickListener<T> mClickListener;
     private ClusterManager.OnClusterInfoWindowClickListener<T> mInfoWindowClickListener;
+    private ClusterManager.OnClusterInfoWindowLongClickListener<T> mInfoWindowLongClickListener;
     private ClusterManager.OnClusterItemClickListener<T> mItemClickListener;
     private ClusterManager.OnClusterItemInfoWindowClickListener<T> mItemInfoWindowClickListener;
+    private ClusterManager.OnClusterItemInfoWindowLongClickListener<T> mItemInfoWindowLongClickListener;
 
     public DefaultClusterRenderer(Context context, GoogleMap map, ClusterManager<T> clusterManager) {
         mMap = map;
@@ -155,6 +157,15 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
             }
         });
 
+        mClusterManager.getMarkerCollection().setOnInfoWindowLongClickListener(new GoogleMap.OnInfoWindowLongClickListener() {
+            @Override
+            public void onInfoWindowLongClick(Marker marker) {
+                if (mItemInfoWindowLongClickListener != null) {
+                    mItemInfoWindowLongClickListener.onClusterItemInfoWindowLongClick(mMarkerCache.get(marker));
+                }
+            }
+        });
+
         mClusterManager.getClusterMarkerCollection().setOnMarkerClickListener(new GoogleMap.OnMarkerClickListener() {
             @Override
             public boolean onMarkerClick(Marker marker) {
@@ -170,14 +181,25 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
                 }
             }
         });
+
+        mClusterManager.getClusterMarkerCollection().setOnInfoWindowLongClickListener(new GoogleMap.OnInfoWindowLongClickListener() {
+            @Override
+            public void onInfoWindowLongClick(Marker marker) {
+                if (mInfoWindowLongClickListener != null) {
+                    mInfoWindowLongClickListener.onClusterInfoWindowLongClick(mClusterMarkerCache.get(marker));
+                }
+            }
+        });
     }
 
     @Override
     public void onRemove() {
         mClusterManager.getMarkerCollection().setOnMarkerClickListener(null);
         mClusterManager.getMarkerCollection().setOnInfoWindowClickListener(null);
+        mClusterManager.getMarkerCollection().setOnInfoWindowLongClickListener(null);
         mClusterManager.getClusterMarkerCollection().setOnMarkerClickListener(null);
         mClusterManager.getClusterMarkerCollection().setOnInfoWindowClickListener(null);
+        mClusterManager.getClusterMarkerCollection().setOnInfoWindowLongClickListener(null);
     }
 
     private LayerDrawable makeClusterBackground() {
@@ -481,6 +503,11 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
     }
 
     @Override
+    public void setOnClusterInfoWindowLongClickListener(ClusterManager.OnClusterInfoWindowLongClickListener<T> listener) {
+        mInfoWindowLongClickListener = listener;
+    }
+
+    @Override
     public void setOnClusterItemClickListener(ClusterManager.OnClusterItemClickListener<T> listener) {
         mItemClickListener = listener;
     }
@@ -488,6 +515,11 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
     @Override
     public void setOnClusterItemInfoWindowClickListener(ClusterManager.OnClusterItemInfoWindowClickListener<T> listener) {
         mItemInfoWindowClickListener = listener;
+    }
+
+    @Override
+    public void setOnClusterItemInfoWindowLongClickListener(ClusterManager.OnClusterItemInfoWindowLongClickListener<T> listener) {
+        mItemInfoWindowLongClickListener = listener;
     }
 
     @Override

--- a/library/src/main/java/com/google/maps/android/collections/MarkerManager.java
+++ b/library/src/main/java/com/google/maps/android/collections/MarkerManager.java
@@ -33,7 +33,8 @@ public class MarkerManager extends MapObjectManager<Marker, MarkerManager.Collec
         GoogleMap.OnInfoWindowClickListener,
         GoogleMap.OnMarkerClickListener,
         GoogleMap.OnMarkerDragListener,
-        GoogleMap.InfoWindowAdapter {
+        GoogleMap.InfoWindowAdapter,
+        GoogleMap.OnInfoWindowLongClickListener {
 
     public MarkerManager(GoogleMap map) {
         super(map);
@@ -43,6 +44,7 @@ public class MarkerManager extends MapObjectManager<Marker, MarkerManager.Collec
     void setListenersOnUiThread() {
         if (mMap != null) {
             mMap.setOnInfoWindowClickListener(this);
+            mMap.setOnInfoWindowLongClickListener(this);
             mMap.setOnMarkerClickListener(this);
             mMap.setOnMarkerDragListener(this);
             mMap.setInfoWindowAdapter(this);
@@ -76,6 +78,14 @@ public class MarkerManager extends MapObjectManager<Marker, MarkerManager.Collec
         Collection collection = mAllObjects.get(marker);
         if (collection != null && collection.mInfoWindowClickListener != null) {
             collection.mInfoWindowClickListener.onInfoWindowClick(marker);
+        }
+    }
+
+    @Override
+    public void onInfoWindowLongClick(Marker marker) {
+        Collection collection = mAllObjects.get(marker);
+        if (collection != null && collection.mInfoWindowLongClickListener != null) {
+            collection.mInfoWindowLongClickListener.onInfoWindowLongClick(marker);
         }
     }
 
@@ -119,6 +129,7 @@ public class MarkerManager extends MapObjectManager<Marker, MarkerManager.Collec
 
     public class Collection extends MapObjectManager.Collection {
         private GoogleMap.OnInfoWindowClickListener mInfoWindowClickListener;
+        private GoogleMap.OnInfoWindowLongClickListener mInfoWindowLongClickListener;
         private GoogleMap.OnMarkerClickListener mMarkerClickListener;
         private GoogleMap.OnMarkerDragListener mMarkerDragListener;
         private GoogleMap.InfoWindowAdapter mInfoWindowAdapter;
@@ -166,6 +177,10 @@ public class MarkerManager extends MapObjectManager<Marker, MarkerManager.Collec
 
         public void setOnInfoWindowClickListener(GoogleMap.OnInfoWindowClickListener infoWindowClickListener) {
             mInfoWindowClickListener = infoWindowClickListener;
+        }
+
+        public void setOnInfoWindowLongClickListener(GoogleMap.OnInfoWindowLongClickListener infoWindowLongClickListener) {
+            mInfoWindowLongClickListener = infoWindowLongClickListener;
         }
 
         public void setOnMarkerClickListener(GoogleMap.OnMarkerClickListener markerClickListener) {


### PR DESCRIPTION
As mentioned in #750, we currently support clicking on info windows for markers in the library, but not long clicking. This PR implements long clicking as well.

BREAKING CHANGE: Note that this could be considered a breaking change because `ClusterRenderer` is a `public interface` and may be used outside of the library if apps implemented their own renderer. Also, if apps were doing `map.setOnInfoWindowLongClickListener()` on their own this implementation will break that behavior and force them to use the collection info window long click listener, similar to how info window click listeners are currently handled (see the [Migration Guide](https://github.com/googlemaps/android-maps-utils#adding-a-custom-info-window)).

I've tested this in the demo app with:

~~~
        mClusterManager.getMarkerCollection().setOnInfoWindowLongClickListener(marker ->
                Toast.makeText(ClusteringDemoActivity.this,
                        "Info window long pressed.",
                        Toast.LENGTH_SHORT).show());
~~~

...and it works, although I can't add the above code in a PR until this is released and we bump the demo app version.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Will this cause breaking changes to existing Java or Kotlin integrations? If so, ensure the commit has a `BREAKING CHANGE` footer so when this change is integrated a major version update is triggered. See: https://www.conventionalcommits.org/en/v1.0.0/

Fixes #750 🦕