### PR TITLE
chore: Make DEFAULT_TOLERANCE public

### DIFF
--- a/library/src/main/java/com/google/maps/android/PolyUtil.kt
+++ b/library/src/main/java/com/google/maps/android/PolyUtil.kt
@@ -46,7 +46,7 @@ import kotlin.math.tan
  * using either geodesic (great circle) or rhumb (loxodromic) paths.
  */
 object PolyUtil {
-    private const val DEFAULT_TOLERANCE = 0.1 // meters
+    const val DEFAULT_TOLERANCE = 0.1 // meters
 
     /**
      * Computes whether the given point lies inside the specified polygon.


### PR DESCRIPTION
Make the `DEFAULT_TOLERANCE` constant in `PolyUtil` public, reverting an oversite when the class was ported to Kotlin.
