### PR TITLE
ci: Run lint on all CI builds

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,4 +21,4 @@ jobs:
         java-version: '11'
         distribution: 'adopt'
     - name: Build with Gradle
-      run: ./gradlew build jacocoTestReport -x lint --stacktrace
+      run: ./gradlew build jacocoTestReport --stacktrace


### PR DESCRIPTION
Closes https://github.com/googlemaps/android-maps-utils/issues/986.

I've also confirmed that I can reproduce https://github.com/googlemaps/android-maps-utils/issues/973 locally on my machine with the same Gradle command when I revert appcompat back to 1.3.1, so CI should now catch issues like https://github.com/googlemaps/android-maps-utils/issues/973 before release.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)
- [X] Will this cause breaking changes to existing Java or Kotlin integrations? If so, ensure the commit has a `BREAKING CHANGE` footer so when this change is integrated a major version update is triggered. See: https://www.conventionalcommits.org/en/v1.0.0/

Fixes https://github.com/googlemaps/android-maps-utils/issues/986 🦕
