### PR TITLE
chore: not run lint on push onto main

### DIFF
--- a/.github/workflows/lint-report.yml
+++ b/.github/workflows/lint-report.yml
@@ -15,9 +15,6 @@
 name: Lint and Upload SARIF
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
The following PR removes a couple of lines that will prevent lint from running when a branch has been merged into main (which we don't need, since we can't post the results and this must be done via a Pull Request).