### PR TITLE
chore: small tweak to put the minimum SDK into the version catalog

### DIFF
--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -28,7 +28,7 @@ android {
     defaultConfig {
         compileSdk = libs.versions.compileSdk.get().toInt()
         applicationId = "com.google.maps.android.utils.demo"
-        minSdk = 21
+        minSdk = libs.versions.minimumSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
         versionCode = 1
         versionName = "1.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,8 @@
 [versions]
 compileSdk = "36"
 targetSdk = "36"
+minimumSdk = "21"
+
 appcompat = "1.7.1"
 dokka-gradle-plugin = "2.0.0"
 gradle = "8.13.0"


### PR DESCRIPTION
This PR moves the minimum SDK version to the version catalog.