### PR TITLE
chore: Remove unused dex config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,24 +46,6 @@ task clean(type: Delete) {
 }
 
 /**
- * Improve build server performance by allowing disabling of pre-dexing
- * (see http://tools.android.com/tech-docs/new-build-system/tips#TOC-Improving-Build-Server-performance.)
- */
-project.ext.preDexLibs = !project.hasProperty('disablePreDex')
-
-subprojects {
-    project.plugins.whenPluginAdded { plugin ->
-        if (rootProject.ext.has('preDexLibs')) {
-            if ("com.android.build.gradle.AppPlugin" == plugin.class.name) {
-                project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
-            } else if ("com.android.build.gradle.LibraryPlugin" == plugin.class.name) {
-                project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
-            }
-        }
-    }
-}
-
-/**
  * This task will copy all of the source code in the `library` module into the `library-v3` module
  * and change its imports from the Maps SDK on Play Services to the Standalone V3 Beta Maps SDK.
  */

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -18,9 +18,6 @@ plugins {
 }
 
 android {
-    dexOptions {
-        javaMaxHeapSize "2g"
-    }
     compileSdkVersion 30
 
     defaultConfig {


### PR DESCRIPTION
Build currently says:
>WARNING:DSL element 'dexOptions' is obsolete and should be removed.
 It will be removed in version 8.0 of the Android Gradle plugin.
 Using it has no effect, and the AndroidGradle plugin optimizes dexing automatically.

Additionaly, the "disablePreDex" property hasn't been used since we've switched to GitHub Actions. The link in the comments to the Android Tools site is also deprecated, so this practice no longer seems to be recommended.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Will this cause breaking changes to existing Java or Kotlin integrations? If so, ensure the commit has a `BREAKING CHANGE` footer so when this change is integrated a major version update is triggered. See: https://www.conventionalcommits.org/en/v1.0.0/