### PR TITLE
chore: Change release log output to --info.

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -15,7 +15,7 @@ plugins:
           from: ":[0-9].[0-9].[0-9]"
           to: ":${nextRelease.version}"
   - - "@semantic-release/exec"
-    - prepareCmd: "./gradlew build --warn --stacktrace"
+    - prepareCmd: "./gradlew build --info --stacktrace"
       publishCmd: "./gradlew publish --warn --stacktrace"
   - - "@semantic-release/git"
     - assets:


### PR DESCRIPTION
The release workflow has been failing but the logs don't say much. Changing the log info to `--info` to get more insight on what's causing the failures. Relates to #858.
