### PR TITLE
perf: Use LinkedHashSet instead of List in StaticCluster

### DIFF
--- a/library/src/main/java/com/google/maps/android/clustering/algo/StaticCluster.java
+++ b/library/src/main/java/com/google/maps/android/clustering/algo/StaticCluster.java
@@ -20,7 +20,7 @@ import com.google.android.gms.maps.model.LatLng;
 import com.google.maps.android.clustering.Cluster;
 import com.google.maps.android.clustering.ClusterItem;
 
-import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.Collection;
 import java.util.List;
 
@@ -29,7 +29,7 @@ import java.util.List;
  */
 public class StaticCluster<T extends ClusterItem> implements Cluster<T> {
     private final LatLng mCenter;
-    private final List<T> mItems = new ArrayList<T>();
+    private final Collection<T> mItems = new LinkedHashSet<>();
 
     public StaticCluster(LatLng center) {
         mCenter = center;


### PR DESCRIPTION
Patch for https://github.com/googlemaps/android-maps-utils/issues/917