### PR TITLE
feat: added cap to polyline

### DIFF
--- a/library/src/main/java/com/google/maps/android/data/geojson/GeoJsonLineStringStyle.java
+++ b/library/src/main/java/com/google/maps/android/data/geojson/GeoJsonLineStringStyle.java
@@ -151,12 +151,12 @@ public class GeoJsonLineStringStyle extends Style implements GeoJsonStyle {
         styleChanged();
     }
 
-    public void setStartCap(Cap cap) {
+    public void setStartCap(@NonNull Cap cap) {
         mPolylineOptions.startCap(cap);
         styleChanged();
     }
 
-    public void setEndCap(Cap cap) {
+    public void setEndCap(@NonNull Cap cap) {
         mPolylineOptions.endCap(cap);
         styleChanged();
     }


### PR DESCRIPTION
The following PR adds the option to set the `startCap` and `endCap` to the polyline.

Fixes: https://github.com/googlemaps/android-maps-utils/issues/1545