### PR TITLE
chore: Change android.yml to run ./gradlew build

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,4 +19,4 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Gradle
-      run: ./gradlew test check jacocoTestReport -x lint --stacktrace
+      run: ./gradlew build jacocoTestReport -x lint --stacktrace


### PR DESCRIPTION
Updating `android.yml` workflow to run the `build` task which will also run `check` and `test`. This change is related to debugging #858
