### PR TITLE
chore: update release action dependency for running on Node 16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         SONATYPE_PASSWORD: ${{ secrets.SYNCED_SONATYPE_PASSWORD }}
         SONATYPE_USERNAME: ${{ secrets.SYNCED_SONATYPE_USERNAME }}
     - name: Semantic Release
-      uses: cycjimmy/semantic-release-action@v2
+      uses: cycjimmy/semantic-release-action@v3
       with:
         extra_plugins: |
           "@semantic-release/commit-analyzer"


### PR DESCRIPTION
Release action [failing](https://github.com/googlemaps/android-maps-utils/actions/runs/3876666515/jobs/6610774150)

cycjimmy/semantic-release-action@v2 runs on Node 12 and v3 runs on Node 16. GitHub has been [warning](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) that it would update actions to run on Node 16.