### PR TITLE
fix: Bump Gradle/plugin to 6.5/4.0.2, replace jacoco dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         google()
         jcenter()
         maven {
-            url "https://plugins.gradle.org/m2/"
+            url 'https://plugins.gradle.org/m2/'
         }
     }
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -18,10 +18,13 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
-        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
+        classpath 'com.android.tools.build:gradle:4.0.2'
+        classpath 'com.hiya:jacoco-android:0.2'
     }
 }
 
@@ -121,13 +124,13 @@ subprojects { project ->
     if (project.ext.artifactId == null) return
 
     apply plugin: 'com.android.library'
-    apply plugin: 'jacoco-android'
+    apply plugin: 'com.hiya.jacoco-android'
     apply plugin: 'maven-publish'
     apply plugin: 'signing'
 
     // Code coverage
     jacoco {
-        toolVersion = "0.8.5"
+        toolVersion = "0.2"
     }
 
     tasks.withType(Test) {

--- a/build.gradle
+++ b/build.gradle
@@ -130,7 +130,7 @@ subprojects { project ->
 
     // Code coverage
     jacoco {
-        toolVersion = "0.2"
+        toolVersion = "0.8.4"
     }
 
     tasks.withType(Test) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Nov 02 14:06:20 EST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
As mentioned in https://github.com/googlemaps/android-maps-utils/issues/794#issuecomment-713009571, to get Android Gradle Plugin 4.x to work we need to depend on a fork of the `jacoco-android` project. 

Here's the issue in the main `jacoco-android` project:
https://github.com/arturdm/jacoco-android-gradle-plugin/pull/75.

If a new release that includes the fix from that PR is released, we can go back to depending on the main project.

An aside - I tested `classpath 'com.android.tools.build:gradle:4.1.0'` as well, but got a different error that I believe is an Android Gradle Plugin issue - I'll open a separate issue to track that (**EDIT** Opened at https://github.com/googlemaps/android-maps-utils/issues/800).

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Will this cause breaking changes to existing Java or Kotlin integrations? If so, ensure the commit has a `BREAKING CHANGE` footer so when this change is integrated a major version update is triggered. See: https://www.conventionalcommits.org/en/v1.0.0/

Fixes #794 🦕
