### PR TITLE
chore: Bump and update lint checks

### DIFF
--- a/lint-checks/build.gradle
+++ b/lint-checks/build.gradle
@@ -15,9 +15,9 @@ dependencies {
     compileOnly "com.android.tools.lint:lint-checks:30.0.0"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     testImplementation "junit:junit:4.13.2"
-    testImplementation "com.android.tools.lint:lint:27.2.2"
-    testImplementation "com.android.tools.lint:lint-tests:27.2.2"
-    testImplementation "com.android.tools:testutils:27.2.2"
+    testImplementation "com.android.tools.lint:lint:30.0.0"
+    testImplementation "com.android.tools.lint:lint-tests:30.0.0"
+    testImplementation "com.android.tools:testutils:30.0.0"
 }
 
 jar {

--- a/lint-checks/src/test/java/com/googe/maps/android/lint/checks/GoogleMapDetectorTest.kt
+++ b/lint-checks/src/test/java/com/googe/maps/android/lint/checks/GoogleMapDetectorTest.kt
@@ -15,6 +15,7 @@
 package com.googe.maps.android.lint.checks
 
 import com.android.tools.lint.checks.infrastructure.LintDetectorTest
+import com.android.tools.lint.checks.infrastructure.TestFile
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Issue
 import com.android.tools.lint.detector.api.TextFormat
@@ -142,7 +143,6 @@ class GoogleMapDetectorTest : LintDetectorTest() {
         package com.google.android.gms.maps;
         
         import android.view.View;
-        import com.google.android.gms.maps.model.Marker;
         
         public class GoogleMap {
            public final void setInfoWindowAdapter(GoogleMap.InfoWindowAdapter adapter) {


### PR DESCRIPTION
This PR replaces dependabot PRs that attempted to bump the lint library dependencies one-at-a-time:
* https://github.com/googlemaps/android-maps-utils/pull/942
* https://github.com/googlemaps/android-maps-utils/pull/941
* https://github.com/googlemaps/android-maps-utils/pull/938

Newer versions of lint dependencies apparently moved a file (and therefore now require an import for `TestFile`) as well as expanded symbol resolution in test file text, and therefore we were getting an error:

```
Couldn't resolve this import [LintError]
import com.google.android.gms.maps.model.Marker;
```

http://googlesamples.github.io/android-custom-lint-rules/api-guide.html (and the result of the failing test) say:

>"If this import is immaterial to the test, either delete it, or mark
 this unit test as allowing resolution errors by setting
 `allowCompilationErrors()`."

 So I've deleted the Marker import in the test file in this commit, as it doesn't seem material to the test.

I also noticed that there is a typo in the test package name (`googe`) but I'll change this in a separate PR after this is merged to avoid hiding the changes in version control in a file move.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Will this cause breaking changes to existing Java or Kotlin integrations? If so, ensure the commit has a `BREAKING CHANGE` footer so when this change is integrated a major version update is triggered. See: https://www.conventionalcommits.org/en/v1.0.0/