### PR TITLE
ci: Change Java distribution adopt->temurin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
 
     - name: Build modules
       run: ./gradlew build jacocoTestReport --stacktrace


### PR DESCRIPTION
https://github.com/actions/setup-java#supported-distributions says:

>NOTE: Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from adopt to temurin to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).)

This PR changes GitHub Actions to use temurin instead of adopt as highly recommended above.