### PR TITLE
chore: updated Java from default to 17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ jobs:
       uses: actions/checkout@v3
       with:
         token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
     - uses: gradle/wrapper-validation-action@v1.1.0
     - name: Create .gpg key
       run: |


### PR DESCRIPTION
This PR updates the Java version in the Release Workflow to 17.