### PR TITLE
feat: exposing getColor function in the ClusterRenderer

### DIFF
--- a/library/src/main/java/com/google/maps/android/clustering/view/ClusterRenderer.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/ClusterRenderer.java
@@ -65,4 +65,9 @@ public interface ClusterRenderer<T extends ClusterItem> {
      * Called when the view is removed.
      */
     void onRemove();
+
+    /**
+     * Called to determine the color of a Cluster.
+     */
+    int getColor(int clusterSize);
 }

--- a/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
@@ -227,7 +227,8 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
         return squareTextView;
     }
 
-    protected int getColor(int clusterSize) {
+    @Override
+    public int getColor(int clusterSize) {
         final float hueRange = 220;
         final float sizeRange = 300;
         final float size = Math.min(clusterSize, sizeRange);


### PR DESCRIPTION
The following PRs exposes the method getColor() in the ClusterRenderer. Thus, developers can override this method and provide their own color schema for clusters.

---

- [X] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)
- [X] Will this cause breaking changes to existing Java or Kotlin integrations? If so, ensure the commit has a `BREAKING CHANGE` footer so when this change is integrated a major version update is triggered. See: https://www.conventionalcommits.org/en/v1.0.0/

Fixes #1121 
