### PR TITLE
feat: Make GeoJsonParser fully public

### DIFF
--- a/library/src/main/java/com/google/maps/android/data/geojson/GeoJsonParser.java
+++ b/library/src/main/java/com/google/maps/android/data/geojson/GeoJsonParser.java
@@ -105,7 +105,7 @@ public class GeoJsonParser {
      *
      * @param geoJsonFile GeoJSON file to parse
      */
-    /* package */ GeoJsonParser(JSONObject geoJsonFile) {
+    public GeoJsonParser(JSONObject geoJsonFile) {
         mGeoJsonFile = geoJsonFile;
         mGeoJsonFeatures = new ArrayList<>();
         mBoundingBox = null;
@@ -169,7 +169,10 @@ public class GeoJsonParser {
 
     /**
      * Parses a single GeoJSON geometry object containing a coordinates array or a geometries array
-     * if it has type GeometryCollection
+     * if it has type GeometryCollection. FeatureCollections, styles, bounding boxes, and properties
+     * are not processed by this method. If you want to parse GeoJSON including FeatureCollections,
+     * styles, bounding boxes, and properties into an array of {@link GeoJsonFeature}s then
+     * instantiate {@link GeoJsonParser} and call {@link GeoJsonParser#getFeatures()}.
      *
      * @param geoJsonGeometry geometry object to parse
      * @return Geometry object
@@ -503,7 +506,7 @@ public class GeoJsonParser {
      *
      * @return array of GeoJsonFeatures
      */
-    /* package */ ArrayList<GeoJsonFeature> getFeatures() {
+    public ArrayList<GeoJsonFeature> getFeatures() {
         return mGeoJsonFeatures;
     }
 
@@ -515,7 +518,7 @@ public class GeoJsonParser {
      * @return LatLngBounds object containing bounding box of FeatureCollection, null if no bounding
      * box
      */
-    /* package */ LatLngBounds getBoundingBox() {
+    public LatLngBounds getBoundingBox() {
         return mBoundingBox;
     }
 


### PR DESCRIPTION
In https://github.com/googlemaps/android-maps-utils/pull/492 the static `GeoJsonParser.parseGeometry()` method was made public based on requests from the community to be able to parse basic geometry objects.

However, as https://github.com/googlemaps/android-maps-utils/issues/785 points out this method ignores FeatureCollections and also doesn't handle styles, bounding boxes, and properties.

This patch makes the `GeoJsonParser` contructor and two getter methods (`getFeatures()` and `getBoundingBox()`) public so developers can use the `GeoJsonParser` in the same way that it's used internally within the library (instantiating it) without needing to instantiate a separate `GeoJsonLayer`.

Better Javadocs have also been added to `parseGeometry()` to explain how it can be used.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Will this cause breaking changes to existing Java or Kotlin integrations? If so, ensure the commit has a `BREAKING CHANGE` footer so when this change is integrated a major version update is triggered. See: https://www.conventionalcommits.org/en/v1.0.0/

Closes #785 🦕
