### PR TITLE
feat!: Add support for setOnInfoWindowCloseListener() for Markers

### DIFF
--- a/library/src/main/java/com/google/maps/android/clustering/ClusterManager.java
+++ b/library/src/main/java/com/google/maps/android/clustering/ClusterManager.java
@@ -65,8 +65,10 @@ public class ClusterManager<T extends ClusterItem> implements
 
     private OnClusterItemClickListener<T> mOnClusterItemClickListener;
     private OnClusterInfoWindowClickListener<T> mOnClusterInfoWindowClickListener;
+    private OnClusterInfoWindowCloseListener<T> mOnClusterInfoWindowCloseListener;
     private OnClusterInfoWindowLongClickListener<T> mOnClusterInfoWindowLongClickListener;
     private OnClusterItemInfoWindowClickListener<T> mOnClusterItemInfoWindowClickListener;
+    private OnClusterItemInfoWindowCloseListener<T> mOnClusterItemInfoWindowCloseListener;
     private OnClusterItemInfoWindowLongClickListener<T> mOnClusterItemInfoWindowLongClickListener;
     private OnClusterClickListener<T> mOnClusterClickListener;
 
@@ -109,9 +111,11 @@ public class ClusterManager<T extends ClusterItem> implements
         mRenderer.onAdd();
         mRenderer.setOnClusterClickListener(mOnClusterClickListener);
         mRenderer.setOnClusterInfoWindowClickListener(mOnClusterInfoWindowClickListener);
+        mRenderer.setOnClusterInfoWindowCloseListener(mOnClusterInfoWindowCloseListener);
         mRenderer.setOnClusterInfoWindowLongClickListener(mOnClusterInfoWindowLongClickListener);
         mRenderer.setOnClusterItemClickListener(mOnClusterItemClickListener);
         mRenderer.setOnClusterItemInfoWindowClickListener(mOnClusterItemInfoWindowClickListener);
+        mRenderer.setOnClusterItemInfoWindowCloseListener(mOnClusterItemInfoWindowCloseListener);
         mRenderer.setOnClusterItemInfoWindowLongClickListener(mOnClusterItemInfoWindowLongClickListener);
         cluster();
     }
@@ -371,6 +375,16 @@ public class ClusterManager<T extends ClusterItem> implements
     }
 
     /**
+     * Sets a callback that's invoked when a Cluster info window is closed. Note: For this listener to function,
+     * the ClusterManager must be added as a info window click listener to the map.
+     */
+    public void setOnClusterInfoWindowCloseListener(OnClusterInfoWindowCloseListener<T> listener) {
+        mOnClusterInfoWindowCloseListener = listener;
+        mRenderer.setOnClusterInfoWindowCloseListener(listener);
+    }
+
+
+    /**
      * Sets a callback that's invoked when a Cluster info window is long-pressed. Note: For this listener to function,
      * the ClusterManager must be added as a info window click listener to the map.
      */
