### PR TITLE
fix(KmlStyle): Fix parsing outline tag when its declared but value is '0' 

### DIFF
--- a/library/src/main/java/com/google/maps/android/data/kml/KmlStyle.java
+++ b/library/src/main/java/com/google/maps/android/data/kml/KmlStyle.java
@@ -417,14 +417,18 @@ public class KmlStyle extends Style {
      */
     private static PolygonOptions createPolygonOptions(PolygonOptions originalPolygonOption,
                                                        boolean isFill, boolean isOutline) {
+        float originalWidth = 0.0f;
         PolygonOptions polygonOptions = new PolygonOptions();
         if (isFill) {
             polygonOptions.fillColor(originalPolygonOption.getFillColor());
         }
+               
         if (isOutline) {
             polygonOptions.strokeColor(originalPolygonOption.getStrokeColor());
-            polygonOptions.strokeWidth(originalPolygonOption.getStrokeWidth());
+            originalWidth = originalPolygonOption.getStrokeWidth();
         }
+        polygonOptions.strokeWidth(originalWidth);
+        
         polygonOptions.clickable(originalPolygonOption.isClickable());
         return polygonOptions;
     }


### PR DESCRIPTION
If the KML contains `<outline>0</outline>` the parser still believes there is a border on each polygon

before the commit:
![321](https://user-images.githubusercontent.com/12833390/111363610-ee886800-8698-11eb-861f-7d9436538c3a.png)

after the commit:
![123](https://user-images.githubusercontent.com/12833390/111363582-e92b1d80-8698-11eb-8b17-b40edf1010e6.png)

the KML
![222](https://user-images.githubusercontent.com/12833390/111363625-f1835880-8698-11eb-988b-b55de836be8d.png)

Fixes #826 