### PR TITLE
chore: Optimize computeLength() measurement

### DIFF
--- a/library/src/main/java/com/google/maps/android/SphericalUtil.java
+++ b/library/src/main/java/com/google/maps/android/SphericalUtil.java
@@ -191,10 +191,10 @@ public class SphericalUtil {
         LatLng prev = null;
         for (LatLng point : path) {
             if (prev != null) {
-                double prevLat = toRadians(prev.getLat());
-                double prevLng = toRadians(prev.getLng());
-                double lat = toRadians(point.getLat());
-                double lng = toRadians(point.getLng());
+                double prevLat = toRadians(prev.latitude);
+                double prevLng = toRadians(prev.longitude);
+                double lat = toRadians(point.latitude);
+                double lng = toRadians(point.longitude);
                 length += distanceRadians(prevLat, prevLng, lat, lng);
             }
             prev = point;

--- a/library/src/main/java/com/google/maps/android/SphericalUtil.java
+++ b/library/src/main/java/com/google/maps/android/SphericalUtil.java
@@ -188,15 +188,16 @@ public class SphericalUtil {
             return 0;
         }
         double length = 0;
-        LatLng prev = path.get(0);
-        double prevLat = toRadians(prev.latitude);
-        double prevLng = toRadians(prev.longitude);
+        LatLng prev = null;
         for (LatLng point : path) {
-            double lat = toRadians(point.latitude);
-            double lng = toRadians(point.longitude);
-            length += distanceRadians(prevLat, prevLng, lat, lng);
-            prevLat = lat;
-            prevLng = lng;
+            if (prev != null) {
+                double prevLat = toRadians(prev.getLat());
+                double prevLng = toRadians(prev.getLng());
+                double lat = toRadians(point.getLat());
+                double lng = toRadians(point.getLng());
+                length += distanceRadians(prevLat, prevLng, lat, lng);
+            }
+            prev = point;
         }
         return length * EARTH_RADIUS;
     }


### PR DESCRIPTION
The first step of the path iteration and the initialized value of the 'prev' point are the same, their distance is zero, ie it does not cause an error, but its calculation is unnecessary