### PR TITLE
fix: Fix incorrectly named secret keys.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,14 +39,15 @@ jobs:
 
         echo "Build and publish"
         sed -i -e "s,sonatypeUsername=,sonatypeUsername=$SONATYPE_USERNAME,g" gradle.properties
-        sed -i -e "s,sonatypePassword=,sonatypePassword=$SONATYPE_PASSWORD,g" gradle.properties
+        SONATYPE_PASSWORD_ESCAPED=$(printf '%s\n' "$SONATYPE_PASSWORD" | sed -e 's/[\/&]/\\&/g')
+        sed -i -e "s,sonatypePassword=,sonatypePassword=$SONATYPE_PASSWORD_ESCAPED,g" gradle.properties
         sed -i -e "s,signing.keyId=,signing.keyId=$GPG_KEY_ID,g" gradle.properties
         sed -i -e "s,signing.password=,signing.password=$GPG_PASSWORD,g" gradle.properties
         sed -i -e "s,signing.secretKeyRingFile=,signing.secretKeyRingFile=$GITHUB_WORKSPACE/release.gpg,g" gradle.properties
-        ./gradlew build publish --debug --stacktrace
+        ./gradlew build publish --stacktrace
       env:
         GPG_KEY_ARMOR: "${{ secrets.SYNCED_GPG_KEY_ARMOR }}"
         GPG_KEY_ID: ${{ secrets.SYNCED_GPG_KEY_ID }}
         GPG_PASSWORD: ${{ secrets.SYNCED_GPG_KEY_PASSWORD }}
-        SONATYPE_PASSWORD: ${{ secrets.SYNCED_SONATYPE_PASSWORD }}
+        SONATYPE_PASSWORD: '${{ secrets.SYNCED_SONATYPE_PASSWORD }}'
         SONATYPE_USERNAME: ${{ secrets.SYNCED_SONATYPE_USERNAME }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,7 @@ on:
       - '*'
   repository_dispatch:
     types: [publish]
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -47,5 +48,5 @@ jobs:
         GPG_KEY_ARMOR: "${{ secrets.SYNCED_GPG_KEY_ARMOR }}"
         GPG_KEY_ID: ${{ secrets.SYNCED_GPG_KEY_ID }}
         GPG_PASSWORD: ${{ secrets.SYNCED_GPG_KEY_PASSWORD }}
-        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-        SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+        SONATYPE_PASSWORD: ${{ secrets.SYNCED_SONATYPE_PASSWORD }}
+        SONATYPE_USERNAME: ${{ secrets.SYNCED_SONATYPE_USERNAME }}


### PR DESCRIPTION
Keys should have a prefix of `SYNCED_`. This is likely why the publishing workflow was resulting in a 401.

Fixes #763 🦕
