### PR TITLE
fix: algorithm concurrency

### DIFF
--- a/library/src/main/java/com/google/maps/android/clustering/ClusterManager.java
+++ b/library/src/main/java/com/google/maps/android/clustering/ClusterManager.java
@@ -123,7 +123,7 @@ public class ClusterManager<T extends ClusterItem> implements
     public void setAlgorithm(ScreenBasedAlgorithm<T> algorithm) {
         algorithm.lock();
         try {
-            Algorithm<T> oldAlgorithm = getAlgorithm();
+            final Algorithm<T> oldAlgorithm = getAlgorithm();
             mAlgorithm = algorithm;
 
             if (oldAlgorithm != null) {
@@ -162,7 +162,7 @@ public class ClusterManager<T extends ClusterItem> implements
      * {@link #cluster()} for the map to be cleared.
      */
     public void clearItems() {
-        Algorithm<T> algorithm = getAlgorithm();
+        final Algorithm<T> algorithm = getAlgorithm();
         algorithm.lock();
         try {
             algorithm.clearItems();
@@ -178,7 +178,7 @@ public class ClusterManager<T extends ClusterItem> implements
      * @return true if the cluster manager contents changed as a result of the call
      */
     public boolean addItems(Collection<T> items) {
-        Algorithm<T> algorithm = getAlgorithm();
+        final Algorithm<T> algorithm = getAlgorithm();
         algorithm.lock();
         try {
             return algorithm.addItems(items);
@@ -194,7 +194,7 @@ public class ClusterManager<T extends ClusterItem> implements
      * @return true if the cluster manager contents changed as a result of the call
      */
     public boolean addItem(T myItem) {
-        Algorithm<T> algorithm = getAlgorithm();
+        final Algorithm<T> algorithm = getAlgorithm();
         algorithm.lock();
         try {
             return algorithm.addItem(myItem);
@@ -210,7 +210,7 @@ public class ClusterManager<T extends ClusterItem> implements
      * @return true if the cluster manager contents changed as a result of the call
      */
     public boolean removeItems(Collection<T> items) {
-        Algorithm<T> algorithm = getAlgorithm();
+        final Algorithm<T> algorithm = getAlgorithm();
         algorithm.lock();
         try {
             return algorithm.removeItems(items);
@@ -226,7 +226,7 @@ public class ClusterManager<T extends ClusterItem> implements
      * @return true if the item was removed from the cluster manager as a result of this call
      */
     public boolean removeItem(T item) {
-        Algorithm<T> algorithm = getAlgorithm();
+        final Algorithm<T> algorithm = getAlgorithm();
         algorithm.lock();
         try {
             return algorithm.removeItem(item);
@@ -243,7 +243,7 @@ public class ClusterManager<T extends ClusterItem> implements
      * contained within the cluster manager and the cluster manager contents are unchanged
      */
     public boolean updateItem(T item) {
-        Algorithm<T> algorithm = getAlgorithm();
+        final Algorithm<T> algorithm = getAlgorithm();
         algorithm.lock();
         try {
             return algorithm.updateItem(item);
@@ -306,7 +306,7 @@ public class ClusterManager<T extends ClusterItem> implements
     private class ClusterTask extends AsyncTask<Float, Void, Set<? extends Cluster<T>>> {
         @Override
         protected Set<? extends Cluster<T>> doInBackground(Float... zoom) {
-            Algorithm<T> algorithm = getAlgorithm();
+            final Algorithm<T> algorithm = getAlgorithm();
             algorithm.lock();
             try {
                 return algorithm.getClusters(zoom[0]);

--- a/library/src/main/java/com/google/maps/android/clustering/ClusterManager.java
+++ b/library/src/main/java/com/google/maps/android/clustering/ClusterManager.java
@@ -123,11 +123,17 @@ public class ClusterManager<T extends ClusterItem> implements
     public void setAlgorithm(ScreenBasedAlgorithm<T> algorithm) {
         algorithm.lock();
         try {
-            if (mAlgorithm != null) {
-                algorithm.addItems(mAlgorithm.getItems());
-            }
-
+            Algorithm<T> oldAlgorithm = getAlgorithm();
             mAlgorithm = algorithm;
+
+            if (oldAlgorithm != null) {
+                oldAlgorithm.lock();
+                try {
+                    algorithm.addItems(oldAlgorithm.getItems());
+                } finally {
+                    oldAlgorithm.unlock();
+                }
+            }
         } finally {
             algorithm.unlock();
         }
@@ -156,11 +162,12 @@ public class ClusterManager<T extends ClusterItem> implements
      * {@link #cluster()} for the map to be cleared.
      */
     public void clearItems() {
-        mAlgorithm.lock();
+        Algorithm<T> algorithm = getAlgorithm();
+        algorithm.lock();
         try {
-            mAlgorithm.clearItems();
+            algorithm.clearItems();
         } finally {
-            mAlgorithm.unlock();
+            algorithm.unlock();
         }
     }
 
@@ -171,11 +178,12 @@ public class ClusterManager<T extends ClusterItem> implements
      * @return true if the cluster manager contents changed as a result of the call
      */
     public boolean addItems(Collection<T> items) {
-        mAlgorithm.lock();
+        Algorithm<T> algorithm = getAlgorithm();
+        algorithm.lock();
         try {
-            return mAlgorithm.addItems(items);
+            return algorithm.addItems(items);
         } finally {
-            mAlgorithm.unlock();
+            algorithm.unlock();
         }
     }
 
@@ -186,11 +194,12 @@ public class ClusterManager<T extends ClusterItem> implements
      * @return true if the cluster manager contents changed as a result of the call
      */
     public boolean addItem(T myItem) {
-        mAlgorithm.lock();
+        Algorithm<T> algorithm = getAlgorithm();
+        algorithm.lock();
         try {
-            return mAlgorithm.addItem(myItem);
+            return algorithm.addItem(myItem);
         } finally {
-            mAlgorithm.unlock();
+            algorithm.unlock();
         }
     }
 
@@ -201,11 +210,12 @@ public class ClusterManager<T extends ClusterItem> implements
      * @return true if the cluster manager contents changed as a result of the call
      */
     public boolean removeItems(Collection<T> items) {
-        mAlgorithm.lock();
+        Algorithm<T> algorithm = getAlgorithm();
+        algorithm.lock();
         try {
-            return mAlgorithm.removeItems(items);
+            return algorithm.removeItems(items);
         } finally {
-            mAlgorithm.unlock();
+            algorithm.unlock();
         }
     }
 
@@ -216,11 +226,12 @@ public class ClusterManager<T extends ClusterItem> implements
      * @return true if the item was removed from the cluster manager as a result of this call
      */
     public boolean removeItem(T item) {
-        mAlgorithm.lock();
+        Algorithm<T> algorithm = getAlgorithm();
+        algorithm.lock();
         try {
-            return mAlgorithm.removeItem(item);
+            return algorithm.removeItem(item);
         } finally {
-            mAlgorithm.unlock();
+            algorithm.unlock();
         }
     }
 
@@ -232,11 +243,12 @@ public class ClusterManager<T extends ClusterItem> implements
      * contained within the cluster manager and the cluster manager contents are unchanged
      */
     public boolean updateItem(T item) {
-        mAlgorithm.lock();
+        Algorithm<T> algorithm = getAlgorithm();
+        algorithm.lock();
         try {
-            return mAlgorithm.updateItem(item);
+            return algorithm.updateItem(item);
         } finally {
-            mAlgorithm.unlock();
+            algorithm.unlock();
         }
     }
 
@@ -294,11 +306,12 @@ public class ClusterManager<T extends ClusterItem> implements
     private class ClusterTask extends AsyncTask<Float, Void, Set<? extends Cluster<T>>> {
         @Override
         protected Set<? extends Cluster<T>> doInBackground(Float... zoom) {
-            mAlgorithm.lock();
+            Algorithm<T> algorithm = getAlgorithm();
+            algorithm.lock();
             try {
-                return mAlgorithm.getClusters(zoom[0]);
+                return algorithm.getClusters(zoom[0]);
             } finally {
-                mAlgorithm.unlock();
+                algorithm.unlock();
             }
         }
 

--- a/library/src/main/java/com/google/maps/android/clustering/algo/PreCachingAlgorithmDecorator.java
+++ b/library/src/main/java/com/google/maps/android/clustering/algo/PreCachingAlgorithmDecorator.java
@@ -104,11 +104,9 @@ public class PreCachingAlgorithmDecorator<T extends ClusterItem> extends Abstrac
         Set<? extends Cluster<T>> results = getClustersInternal(discreteZoom);
         // TODO: Check if requests are already in-flight.
         if (mCache.get(discreteZoom + 1) == null) {
-            // It seems this cannot use a thread pool due to thread locking issues (#660)
             mExecutor.execute(new PrecacheRunnable(discreteZoom + 1));
         }
         if (mCache.get(discreteZoom - 1) == null) {
-            // It seems this cannot use a thread pool due to thread locking issues (#660)
             mExecutor.execute(new PrecacheRunnable(discreteZoom - 1));
         }
         return results;

--- a/library/src/main/java/com/google/maps/android/clustering/algo/PreCachingAlgorithmDecorator.java
+++ b/library/src/main/java/com/google/maps/android/clustering/algo/PreCachingAlgorithmDecorator.java
@@ -23,6 +23,8 @@ import com.google.maps.android.clustering.ClusterItem;
 
 import java.util.Collection;
 import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -35,6 +37,7 @@ public class PreCachingAlgorithmDecorator<T extends ClusterItem> extends Abstrac
     // TODO: evaluate maxSize parameter for LruCache.
     private final LruCache<Integer, Set<? extends Cluster<T>>> mCache = new LruCache<Integer, Set<? extends Cluster<T>>>(5);
     private final ReadWriteLock mCacheLock = new ReentrantReadWriteLock();
+    private final Executor mExecutor = Executors.newCachedThreadPool();
 
     public PreCachingAlgorithmDecorator(Algorithm<T> algorithm) {
         mAlgorithm = algorithm;
@@ -102,11 +105,11 @@ public class PreCachingAlgorithmDecorator<T extends ClusterItem> extends Abstrac
         // TODO: Check if requests are already in-flight.
         if (mCache.get(discreteZoom + 1) == null) {
             // It seems this cannot use a thread pool due to thread locking issues (#660)
-            new Thread(new PrecacheRunnable(discreteZoom + 1)).start();
+            mExecutor.execute(new PrecacheRunnable(discreteZoom + 1));
         }
         if (mCache.get(discreteZoom - 1) == null) {
             // It seems this cannot use a thread pool due to thread locking issues (#660)
-            new Thread(new PrecacheRunnable(discreteZoom - 1)).start();
+            mExecutor.execute(new PrecacheRunnable(discreteZoom - 1));
         }
         return results;
     }

--- a/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
@@ -334,7 +334,6 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
             });
             renderTask.setProjection(projection);
             renderTask.setMapZoom(mMap.getCameraPosition().zoom);
-            // It seems this cannot use a thread pool due to thread locking issues (#660)
             mExecutor.execute(renderTask);
         }
 

--- a/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
@@ -66,6 +66,8 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -79,6 +81,7 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
     private final ClusterManager<T> mClusterManager;
     private final float mDensity;
     private boolean mAnimate;
+    private final Executor mExecutor = Executors.newSingleThreadExecutor();
 
     private static final int[] BUCKETS = {10, 20, 50, 100, 200, 500, 1000};
     private ShapeDrawable mColoredCircleBackground;
@@ -332,7 +335,7 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
             renderTask.setProjection(projection);
             renderTask.setMapZoom(mMap.getCameraPosition().zoom);
             // It seems this cannot use a thread pool due to thread locking issues (#660)
-            new Thread(renderTask).start();
+            mExecutor.execute(renderTask);
         }
 
         public void queue(Set<? extends Cluster<T>> clusters) {


### PR DESCRIPTION
Lock and unlock a local algorithm reference. Ensure methods operate on the same algorithm reference during lock, operation, and unlock. Ensure algorithm reference is not replaced while in use.

This crash is caused by calling `ClusterManager.setAlgorithm()` immediately after `ClusterManager.cluster()` such that the `mAlgorithm` reference is changed in the middle of the background cluster task. So `mAlgorithm.lock()` and `mAlgorithm.unlock()` are actually referencing first the old and then the new algorithm. The thread that called `setAlgorithm()` is the one that locks the algorithm and the `AsyncTask` background thread is the one that attempts to unlock it, resulting in the crash.

This bug was introduced in https://github.com/googlemaps/android-maps-utils/pull/506 when the algorithm lock was moved from the `ClusterManager` to the `Algorithm`, which allows the algorithm to be accessed by a `ViewModel`, outside the `ClusterManager`, which can be recreated as part of the view layer.

Also restores https://github.com/googlemaps/android-maps-utils/pull/601 to use thread pools, since this wasn't the cause for this bug.

Fixes https://github.com/googlemaps/android-maps-utils/issues/660 🦕
