### PR TITLE
feat: Add BoM module and fix modularized artifactIds

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 plugins {
     id("android.maps.utils.BomPublishingConventionPlugin")
 }

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    id("android.maps.utils.BomPublishingConventionPlugin")
+}
+
+dependencies {
+    constraints {
+        api(project(":clustering"))
+        api(project(":data"))
+        api(project(":heatmaps"))
+        api(project(":library"))
+        api(project(":onion"))
+        api(project(":ui"))
+        api(project(":visual-testing"))
+    }
+}

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -39,5 +39,9 @@ gradlePlugin {
             id = "android.maps.utils.PublishingConventionPlugin"
             implementationClass = "PublishingConventionPlugin"
         }
+        register("bomPublishingConventionPlugin") {
+            id = "android.maps.utils.BomPublishingConventionPlugin"
+            implementationClass = "BomPublishingConventionPlugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/BomPublishingConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/BomPublishingConventionPlugin.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.*
+
+class BomPublishingConventionPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.run {
+            apply(plugin = "java-platform")
+            apply(plugin = "com.vanniktech.maven.publish")
+            
+            extensions.configure<MavenPublishBaseExtension> {
+                publishToMavenCentral()
+                signAllPublications()
+
+                coordinates(
+                    artifactId = "maps-utils-bom",
+                )
+
+                pom {
+                    name.set("android-maps-utils-bom")
+                    description.set("BoM for android-maps-utils")
+                    url.set("https://github.com/googlemaps/android-maps-utils")
+                    licenses {
+                        license {
+                            name.set("The Apache Software License, Version 2.0")
+                            url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                            distribution.set("repo")
+                        }
+                    }
+                    scm {
+                        connection.set("scm:git@github.com:googlemaps/android-maps-utils.git")
+                        developerConnection.set("scm:git@github.com:googlemaps/android-maps-utils.git")
+                        url.set("https://github.com/googlemaps/android-maps-utils")
+                    }
+                    developers {
+                        developer {
+                            id.set("google")
+                            name.set("Google LLC")
+                        }
+                    }
+                    organization {
+                        name.set("Google Inc")
+                        url.set("http://developers.google.com/maps")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
@@ -66,8 +66,13 @@ class PublishingConventionPlugin : Plugin<Project> {
             publishToMavenCentral()
             signAllPublications()
 
+            val artifactName = if (project.name == "library") {
+                "android-maps-utils"
+            } else {
+                "maps-utils-${project.name}"
+            }
             coordinates(
-                artifactId = "android-maps-utils",
+                artifactId = artifactName,
             )
 
             pom {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,4 +29,4 @@ pluginManagement {
     }
 }
 
-include("demo", "clustering", "heatmaps", "ui", "data", "lint-checks", "library", "onion", "visual-testing")
+include("demo", "clustering", "heatmaps", "ui", "data", "lint-checks", "library", "onion", "visual-testing", "bom")


### PR DESCRIPTION
- Adds a new `bom` module applying the `java-platform` plugin to enforce version alignment for all the newly modularized components.
- Adds `BomPublishingConventionPlugin` to standardise publishing of the BoM.
- Fixes an issue where all modules were being published with the legacy `android-maps-utils` artifact ID, which would cause them to overwrite each other on Maven Central. Modules are now published as `maps-utils-clustering`, `maps-utils-heatmaps`, etc., while `library` correctly retains the legacy `android-maps-utils` artifact ID.