### PR TITLE
chore(dependencies): general update of dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  */
 
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.7.20'
     repositories {
         google()
         mavenCentral()
@@ -24,9 +24,9 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath 'com.hiya:jacoco-android:0.2'
-        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.0"
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -23,12 +23,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     defaultConfig {
         applicationId "com.google.maps.android.utils.demo"
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
     }
@@ -57,13 +57,14 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+    namespace 'com.google.maps.android.utils.demo'
 }
 
 // [START maps_android_utils_install_snippet]
 dependencies {
 
     // [START_EXCLUDE silent]
-    implementation 'androidx.appcompat:appcompat:1.4.0-alpha03'
+    implementation 'androidx.appcompat:appcompat:1.7.0-alpha01'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
 
     // GMS
@@ -75,7 +76,7 @@ dependencies {
     v3Implementation 'com.android.volley:volley:1.2.1' // TODO - Remove this after Maps SDK v3 beta includes Volley versions on Maven Central
     v3Implementation project(':library-v3')
     v3Implementation 'androidx.multidex:multidex:2.0.1'
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     // [END_EXCLUDE]
 }

--- a/demo/src/gms/java/com/google/maps/android/utils/demo/SampleManager.java
+++ b/demo/src/gms/java/com/google/maps/android/utils/demo/SampleManager.java
@@ -1,0 +1,16 @@
+package com.google.maps.android.utils.demo;
+
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.GroundOverlay;
+import com.google.maps.android.collections.GroundOverlayManager;
+
+
+import androidx.annotation.NonNull;
+
+public class SampleManager extends GroundOverlayManager implements GoogleMap.OnGroundOverlayClickListener {
+
+
+    public SampleManager(@NonNull GoogleMap map) {
+        super(map);
+    }
+}

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.google.maps.android.utils.demo">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <permission
         android:name="com.google.maps.android.utils.permission.MAPS_RECEIVE"
@@ -43,6 +42,7 @@
             android:value="${MAPS_API_KEY}" />
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/library-v3/build.gradle
+++ b/library-v3/build.gradle
@@ -19,11 +19,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 33
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
         // This enables us to tell when we're running unit tests on Travis (#573)
@@ -48,23 +48,24 @@ android {
             returnDefaultValues = true
         }
     }
+    namespace 'com.google.maps.android'
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'com.google.android.libraries.maps:maps:3.1.0-beta'
     implementation 'com.android.volley:volley:1.2.1' // TODO - Remove this after Maps SDK v3 beta includes Volley versions on Maven Central
     implementation 'com.google.android.gms:play-services-basement:18.1.0'
-    implementation 'com.google.android.gms:play-services-base:18.0.0'
+    implementation 'com.google.android.gms:play-services-base:18.1.0'
     implementation 'com.google.android.gms:play-services-gcm:17.0.0'
-    implementation 'com.google.android.gms:play-services-location:19.0.1'
+    implementation 'com.google.android.gms:play-services-location:21.0.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // TODO: Add shared dependencies with `library` to root build.gradle
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.7.3'
     testImplementation 'net.sf.kxml:kxml2:2.3.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
 }

--- a/library-v3/src/main/AndroidManifest.xml
+++ b/library-v3/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.maps.android" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -18,11 +18,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         consumerProguardFiles 'consumer-rules.pro'
@@ -51,11 +51,12 @@ android {
             returnDefaultValues = true
         }
     }
+    namespace 'com.google.maps.android'
 }
 
 dependencies {
     implementation 'com.google.android.gms:play-services-maps:17.0.1'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
     lintPublish project(':lint-checks')
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.7.3'

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.maps.android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- https://groups.google.com/group/adt-dev/browse_thread/thread/c059c0380998092b/6720093fb40fdaf9 -->
     <application>
         <meta-data


### PR DESCRIPTION
The current Pull Request introduces a general update of dependencies, and supersedes all the existing dependabot PRs.

This PR affecs the demo-java, demo-kotlin and snippets projects.

Increased compileSdkVersion.
Increased targetSdkVersion.
Moves namespace from AndroidManifest to the build.gradle file.
Increases Gradle plugin version.
General dependencies updated.
This supersedes all the existing dependabot PRs:

#1118, #1117, #1110, #1108 and #1069