### PR TITLE
feat: added parameter to modify duration to AnimationUtil

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", vers
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 jacoco-android = { module = "com.mxalbert.gradle:jacoco-android", version.ref = "jacoco-android" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 lifecycle-extensions = { module = "androidx.lifecycle:lifecycle-extensions", version.ref = "lifecycle-extensions" }
 lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle-viewmodel-ktx" }
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -70,8 +70,6 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation (libs.kotlin.test)
     implementation(libs.kotlin.stdlib.jdk8)
-
-
 }
 
 tasks.register("instrumentTest") {

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -68,7 +68,10 @@ dependencies {
     testImplementation(libs.robolectric)
     testImplementation(libs.kxml2)
     testImplementation(libs.mockk)
+    testImplementation (libs.kotlin.test)
     implementation(libs.kotlin.stdlib.jdk8)
+
+
 }
 
 tasks.register("instrumentTest") {

--- a/library/src/main/java/com/google/maps/android/ui/AnimationUtil.java
+++ b/library/src/main/java/com/google/maps/android/ui/AnimationUtil.java
@@ -29,7 +29,7 @@ import com.google.android.gms.maps.model.Marker;
  * <p>
  */
 public class AnimationUtil {
-    
+
     /**
      * Animates a marker from it's current position to the provided finalPosition
      *
@@ -85,7 +85,7 @@ public class AnimationUtil {
     }
 
     /**
-     * For other LatLngInterpolator interpolators, see https://gist.github.com/broady/6314689
+     * For other LatLngInterpolator interpolators, see <a href="https://gist.github.com/broady/6314689">link here</a>
      */
     interface LatLngInterpolator {
 

--- a/library/src/main/java/com/google/maps/android/ui/AnimationUtil.java
+++ b/library/src/main/java/com/google/maps/android/ui/AnimationUtil.java
@@ -36,13 +36,28 @@ public class AnimationUtil {
      * @param marker        marker to animate
      * @param finalPosition the final position of the marker after the animation
      */
-     public static void animateMarkerTo(final Marker marker, final LatLng finalPosition) {
+    public static void animateMarkerTo(final Marker marker, final LatLng finalPosition) {
+        animateMarkerTo(marker, finalPosition, 2000); // delegate to new version
+    }
+
+
+    /**
+     * Animates a marker from its current position to the provided finalPosition.
+     *
+     * @param marker        marker to animate
+     * @param finalPosition the final position of the marker after the animation
+     * @param durationInMs  the duration of the animation in milliseconds
+     */
+    public static void animateMarkerTo(
+            final Marker marker,
+            final LatLng finalPosition,
+            final long durationInMs
+    ) {
         final LatLngInterpolator latLngInterpolator = new LatLngInterpolator.Linear();
         final LatLng startPosition = marker.getPosition();
         final Handler handler = new Handler();
         final long start = SystemClock.uptimeMillis();
         final Interpolator interpolator = new AccelerateDecelerateInterpolator();
-        final float durationInMs = 2000;
 
         handler.post(new Runnable() {
             long elapsed;
@@ -55,7 +70,7 @@ public class AnimationUtil {
             public void run() {
                 // Calculate progress using interpolator
                 elapsed = SystemClock.uptimeMillis() - start;
-                t = elapsed / durationInMs;
+                t = elapsed / (float) durationInMs;
                 v = interpolator.getInterpolation(t);
 
                 marker.setPosition(latLngInterpolator.interpolate(v, startPosition, finalPosition));

--- a/library/src/test/java/com/google/maps/android/AnimationUtilTest.kt
+++ b/library/src/test/java/com/google/maps/android/AnimationUtilTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.maps.android
 
 import com.google.android.gms.maps.model.LatLng

--- a/library/src/test/java/com/google/maps/android/AnimationUtilTest.kt
+++ b/library/src/test/java/com/google/maps/android/AnimationUtilTest.kt
@@ -1,0 +1,63 @@
+package com.google.maps.android
+
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.Marker
+import com.google.maps.android.ui.AnimationUtil
+import io.mockk.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+class AnimationUtilTest {
+
+    private lateinit var marker: Marker
+    private lateinit var currentPosition: LatLng
+
+    @Before
+    fun setUp() {
+        marker = mockk(relaxed = true)
+
+        // Initial position
+        currentPosition = LatLng(0.0, 0.0)
+
+        // Mock the marker position getter and setter
+        every { marker.position } answers { currentPosition }
+        every { marker.setPosition(any()) } answers {
+            currentPosition = firstArg()
+            Unit
+        }
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `animateMarkerTo moves marker to final position with a buffer tolerance`() {
+        val finalPosition = LatLng(10.0, 10.0)
+        val durationMs = 100L
+
+        // Start the animation
+        AnimationUtil.animateMarkerTo(marker, finalPosition, durationMs)
+
+        val mainLooper = Shadows.shadowOf(android.os.Looper.getMainLooper())
+
+        // Simulate time passing in 16ms increments until we exceed the animation duration
+        var timePassed = 0L
+        while (timePassed <= durationMs + 100) { // Allowing a little buffer for completion
+            mainLooper.idleFor(16, TimeUnit.MILLISECONDS)
+            timePassed += 16
+        }
+
+        // Check the final position — allowing a reasonable tolerance (0.5 or more)
+        assertEquals(10.0, currentPosition.latitude, 0.5)  // 0.5 tolerance
+        assertEquals(10.0, currentPosition.longitude, 0.5) // 0.5 tolerance
+    }
+}


### PR DESCRIPTION
The following PR introduces a new method, to modify the duration of the animation in the `AnimationUtil`. In order to keep the API backwards compatible and avoid a breaking change, the previous method is preserved.

Fixes #1504 