### PR TITLE
chore: add license header to docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,6 +50,8 @@ jobs:
 
         echo "Unpacking tar into gh-pages branch"
         git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+        go install github.com/google/addlicense@latest
+        addlicense .
         cd $GITHUB_WORKSPACE && git checkout gh-pages && tar xvf ~/android-maps-utils-docs.tar
 
     # Commit changes and create a PR


### PR DESCRIPTION
The following PR installs [addlicense](https://github.com/google/addlicense/), and runs it before the documentation is generated. At the moment, the header-check step is [failing](https://github.com/googlemaps/android-maps-utils/pull/1414) since the headers have not been added (and the enforcement level changes based on [the sync file](https://github.com/googleapis/repo-automation-bots/tree/main/packages/sync-repo-settings)) 
