### PR TITLE
fix: Add container ground overlays in KML/KMZ

### DIFF
--- a/library/src/main/java/com/google/maps/android/data/kml/KmlRenderer.java
+++ b/library/src/main/java/com/google/maps/android/data/kml/KmlRenderer.java
@@ -451,7 +451,7 @@ public class KmlRenderer extends Renderer {
             if (groundOverlayUrl != null && groundOverlay.getLatLngBox() != null) {
                 // Can't draw overlay if url and coordinates are missing
                 if (getCachedGroundOverlayImage(groundOverlayUrl) != null) {
-                    addGroundOverlayToMap(groundOverlayUrl, getGroundOverlayMap(), true);
+                    addGroundOverlayToMap(groundOverlayUrl, groundOverlays, true);
                 } else {
                     mGroundOverlayUrls.add(groundOverlayUrl);
                 }


### PR DESCRIPTION
Pass the correct set of ground overlays from a nested container to properly add to the map.

Fixes #740 🦕