### PR TITLE
chore: update Maven configuration

### DIFF
--- a/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
@@ -67,7 +67,7 @@ class PublishingConventionPlugin : Plugin<Project> {
             signAllPublications()
 
             pom {
-                name.set(project.name)
+                name.set("android-maps-utils")
                 description.set("Handy extensions to the Google Maps Android API.")
                 url.set("https://github.com/googlemaps/android-maps-utils")
                 licenses {


### PR DESCRIPTION
This PR modifies the Maven plugin configuration to set it as android-maps-utils, allowing us to publish on Maven Central under this category.