### PR TITLE
fix: fix for ConcurrentModificationException

### DIFF
--- a/library/src/main/java/com/google/maps/android/clustering/view/ClusterRendererMultipleItems.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/ClusterRendererMultipleItems.java
@@ -1190,7 +1190,7 @@ public class ClusterRendererMultipleItems<T extends ClusterItem> implements Clus
 
         private final Lock lock;
 
-        private AnimationTask(MarkerWithPosition markerWithPosition, LatLng from, LatLng to, Lock lock)  {
+        private AnimationTask(MarkerWithPosition markerWithPosition, LatLng from, LatLng to, Lock lock) {
             this.markerWithPosition = markerWithPosition;
             this.marker = markerWithPosition.marker;
             this.from = from;
@@ -1212,12 +1212,15 @@ public class ClusterRendererMultipleItems<T extends ClusterItem> implements Clus
                 new Handler(Looper.getMainLooper()).post(this::cancel);
                 return;
             }
-            markerWithPosition.position = to;
-            mRemoveOnComplete = false;
-            valueAnimator.cancel();
-            lock.lock();
-            ongoingAnimations.remove(this);
-            lock.unlock();
+            try {
+                markerWithPosition.position = to;
+                mRemoveOnComplete = false;
+                valueAnimator.cancel();
+                lock.lock();
+                ongoingAnimations.remove(this);
+            } finally {
+                lock.unlock();
+            }
         }
 
         @Override
@@ -1230,7 +1233,9 @@ public class ClusterRendererMultipleItems<T extends ClusterItem> implements Clus
             markerWithPosition.position = to;
 
             // Remove the task from the queue
+            lock.lock();
             ongoingAnimations.remove(this);
+            lock.unlock();
         }
 
         public void removeOnAnimationComplete(MarkerManager markerManager) {

--- a/library/src/main/java/com/google/maps/android/clustering/view/ClusterRendererMultipleItems.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/ClusterRendererMultipleItems.java
@@ -64,6 +64,7 @@ import com.google.maps.android.ui.SquareTextView;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -689,7 +690,7 @@ public class ClusterRendererMultipleItems<T extends ClusterItem> implements Clus
          */
         public void animate(MarkerWithPosition marker, LatLng from, LatLng to) {
             lock.lock();
-            AnimationTask task = new AnimationTask(marker, from, to);
+            AnimationTask task = new AnimationTask(marker, from, to, lock);
 
             for (AnimationTask existingTask : ongoingAnimations) {
                 if (existingTask.marker.getId().equals(task.marker.getId())) {
@@ -713,10 +714,13 @@ public class ClusterRendererMultipleItems<T extends ClusterItem> implements Clus
          */
         public void animateThenRemove(MarkerWithPosition marker, LatLng from, LatLng to) {
             lock.lock();
-            AnimationTask animationTask = new AnimationTask(marker, from, to);
-            for (AnimationTask existingTask : ongoingAnimations) {
+            AnimationTask animationTask = new AnimationTask(marker, from, to, lock);
+            Iterator<AnimationTask> iterator = ongoingAnimations.iterator();
+            while (iterator.hasNext()) {
+                AnimationTask existingTask = iterator.next();
                 if (existingTask.marker.getId().equals(animationTask.marker.getId())) {
                     existingTask.cancel();
+                    iterator.remove();
                     break;
                 }
             }
@@ -1188,11 +1192,14 @@ public class ClusterRendererMultipleItems<T extends ClusterItem> implements Clus
         private MarkerManager mMarkerManager;
         private ValueAnimator valueAnimator;
 
-        private AnimationTask(MarkerWithPosition markerWithPosition, LatLng from, LatLng to) {
+        private final Lock lock;
+
+        private AnimationTask(MarkerWithPosition markerWithPosition, LatLng from, LatLng to, Lock lock)  {
             this.markerWithPosition = markerWithPosition;
             this.marker = markerWithPosition.marker;
             this.from = from;
             this.to = to;
+            this.lock = lock;
         }
 
         public void perform() {
@@ -1212,7 +1219,9 @@ public class ClusterRendererMultipleItems<T extends ClusterItem> implements Clus
             markerWithPosition.position = to;
             mRemoveOnComplete = false;
             valueAnimator.cancel();
+            lock.lock();
             ongoingAnimations.remove(this);
+            lock.unlock();
         }
 
         @Override

--- a/library/src/main/java/com/google/maps/android/clustering/view/ClusterRendererMultipleItems.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/ClusterRendererMultipleItems.java
@@ -715,9 +715,7 @@ public class ClusterRendererMultipleItems<T extends ClusterItem> implements Clus
         public void animateThenRemove(MarkerWithPosition marker, LatLng from, LatLng to) {
             lock.lock();
             AnimationTask animationTask = new AnimationTask(marker, from, to, lock);
-            Iterator<AnimationTask> iterator = ongoingAnimations.iterator();
-            while (iterator.hasNext()) {
-                AnimationTask existingTask = iterator.next();
+            for (AnimationTask existingTask : ongoingAnimations) {
                 if (existingTask.marker.getId().equals(animationTask.marker.getId())) {
                     existingTask.cancel();
                     break;

--- a/library/src/main/java/com/google/maps/android/clustering/view/ClusterRendererMultipleItems.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/ClusterRendererMultipleItems.java
@@ -720,7 +720,6 @@ public class ClusterRendererMultipleItems<T extends ClusterItem> implements Clus
                 AnimationTask existingTask = iterator.next();
                 if (existingTask.marker.getId().equals(animationTask.marker.getId())) {
                     existingTask.cancel();
-                    iterator.remove();
                     break;
                 }
             }

--- a/library/src/main/java/com/google/maps/android/clustering/view/ClusterRendererMultipleItems.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/ClusterRendererMultipleItems.java
@@ -64,7 +64,6 @@ import com.google.maps.android.ui.SquareTextView;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
This PR fixes an issue that triggered a ConcurrentModificationException when accessing a list in the new `ClusterRendererMultipleItems`.

Fixes #1483  🦕
