### PR TITLE
chore: fix publish command

### DIFF
--- a/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
@@ -71,6 +71,12 @@ class PublishingConventionPlugin : Plugin<Project> {
         extensions.configure<PublishingExtension> {
             publications {
                 create<MavenPublication>("aar") {
+                    artifactId = if (project.name == "library") {
+                        "android-maps-utils"
+                    } else {
+                        null
+                    }
+
                     afterEvaluate {
                         from(components["release"])
                     }
@@ -104,9 +110,13 @@ class PublishingConventionPlugin : Plugin<Project> {
             }
             repositories {
                 maven {
-                    val releasesRepoUrl = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-                    val snapshotsRepoUrl = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-                    url = if (project.version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
+                    val releasesRepoUrl =
+                        uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+                    val snapshotsRepoUrl =
+                        uri("https://oss.sonatype.org/content/repositories/snapshots/")
+                    url = if (project.version.toString()
+                            .endsWith("SNAPSHOT")
+                    ) snapshotsRepoUrl else releasesRepoUrl
                     credentials {
                         username = project.findProperty("sonatypeToken") as String?
                         password = project.findProperty("sonatypeTokenPassword") as String?

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,13 +35,7 @@ tasks.register<Delete>("clean") {
     delete(rootProject.buildDir)
 }
 
-
 allprojects {
     group = "com.google.maps.android"
     version = "3.10.0"
-    val projectArtifactId = if (project.name == "library") {
-        "android-maps-utils"
-    } else {
-        null
-    }
 }


### PR DESCRIPTION
The following PR fixes the publish command.

We had before this code in the main build gradle file, which was not being read on the Convention Plugin, which works on a different scope:

```kotlin
 artifactId = if (project.name == "library") {
                        "android-maps-utils"
                    } else {
                        null
                    }
```

One could say: how do we do it on the android-maps-utils? We name the modules as they should be named.

This should fix the generation of the artifact to have the proper artifactId. Checked locally with `./gradlew clean publishToMavenLocal   `

```xml
<?xml version="1.0" encoding="UTF-8"?>
<metadata>
  <groupId>com.google.maps.android</groupId>
  <artifactId>android-maps-utils</artifactId>
  <versioning>
    <latest>3.10.0</latest>
    <release>3.10.0</release>
    <versions>
      <version>3.10.0</version>
    </versions>
    <lastUpdated>20250121165121</lastUpdated>
  </versioning>
</metadata>
```
