### PR TITLE
chore: migrated new Maven Central URL

### DIFF
--- a/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
@@ -111,9 +111,9 @@ class PublishingConventionPlugin : Plugin<Project> {
             repositories {
                 maven {
                     val releasesRepoUrl =
-                        uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+                        uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
                     val snapshotsRepoUrl =
-                        uri("https://oss.sonatype.org/content/repositories/snapshots/")
+                        uri("https://central.sonatype.com/repository/maven-snapshots/")
                     url = if (project.version.toString()
                             .endsWith("SNAPSHOT")
                     ) snapshotsRepoUrl else releasesRepoUrl


### PR DESCRIPTION
This draft PR migrates the URL required to push onto the new Maven Central. More information about it:

https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/