### PR TITLE
ci: Remove build.gradle.ktx from .releaserc.

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,7 +7,6 @@ plugins:
     - replacements:
         - files:
             - "build.gradle"
-            - "build.gradle.kts"
           from: "\\bversion = '.*'"
           to: "version = '${nextRelease.version}'"
         - files:
@@ -20,7 +19,6 @@ plugins:
   - - "@semantic-release/git"
     - assets:
         - "build.gradle"
-        - "build.gradle.kts"
         - "*.md"
   - "@semantic-release/github"
 options:


### PR DESCRIPTION
Changes introduced in #998 and #1010 required that the release workflow match on a file named `build.gradle.kts`. These changes were done as a way to simplify managing multiple Android repos in our org. Unfortunately, it looks like semantic release will fail if one of the enumerated files is not found and so it is necessary to create a separate `.releaserc` for Groovy repos and another `.releaserc` for Gradle Kotlin DSL (will handle that in the .github repo separately).

Fixes #1012 🦕
