### PR TITLE
fix: Respect setMinClusterSize() correctly when clustering

### DIFF
--- a/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
@@ -256,10 +256,28 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
         return BUCKETS[BUCKETS.length - 1];
     }
 
+    /**
+     * Gets the minimum cluster size used to render clusters. For example, if "4" is returned,
+     * then for any clusters of size 3 or less the items will be rendered as individual markers
+     * instead of as a single cluster marker.
+     *
+     * @return the minimum cluster size used to render clusters. For example, if "4" is returned,
+     * then for any clusters of size 3 or less the items will be rendered as individual markers
+     * instead of as a single cluster marker.
+     */
     public int getMinClusterSize() {
         return mMinClusterSize;
     }
 
+    /**
+     * Sets the minimum cluster size used to render clusters. For example, if "4" is provided,
+     * then for any clusters of size 3 or less the items will be rendered as individual markers
+     * instead of as a single cluster marker.
+     *
+     * @param minClusterSize the minimum cluster size used to render clusters. For example, if "4"
+     *                       is provided, then for any clusters of size 3 or less the items will be
+     *                       rendered as individual markers instead of as a single cluster marker.
+     */
     public void setMinClusterSize(int minClusterSize) {
         mMinClusterSize = minClusterSize;
     }
@@ -328,9 +346,12 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
 
     /**
      * Determine whether the cluster should be rendered as individual markers or a cluster.
+     * @param cluster cluster to examine for rendering
+     * @return true if the provided cluster should be rendered as a single marker on the map, false
+     * if the items within this cluster should be rendered as individual markers instead.
      */
     protected boolean shouldRenderAsCluster(@NonNull Cluster<T> cluster) {
-        return cluster.getSize() > mMinClusterSize;
+        return cluster.getSize() >= mMinClusterSize;
     }
 
     /**


### PR DESCRIPTION
Previously, when `setMinClusterSize(4)` was called, clusters of size 4 would still be rendered as individual markers instead of clusters (only clusters of size 5 or more would be rendered as individual cluster markers).

With this change, now `setMinClusterSize(4)` will result in clusters of size 4 being rendered as clusters instead of individual markers.

Also add more Javadocs.

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Will this cause breaking changes to existing Java or Kotlin integrations? If so, ensure the commit has a `BREAKING CHANGE` footer so when this change is integrated a major version update is triggered. See: https://www.conventionalcommits.org/en/v1.0.0/

Fixes #696 🦕
