### PR TITLE
refactor: Improve null safety and readability in createInfoWindow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ dependencies {
     // Utilities for Maps SDK for Android (requires Google Play Services)
     // You do not need to add a separate dependency for the Maps SDK for Android
     // since this library builds in the compatible version of the Maps SDK.
-    implementation 'com.google.maps.android:android-maps-utils:3.19.0'
+    implementation 'com.google.maps.android:android-maps-utils:3.19.1'
 
     // Optionally add the Kotlin Extensions (KTX) for full Kotlin language support
     // See latest version at https://github.com/googlemaps/android-maps-ktx

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,5 +37,5 @@ tasks.register<Delete>("clean") {
 
 allprojects {
     group = "com.google.maps.android"
-    version = "3.19.0"
+    version = "3.19.1"
 }

--- a/library/src/main/java/com/google/maps/android/data/Renderer.java
+++ b/library/src/main/java/com/google/maps/android/data/Renderer.java
@@ -1145,23 +1145,33 @@ public class Renderer {
 
     /**
      * Creates a new InfoWindowAdapter and sets text if marker snippet or title is set. This allows
-     * the info window to have custom HTML.
+     * the info window to have custom HTML. If the marker has no title, the InfoWindow is deactivated.
      */
     private void createInfoWindow() {
         mMarkers.setInfoWindowAdapter(new GoogleMap.InfoWindowAdapter() {
 
-            public View getInfoWindow(@NonNull Marker arg0) {
+            public View getInfoWindow(@NonNull Marker marker) {
                 return null;
             }
 
-            public View getInfoContents(@NonNull Marker arg0) {
+            @Override
+            public View getInfoContents(@NonNull Marker marker) {
+                String title = marker.getTitle();
+                if (title == null) {
+                    return null;
+                }
+
                 View view = LayoutInflater.from(mContext).inflate(R.layout.amu_info_window, null);
                 TextView infoWindowText = view.findViewById(R.id.window);
-                if (arg0.getSnippet() != null) {
-                    infoWindowText.setText(Html.fromHtml(arg0.getTitle() + "<br>" + arg0.getSnippet()));
-                } else {
-                    infoWindowText.setText(Html.fromHtml(arg0.getTitle()));
+
+                StringBuilder infoText = new StringBuilder(title);
+
+                String snippet = marker.getSnippet();
+                if (snippet != null) {
+                    infoText.append("<br>").append(snippet);
                 }
+                infoWindowText.setText(Html.fromHtml(infoText.toString()));
+
                 return view;
             }
         });


### PR DESCRIPTION
Refactor the createInfoWindow method in Renderer.java. A minor improvement, focusing on null safety, clearer parameter naming, and a more robust way to build the info window text.
