### PR TITLE
docs: Uprev recommended android-maps-utils lib version

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -61,7 +61,7 @@ android {
 
 // [START maps_android_utils_install_snippet]
 dependencies {
-    implementation 'com.google.maps.android:android-maps-utils:2.3.0'
+    implementation 'com.google.maps.android:android-maps-utils:3.4.0'
 
     // [START_EXCLUDE silent]
     implementation 'com.google.android.gms:play-services-maps:18.0.2'


### PR DESCRIPTION
This fixes #1167. To be clear, I don't think this is a great fix. But I'm not familiar enough with the project to understand why the setup docs reference this `devsite` branch for pulling examples rather than either embedding it directly in the docs or using another method for dynamically updating things. So I've just elected to uprev the hardcoded value here.

The `devsite` branch does not currently build for many other reasons, and so:

1. I didn't try to make this branch build, nor run the tests.
2. I didn't try to manually search for other places in the docs or `devsite` branch which are out of date.