### PR TITLE
chore: Bump version to 2.2.5 and fix .releaserc.

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,7 +7,7 @@ plugins:
     - replacements:
         - files:
             - "./build.gradle"
-          from: "\bversion = '.*'"
+          from: "\\bversion = '.*'"
           to: "version = '${nextRelease.version}'"
 
         - files:

--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ ext.projectArtifactId = { project ->
 
 allprojects {
     group = 'com.google.maps.android'
-    version = '2.2.4'
+    version = '2.2.5'
     project.ext.artifactId = rootProject.ext.projectArtifactId(project)
 }
 


### PR DESCRIPTION
Summary:

* Bump version to 2.2.5 which is the correct latest release.
* Escaped boundary character in .releaserc to correctly match on the word "version". Semantic release plugin uses Javascript's RegExp object which I tested in the console (see screenshot).

![image](https://user-images.githubusercontent.com/463186/125143933-1af54380-e0d1-11eb-8a47-70c8ed87b834.png)

Fixes #924 🦕