@@ -395,6 +409,16 @@ public class ClusterManager<T extends ClusterItem> implements
     public void setOnClusterItemInfoWindowClickListener(OnClusterItemInfoWindowClickListener<T> listener) {
         mOnClusterItemInfoWindowClickListener = listener;
         mRenderer.setOnClusterItemInfoWindowClickListener(listener);
+    }
+
+
+    /**
+     * Sets a callback that's invoked when an individual ClusterItem's Info Window is closed. Note: For this
+     * listener to function, the ClusterManager must be added as a info window click listener to the map.
+     */
+    public void setOnClusterItemInfoWindowCloseListener(OnClusterItemInfoWindowCloseListener<T> listener) {
+        mOnClusterItemInfoWindowCloseListener = listener;
+        mRenderer.setOnClusterItemInfoWindowCloseListener(listener);
     }
 
     /**
@@ -426,6 +450,13 @@ public class ClusterManager<T extends ClusterItem> implements
     }
 
     /**
+     * Called when a Cluster's Info Window is closed.
+     */
+    public interface OnClusterInfoWindowCloseListener<T extends ClusterItem> {
+        void onClusterInfoWindowClose(Cluster<T> cluster);
+    }
+
+    /**
      * Called when a Cluster's Info Window is long clicked.
      */
     public interface OnClusterInfoWindowLongClickListener<T extends ClusterItem> {
@@ -454,6 +485,13 @@ public class ClusterManager<T extends ClusterItem> implements
      */
     public interface OnClusterItemInfoWindowClickListener<T extends ClusterItem> {
         void onClusterItemInfoWindowClick(T item);
+    }
+
+    /**
+     * Called when an individual ClusterItem's Info Window is closed.
+     */
+    public interface OnClusterItemInfoWindowCloseListener<T extends ClusterItem> {
+        void onClusterItemInfoWindowClose(T item);
     }
 
     /**

--- a/library/src/main/java/com/google/maps/android/clustering/view/ClusterRenderer.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/ClusterRenderer.java
@@ -40,11 +40,15 @@ public interface ClusterRenderer<T extends ClusterItem> {
 
     void setOnClusterInfoWindowClickListener(ClusterManager.OnClusterInfoWindowClickListener<T> listener);
 
+    void setOnClusterInfoWindowCloseListener(ClusterManager.OnClusterInfoWindowCloseListener<T> listener);
+
     void setOnClusterInfoWindowLongClickListener(ClusterManager.OnClusterInfoWindowLongClickListener<T> listener);
 
     void setOnClusterItemClickListener(ClusterManager.OnClusterItemClickListener<T> listener);
 
     void setOnClusterItemInfoWindowClickListener(ClusterManager.OnClusterItemInfoWindowClickListener<T> listener);
+
+    void setOnClusterItemInfoWindowCloseListener(ClusterManager.OnClusterItemInfoWindowCloseListener<T> listener);
 
     void setOnClusterItemInfoWindowLongClickListener(ClusterManager.OnClusterItemInfoWindowLongClickListener<T> listener);
 

--- a/library/src/main/java/com/google/maps/android/clustering/view/ClusterRendererMultipleItems.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/ClusterRendererMultipleItems.java
@@ -172,9 +172,11 @@ public class ClusterRendererMultipleItems<T extends ClusterItem> implements Clus
 
     private ClusterManager.OnClusterClickListener<T> mClickListener;
     private ClusterManager.OnClusterInfoWindowClickListener<T> mInfoWindowClickListener;
+    private ClusterManager.OnClusterInfoWindowCloseListener<T> mInfoWindowCloseListener;
     private ClusterManager.OnClusterInfoWindowLongClickListener<T> mInfoWindowLongClickListener;
     private ClusterManager.OnClusterItemClickListener<T> mItemClickListener;
     private ClusterManager.OnClusterItemInfoWindowClickListener<T> mItemInfoWindowClickListener;
+    private ClusterManager.OnClusterItemInfoWindowCloseListener<T> mItemInfoWindowCloseListener;
     private ClusterManager.OnClusterItemInfoWindowLongClickListener<T> mItemInfoWindowLongClickListener;
 
     public ClusterRendererMultipleItems(Context context, GoogleMap map, ClusterManager<T> clusterManager) {
@@ -205,6 +207,13 @@ public class ClusterRendererMultipleItems<T extends ClusterItem> implements Clus
             }
         });
 
+        mClusterManager.getMarkerCollection().setOnInfoWindowCloseListener(marker -> {
+            RendererLogger.d("ClusterRenderer", "Info window closed for marker: " + marker);
+            if (mItemInfoWindowCloseListener != null) {
+                mItemInfoWindowCloseListener.onClusterItemInfoWindowClose(mMarkerCache.get(marker));
+            }
+        });
+
         mClusterManager.getMarkerCollection().setOnInfoWindowLongClickListener(marker -> {
             RendererLogger.d("ClusterRenderer", "Info window long-clicked for marker: " + marker);
             if (mItemInfoWindowLongClickListener != null) {
@@ -223,6 +232,13 @@ public class ClusterRendererMultipleItems<T extends ClusterItem> implements Clus
             }
         });
 
+        mClusterManager.getClusterMarkerCollection().setOnInfoWindowCloseListener(marker -> {
+            RendererLogger.d("ClusterRenderer", "Info window closed for cluster marker: " + marker);
+            if (mInfoWindowCloseListener != null) {
+                mInfoWindowCloseListener.onClusterInfoWindowClose(mClusterMarkerCache.get(marker));
+            }
+        });
+
         mClusterManager.getClusterMarkerCollection().setOnInfoWindowLongClickListener(marker -> {
             RendererLogger.d("ClusterRenderer", "Info window long-clicked for cluster marker: " + marker);
             if (mInfoWindowLongClickListener != null) {
@@ -236,9 +252,11 @@ public class ClusterRendererMultipleItems<T extends ClusterItem> implements Clus
     public void onRemove() {
         mClusterManager.getMarkerCollection().setOnMarkerClickListener(null);
         mClusterManager.getMarkerCollection().setOnInfoWindowClickListener(null);
+        mClusterManager.getMarkerCollection().setOnInfoWindowCloseListener(null);
         mClusterManager.getMarkerCollection().setOnInfoWindowLongClickListener(null);
         mClusterManager.getClusterMarkerCollection().setOnMarkerClickListener(null);
         mClusterManager.getClusterMarkerCollection().setOnInfoWindowClickListener(null);
+        mClusterManager.getClusterMarkerCollection().setOnInfoWindowCloseListener(null);
         mClusterManager.getClusterMarkerCollection().setOnInfoWindowLongClickListener(null);
     }
 
@@ -592,6 +610,11 @@ public class ClusterRendererMultipleItems<T extends ClusterItem> implements Clus
     }
 
     @Override
+    public void setOnClusterInfoWindowCloseListener(ClusterManager.OnClusterInfoWindowCloseListener<T> listener) {
+        mInfoWindowCloseListener = listener;
+    }
+
+    @Override
     public void setOnClusterInfoWindowLongClickListener(ClusterManager.OnClusterInfoWindowLongClickListener<T> listener) {
         mInfoWindowLongClickListener = listener;
     }
@@ -604,6 +627,11 @@ public class ClusterRendererMultipleItems<T extends ClusterItem> implements Clus
     @Override
     public void setOnClusterItemInfoWindowClickListener(ClusterManager.OnClusterItemInfoWindowClickListener<T> listener) {
         mItemInfoWindowClickListener = listener;
+    }
+
+    @Override
+    public void setOnClusterItemInfoWindowCloseListener(ClusterManager.OnClusterItemInfoWindowCloseListener<T> listener) {
+        mItemInfoWindowCloseListener = listener;
     }
 
     @Override

--- a/library/src/main/java/com/google/maps/android/clustering/view/DefaultAdvancedMarkersClusterRenderer.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/DefaultAdvancedMarkersClusterRenderer.java
@@ -127,9 +127,11 @@ public class DefaultAdvancedMarkersClusterRenderer<T extends ClusterItem> implem
 
     private ClusterManager.OnClusterClickListener<T> mClickListener;
     private ClusterManager.OnClusterInfoWindowClickListener<T> mInfoWindowClickListener;
+    private ClusterManager.OnClusterInfoWindowCloseListener<T> mInfoWindowCloseListener;
     private ClusterManager.OnClusterInfoWindowLongClickListener<T> mInfoWindowLongClickListener;
     private ClusterManager.OnClusterItemClickListener<T> mItemClickListener;
     private ClusterManager.OnClusterItemInfoWindowClickListener<T> mItemInfoWindowClickListener;
+    private ClusterManager.OnClusterItemInfoWindowCloseListener<T> mItemInfoWindowCloseListener;
     private ClusterManager.OnClusterItemInfoWindowLongClickListener<T> mItemInfoWindowLongClickListener;
 
     public DefaultAdvancedMarkersClusterRenderer(Context context, GoogleMap map, ClusterManager<T> clusterManager) {
@@ -162,6 +164,15 @@ public class DefaultAdvancedMarkersClusterRenderer<T extends ClusterItem> implem
             }
         });
 
+        mClusterManager.getMarkerCollection().setOnInfoWindowCloseListener(new GoogleMap.OnInfoWindowCloseListener() {
+            @Override
+            public void onInfoWindowClose(@NonNull Marker marker) {
+                if (mItemInfoWindowCloseListener != null) {
+                    mItemInfoWindowCloseListener.onClusterItemInfoWindowClose(mMarkerCache.get(marker));
+                }
+            }
+        });
+
         mClusterManager.getMarkerCollection().setOnInfoWindowLongClickListener(marker -> {
             if (mItemInfoWindowLongClickListener != null) {
                 mItemInfoWindowLongClickListener.onClusterItemInfoWindowLongClick(mMarkerCache.get(marker));
@@ -177,6 +188,12 @@ public class DefaultAdvancedMarkersClusterRenderer<T extends ClusterItem> implem
             }
         });
 
+        mClusterManager.getClusterMarkerCollection().setOnInfoWindowCloseListener(marker -> {
+            if (mInfoWindowCloseListener != null) {
+                mInfoWindowCloseListener.onClusterInfoWindowClose(mClusterMarkerCache.get(marker));
+            }
+        });
+
         mClusterManager.getClusterMarkerCollection().setOnInfoWindowLongClickListener(marker -> {
             if (mInfoWindowLongClickListener != null) {
                 mInfoWindowLongClickListener.onClusterInfoWindowLongClick(mClusterMarkerCache.get(marker));
@@ -188,9 +205,11 @@ public class DefaultAdvancedMarkersClusterRenderer<T extends ClusterItem> implem
     public void onRemove() {
         mClusterManager.getMarkerCollection().setOnMarkerClickListener(null);
         mClusterManager.getMarkerCollection().setOnInfoWindowClickListener(null);
+        mClusterManager.getMarkerCollection().setOnInfoWindowCloseListener(null);
         mClusterManager.getMarkerCollection().setOnInfoWindowLongClickListener(null);
         mClusterManager.getClusterMarkerCollection().setOnMarkerClickListener(null);
         mClusterManager.getClusterMarkerCollection().setOnInfoWindowClickListener(null);
+        mClusterManager.getClusterMarkerCollection().setOnInfoWindowCloseListener(null);
         mClusterManager.getClusterMarkerCollection().setOnInfoWindowLongClickListener(null);
     }
 
@@ -544,6 +563,11 @@ public class DefaultAdvancedMarkersClusterRenderer<T extends ClusterItem> implem
     }
 
     @Override
+    public void setOnClusterInfoWindowCloseListener(ClusterManager.OnClusterInfoWindowCloseListener<T> listener) {
+        mInfoWindowCloseListener = listener;
+    }
+
+    @Override
     public void setOnClusterInfoWindowLongClickListener(ClusterManager.OnClusterInfoWindowLongClickListener<T> listener) {
         mInfoWindowLongClickListener = listener;
     }
@@ -556,6 +580,11 @@ public class DefaultAdvancedMarkersClusterRenderer<T extends ClusterItem> implem
     @Override
     public void setOnClusterItemInfoWindowClickListener(ClusterManager.OnClusterItemInfoWindowClickListener<T> listener) {
         mItemInfoWindowClickListener = listener;
+    }
+
+    @Override
+    public void setOnClusterItemInfoWindowCloseListener(ClusterManager.OnClusterItemInfoWindowCloseListener<T> listener) {
+        mItemInfoWindowCloseListener = listener;
     }
 
     @Override

--- a/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
@@ -126,9 +126,11 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
 
     private ClusterManager.OnClusterClickListener<T> mClickListener;
     private ClusterManager.OnClusterInfoWindowClickListener<T> mInfoWindowClickListener;
+    private ClusterManager.OnClusterInfoWindowCloseListener<T> mInfoWindowCloseListener;
     private ClusterManager.OnClusterInfoWindowLongClickListener<T> mInfoWindowLongClickListener;
     private ClusterManager.OnClusterItemClickListener<T> mItemClickListener;
     private ClusterManager.OnClusterItemInfoWindowClickListener<T> mItemInfoWindowClickListener;
+    private ClusterManager.OnClusterItemInfoWindowCloseListener<T> mItemInfoWindowCloseListener;
     private ClusterManager.OnClusterItemInfoWindowLongClickListener<T> mItemInfoWindowLongClickListener;
 
     public DefaultClusterRenderer(Context context, GoogleMap map, ClusterManager<T> clusterManager) {
@@ -153,6 +155,12 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
             }
         });
 
+        mClusterManager.getMarkerCollection().setOnInfoWindowCloseListener(marker -> {
+            if (mItemInfoWindowCloseListener != null) {
+                mItemInfoWindowCloseListener.onClusterItemInfoWindowClose(mMarkerCache.get(marker));
+            }
+        });
+
         mClusterManager.getMarkerCollection().setOnInfoWindowLongClickListener(marker -> {
             if (mItemInfoWindowLongClickListener != null) {
                 mItemInfoWindowLongClickListener.onClusterItemInfoWindowLongClick(mMarkerCache.get(marker));
@@ -168,6 +176,12 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
             }
         });
 
+        mClusterManager.getClusterMarkerCollection().setOnInfoWindowCloseListener(marker -> {
+            if (mInfoWindowCloseListener != null) {
+                mInfoWindowCloseListener.onClusterInfoWindowClose(mClusterMarkerCache.get(marker));
+            }
+        });
+
         mClusterManager.getClusterMarkerCollection().setOnInfoWindowLongClickListener(marker -> {
             if (mInfoWindowLongClickListener != null) {
                 mInfoWindowLongClickListener.onClusterInfoWindowLongClick(mClusterMarkerCache.get(marker));
@@ -179,9 +193,11 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
     public void onRemove() {
         mClusterManager.getMarkerCollection().setOnMarkerClickListener(null);
         mClusterManager.getMarkerCollection().setOnInfoWindowClickListener(null);
+        mClusterManager.getMarkerCollection().setOnInfoWindowCloseListener(null);
         mClusterManager.getMarkerCollection().setOnInfoWindowLongClickListener(null);
         mClusterManager.getClusterMarkerCollection().setOnMarkerClickListener(null);
         mClusterManager.getClusterMarkerCollection().setOnInfoWindowClickListener(null);
+        mClusterManager.getClusterMarkerCollection().setOnInfoWindowCloseListener(null);
         mClusterManager.getClusterMarkerCollection().setOnInfoWindowLongClickListener(null);
     }
 
@@ -535,6 +551,11 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
     }
 
     @Override
+    public void setOnClusterInfoWindowCloseListener(ClusterManager.OnClusterInfoWindowCloseListener<T> listener) {
+        mInfoWindowCloseListener = listener;
+    }
+
+    @Override
     public void setOnClusterInfoWindowLongClickListener(ClusterManager.OnClusterInfoWindowLongClickListener<T> listener) {
         mInfoWindowLongClickListener = listener;
     }
@@ -547,6 +568,11 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
     @Override
     public void setOnClusterItemInfoWindowClickListener(ClusterManager.OnClusterItemInfoWindowClickListener<T> listener) {
         mItemInfoWindowClickListener = listener;
+    }
+
+    @Override
+    public void setOnClusterItemInfoWindowCloseListener(ClusterManager.OnClusterItemInfoWindowCloseListener<T> listener) {
+        mItemInfoWindowCloseListener = listener;
     }
 
     @Override

--- a/library/src/main/java/com/google/maps/android/collections/MarkerManager.java
+++ b/library/src/main/java/com/google/maps/android/collections/MarkerManager.java
@@ -34,6 +34,7 @@ import androidx.annotation.NonNull;
  */
 public class MarkerManager extends MapObjectManager<Marker, MarkerManager.Collection> implements
         GoogleMap.OnInfoWindowClickListener,
+        GoogleMap.OnInfoWindowCloseListener,
         GoogleMap.OnMarkerClickListener,
         GoogleMap.OnMarkerDragListener,
         GoogleMap.InfoWindowAdapter,
@@ -47,6 +48,7 @@ public class MarkerManager extends MapObjectManager<Marker, MarkerManager.Collec
     void setListenersOnUiThread() {
         if (mMap != null) {
             mMap.setOnInfoWindowClickListener(this);
+            mMap.setOnInfoWindowCloseListener(this);
             mMap.setOnInfoWindowLongClickListener(this);
             mMap.setOnMarkerClickListener(this);
             mMap.setOnMarkerDragListener(this);
@@ -81,6 +83,14 @@ public class MarkerManager extends MapObjectManager<Marker, MarkerManager.Collec
         Collection collection = mAllObjects.get(marker);
         if (collection != null && collection.mInfoWindowClickListener != null) {
             collection.mInfoWindowClickListener.onInfoWindowClick(marker);
+        }
+    }
+
+    @Override
+    public void onInfoWindowClose(@NonNull Marker marker) {
+        Collection collection = mAllObjects.get(marker);
+        if (collection != null && collection.mInfoWindowCloseListener != null) {
+            collection.mInfoWindowCloseListener.onInfoWindowClose(marker);
         }
     }
 
@@ -132,6 +142,7 @@ public class MarkerManager extends MapObjectManager<Marker, MarkerManager.Collec
 
     public class Collection extends MapObjectManager.Collection {
         private GoogleMap.OnInfoWindowClickListener mInfoWindowClickListener;
+        private GoogleMap.OnInfoWindowCloseListener mInfoWindowCloseListener;
         private GoogleMap.OnInfoWindowLongClickListener mInfoWindowLongClickListener;
         private GoogleMap.OnMarkerClickListener mMarkerClickListener;
         private GoogleMap.OnMarkerDragListener mMarkerDragListener;
@@ -185,6 +196,10 @@ public class MarkerManager extends MapObjectManager<Marker, MarkerManager.Collec
 
         public void setOnInfoWindowClickListener(GoogleMap.OnInfoWindowClickListener infoWindowClickListener) {
             mInfoWindowClickListener = infoWindowClickListener;
+        }
+
+        public void setOnInfoWindowCloseListener(GoogleMap.OnInfoWindowCloseListener infoWindowCloseListener) {
+            mInfoWindowCloseListener = infoWindowCloseListener;
         }
 
         public void setOnInfoWindowLongClickListener(GoogleMap.OnInfoWindowLongClickListener infoWindowLongClickListener) {


### PR DESCRIPTION
BREAKING CHANGE: ClusterRenderer adds two InfoWindowClose listeners. Applications that used ClusterRenderer or MarkerManager with GoogleMap.setOnInfoWindowCloseListener must now register their listener(s) with relevant collection/clustering management class.

Circa 2020, we added some more InfoWindow-related events to Marker/ClusterManager but InfoWindowClose was not included. This change addresses a discrepancy in the class documentation for MarkerManager which claims to "[d]elegates all Marker-related events to each ...".  The close handler has been missing.

[1] https://github.com/googlemaps/android-maps-utils/commit/8a3fc0195a61cb794c01ca266f59f1c034487484

Addresses #1540 

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Edit the title of this pull request with a [semantic commit prefix](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#type) (e.g. "fix: "), which is necessary for automated release workflows to decide whether to generate a new release and what type it should be.
- [X] Will this cause breaking changes to existing Java or Kotlin integrations? If so, ensure the commit has a `BREAKING CHANGE` footer so when this change is integrated a major version update is triggered. See: https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
