### PR TITLE
chore: Add workflow_dispatch to all workflows.

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,9 +2,10 @@ name: Android CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ '*' ]
   pull_request:
-    branches: [ main ]
+    branches: [ '*' ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ name: Release
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
In an attempt to debug issue #858, this change introduces two changes to the way GitHub workflows function in this repo:
* The `android` workflow will now run on all branches
* The `workflow_dispatch` was added so both `android` and `release` can be manually run. See: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
