### PR TITLE
chore: Add word boundary on 'version' for semantic-release-replace-plugin

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,7 +7,7 @@ plugins:
     - replacements:
         - files:
             - "./build.gradle"
-          from: "version = '.*'"
+          from: "\bversion = '.*'"
           to: "version = '${nextRelease.version}'"
 
         - files:


### PR DESCRIPTION
The previous regex for semantic-release-replace-plugin matched on a string that was not supposed to be affected by the plugin. Specifically, the string "ext.kotlin_version = '1.5.20'" would be replaced by the plugin to "ext.kotlin_version ='2.2.5'" wherein '2.2.5' is the next version of this library. The fix was to add a word boundary (\b) on the regex so that it only matches on the word "version" and not words suffixed with "version".

Fixes #920 🦕
