### PR TITLE
fix: Remove Gradle configureondemand

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,6 @@
 # Specifies the JVM arguments used for the daemon process.
 org.gradle.daemon=true
 org.gradle.parallel=true
-org.gradle.configureondemand=true
 org.gradle.jvmargs=-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.


### PR DESCRIPTION
This is Option 1 to fix https://github.com/googlemaps/android-maps-utils/issues/800 as mentioned in https://github.com/googlemaps/android-maps-utils/issues/800#issuecomment-732239657.

Option 2 is presented in PR https://github.com/googlemaps/android-maps-utils/pull/894.

@arriolac What are your thoughts on this vs. Option 2?

This is certainly a simpler fix that keeps the old configuration, but the potential downside is reduced performance. I don't know what the real-world impact on this project is.

Only one of these two PRs should be merged.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Will this cause breaking changes to existing Java or Kotlin integrations? If so, ensure the commit has a `BREAKING CHANGE` footer so when this change is integrated a major version update is triggered. See: https://www.conventionalcommits.org/en/v1.0.0/

Fixes #800 🦕
