### PR TITLE
chore: fix SARIF upload by splitting per category

### DIFF
--- a/.github/workflows/lint-report.yml
+++ b/.github/workflows/lint-report.yml
@@ -36,11 +36,14 @@ jobs:
       - name: Run Android Lint
         run: ./gradlew lint
 
-      - name: Merge SARIF files
-        run: |
-          jq -s '{ "$schema": "https://json.schemastore.org/sarif-2.1.0", "version": "2.1.0", "runs": map(.runs) | add }'  library/build/reports/lint-results-debug.sarif  demo/build/reports/lint-results-debug.sarif > merged.sarif
-
-      - name: Upload SARIF file
+      - name: Upload SARIF for library
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: merged.sarif
+          sarif_file: library/build/reports/lint-results-debug.sarif
+          category: library
+
+      - name: Upload SARIF for demo
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: demo/build/reports/lint-results-debug.sarif
+          category: demo


### PR DESCRIPTION
This PR updates the workflow to upload SARIF files separately for each module (library, demo) with distinct categories.

Merging SARIF runs is [no longer supported](https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/) by GitHub Code Scanning as of mid-2025. This change ensures compatibility and removes the deprecated jq merge step.