### PR TITLE
fix: Bump appcompat to avoid "OnClickXmlDetector called context.getMainProject()" lint error

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -64,7 +64,7 @@ dependencies {
 
     // [START_EXCLUDE silent]
     // implementation project(':library')
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.appcompat:appcompat:1.4.0-alpha03'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
 
     // GMS


### PR DESCRIPTION
Closes  https://github.com/googlemaps/android-maps-utils/issues/973

@arriolac This avoids #973 when running lint on the demo app which should allow the semantic release to pass. It bumps to an alpha version of appcompat to avoid an apparent compatibility issue with AGP7 and the latest stable release for appcompat (v1.3.1), but given that the demo app is using the dependency (and not the library) it shouldn't affect library stability.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Will this cause breaking changes to existing Java or Kotlin integrations? If so, ensure the commit has a `BREAKING CHANGE` footer so when this change is integrated a major version update is triggered. See: https://www.conventionalcommits.org/en/v1.0.0/

Fixes #973 🦕
