### PR TITLE
ci: Add official Gradle wrapper validation

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,6 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: gradle/wrapper-validation-action@v1.0.4
     - name: set up JDK 1.8
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
+    - uses: gradle/wrapper-validation-action@v1.0.4
     - name: Create .gpg key
       run: |
         echo $GPG_KEY_ARMOR | base64 --decode > ./release.asc


### PR DESCRIPTION
This official action from Gradle validates the checksums of Gradle Wrapper JAR files present in the source tree and fails if unknown Gradle Wrapper JAR files are found.

See https://github.com/gradle/wrapper-validation-action

This PR is a follow up to https://github.com/googlemaps/android-maps-utils/pull/922

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Will this cause breaking changes to existing Java or Kotlin integrations? If so, ensure the commit has a `BREAKING CHANGE` footer so when this change is integrated a major version update is triggered. See: https://www.conventionalcommits.org/en/v1.0.0/
