### PR TITLE
fix: Correctly parse `<hotSpot>` elements

### DIFF
--- a/library/src/main/java/com/google/maps/android/data/Style.java
+++ b/library/src/main/java/com/google/maps/android/data/Style.java
@@ -16,6 +16,8 @@
 
 package com.google.maps.android.data;
 
+import android.util.Log;
+
 import com.google.android.gms.maps.model.MarkerOptions;
 import com.google.android.gms.maps.model.PolygonOptions;
 import com.google.android.gms.maps.model.PolylineOptions;
@@ -30,6 +32,7 @@ import java.util.Observable;
  * and {@link com.google.maps.android.data.geojson.GeoJsonPolygonStyle GeoJsonPolygonStyle}
  */
 public abstract class Style extends Observable {
+    private static final String LOG_TAG = "Style";
 
     protected MarkerOptions mMarkerOptions;
 
@@ -82,8 +85,14 @@ public abstract class Style extends Observable {
         if (xUnits.equals("fraction")) {
             xAnchor = x;
         }
+        else {
+            Log.w(LOG_TAG, "Hotspot xUnits other than \"fraction\" are not supported.");
+        }
         if (yUnits.equals("fraction")) {
             yAnchor = y;
+        }
+        else {
+            Log.w(LOG_TAG, "Hotspot yUnits other than \"fraction\" are not supported.");
         }
 
         mMarkerOptions.anchor(xAnchor, yAnchor);

--- a/library/src/main/java/com/google/maps/android/data/kml/KmlStyleParser.java
+++ b/library/src/main/java/com/google/maps/android/data/kml/KmlStyleParser.java
@@ -24,10 +24,13 @@ import java.util.HashMap;
 import static org.xmlpull.v1.XmlPullParser.END_TAG;
 import static org.xmlpull.v1.XmlPullParser.START_TAG;
 
+import android.util.Log;
+
 /**
  * Parses the styles of a given KML file into a KmlStyle object
  */
 /* package */ class KmlStyleParser {
+    private static final String LOG_TAG = "KmlStyleParser";
 
     private final static String STYLE_TAG = "styleUrl";
 
@@ -184,18 +187,24 @@ import static org.xmlpull.v1.XmlPullParser.START_TAG;
      *
      * @param style Style object to apply hotspot properties to
      */
-    private static void setIconHotSpot(XmlPullParser parser, KmlStyle style)
-            throws XmlPullParserException {
-        if (parser.isEmptyElementTag()) {
-            return;
-        }
+    private static void setIconHotSpot(XmlPullParser parser, KmlStyle style) {
         float xValue, yValue;
         String xUnits, yUnits;
-        xValue = Float.parseFloat(parser.getAttributeValue(null, "x"));
-        yValue = Float.parseFloat(parser.getAttributeValue(null, "y"));
-        xUnits = parser.getAttributeValue(null, "xunits");
-        yUnits = parser.getAttributeValue(null, "yunits");
-        style.setHotSpot(xValue, yValue, xUnits, yUnits);
+
+        try {
+            xValue = Float.parseFloat(parser.getAttributeValue(null, "x"));
+            yValue = Float.parseFloat(parser.getAttributeValue(null, "y"));
+            xUnits = parser.getAttributeValue(null, "xunits");
+            yUnits = parser.getAttributeValue(null, "yunits");
+            style.setHotSpot(xValue, yValue, xUnits, yUnits);
+        }
+        catch(NullPointerException e) {
+            Log.w(LOG_TAG,
+                    "Missing 'x' or 'y' attributes in hotSpot for style with id: " + style.getStyleId());
+        }
+        catch(NumberFormatException e) {
+            Log.w(LOG_TAG, "Invalid number in 'x' or 'y' attributes in hotSpot for style with id: " + style.getStyleId());
+        }
     }
 
     /**

--- a/library/src/test/java/com/google/maps/android/data/kml/KmlParserTest.java
+++ b/library/src/test/java/com/google/maps/android/data/kml/KmlParserTest.java
@@ -60,7 +60,15 @@ public class KmlParserTest {
         KmlParser mParser = new KmlParser(parser);
         mParser.parseKml();
         assertNotNull(mParser.getPlacemarks());
-        assertEquals(1, mParser.getPlacemarks().size());
+        assertEquals(2, mParser.getPlacemarks().size());
+        HashMap<String, KmlStyle> styles = mParser.getStyles();
+        assertEquals(3, styles.size());
+        KmlStyle validStyle = styles.get("#validHotspot");
+        assertNotNull(validStyle);
+        double hotspotX = validStyle.getMarkerOptions().getAnchorU();
+        double hotspotY = validStyle.getMarkerOptions().getAnchorV();
+        assertEquals(0.5234, hotspotX, 0.0001);
+        assertEquals(0.5062, hotspotY, 0.0001);
     }
 
     @Test

--- a/library/src/test/resources/amu_empty_hotspot.kml
+++ b/library/src/test/resources/amu_empty_hotspot.kml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <kml>
-    <Style x="20" y="2" xunits="pixels" yunits="pixels" id="shp_centerpoint">
+    <Style id="emptyHotspot">
       <IconStyle>
         <scale>0.8</scale>
         <Icon>
@@ -13,9 +13,22 @@
         <color>FFFFFFFF</color>
       </LabelStyle>
     </Style>
+    <Style id="validHotspot">
+      <IconStyle>
+        <scale>0.8</scale>
+        <Icon>
+          <href>http://maps.google.com/mapfiles/kml/pal4/icon57.png</href>
+        </Icon>
+        <hotSpot x="0.5234" y="0.5062" xunits="fraction" yunits="fraction"/>
+      </IconStyle>
+      <LabelStyle>
+        <scale>1</scale>
+        <color>FFFFFFFF</color>
+      </LabelStyle>
+    </Style>
       <Placemark>
         <name>60A</name>
-        <description>Test</description>
+        <description>Empty Hotspot</description>
         <visibility>1</visibility>
         <Point>
           <extrude>0</extrude>
@@ -23,6 +36,18 @@
           <altitudeMode>0</altitudeMode>
           <coordinates>-111.957935372607,44.0811954480368,0</coordinates>
         </Point>
-        <styleUrl>#shp_centerpoint</styleUrl>
+        <styleUrl>#emptyHotspot</styleUrl>
+      </Placemark>
+      <Placemark>
+        <name>60B</name>
+        <description>Valid Hotspot</description>
+        <visibility>1</visibility>
+        <Point>
+          <extrude>0</extrude>
+          <tessellate>1</tessellate>
+          <altitudeMode>0</altitudeMode>
+          <coordinates>-112.057935372607,44.1811954480368,0</coordinates>
+        </Point>
+        <styleUrl>#validHotspot</styleUrl>
       </Placemark>
 </kml>


### PR DESCRIPTION
Fixes #1172

The library currently never parses `<hotSpot>` element in KML, because they are always empty tags. A valid `<hotSpot>` element should be empty, with the necessary attributes like the following:
```xml
<hotSpot x="0.5" y="0.5" xunits="fraction" yunits="fraction"/>
```

I also adjusted the test for parsing `<hotSpot>` to be a valid KML file (none of `x`, `y`, `xunits`, or `yunits` are valid attributes for `<Style>`), and with a valid and invalid `<hotSpot`> in the case of an invalid `<hotSpot>` the default anchor should be used.

Finally, I also added some warnings to clarify that the library only supports `xunits` and `yunits` that have the value `"fraction"`. I would recommend that this clarification is made in the [KML support table in the official developer docs](https://developers.google.com/maps/documentation/android-sdk/utility/kml#supported). The warnings are the best way to let a user know about this, since there are other values that are part of the KML spec, and it's confusing why the `<hotSpot>` for a style isn't working when the units are `"pixels"` or `"insetPixels"`.

In order to test with another application, I had to update the root and library `build.gradle` files to support Jitpack. Let me know if I should take these changes out of the PR, but the current Jitpack override in the library `build.gradle` does not work.