### PR TITLE
fix: added dokka and fix doc generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,67 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A workflow that updates the gh-pages branch whenever a new release is made
+name: Update documentation
+
+on:
+  push:
+    branches: [ main ]
+  repository_dispatch:
+      types: [gh-pages]
+  workflow_dispatch:
+
+jobs:
+  gh-page-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+
+    - name: Gradle Wrapper Validation
+      uses: gradle/wrapper-validation-action@v1.0.4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v2.3.1
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    # Run dokka and create tar
+    - name: Generate documentation
+      run: |
+        ./gradlew dokkaHtml
+
+        echo "Creating tar for generated docs"
+        cd $GITHUB_WORKSPACE/build/dokka/html && tar cvf ~/android-maps-utils-docs.tar .
+
+        echo "Unpacking tar into gh-pages branch"
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+        cd $GITHUB_WORKSPACE && git checkout gh-pages && tar xvf ~/android-maps-utils-docs.tar
+
+    # Commit changes and create a PR
+    - name: PR Changes
+      uses: peter-evans/create-pull-request@v3
+      with:
+        token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
+        commit-message: 'docs: Update docs'
+        author: googlemaps-bot <googlemaps-bot@google.com>
+        committer: googlemaps-bot <googlemaps-bot@google.com>
+        labels: docs
+        title: 'docs: Update docs'
+        body: |
+            Updated GitHub pages with latest from `./gradlew dokkaHtml`.
+        branch: googlemaps-bot/update_gh_pages

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,10 @@ buildscript {
         classpath 'com.mxalbert.gradle:jacoco-android:0.2.1'
         classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.9.0"
     }
 }
+
 
 allprojects {
     repositories {
@@ -104,9 +106,9 @@ subprojects { project ->
     }
 
     tasks.register('javadocJar', Jar) {
-        dependsOn javadoc
+        dependsOn dokkaHtml
         archiveClassifier  = 'javadoc'
-        from javadoc.destinationDir
+        from dokkaHtml.outputDirectory
     }
 
     publishing {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'kotlin-android'
+    id 'org.jetbrains.dokka'
 }
 
 android {


### PR DESCRIPTION
This PR fixes the doc generation, broken since 3.4.0.

JavaDoc does not like Kotlin, so we are updating it to a more modern documentation framework, Dokka. We are adding also a new flow to upload the documentation to the GitHub pages.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Edit the title of this pull request with a [semantic commit prefix](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#type) (e.g. "fix: "), which is necessary for automated release workflows to decide whether to generate a new release and what type it should be.
- [ ] Will this cause breaking changes to existing Java or Kotlin integrations? If so, ensure the commit has a `BREAKING CHANGE` footer so when this change is integrated a major version update is triggered. See: https://www.conventionalcommits.org/en/v1.0.0/
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #1248 🦕
