### PR TITLE
build: fix expression injection in triage-issue.yml

### DIFF
--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -56,9 +56,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          LABELS: ${{ steps.run_script.outputs.labels }}
         run: |
           # Convert comma-separated labels to gh command arguments
-          IFS=',' read -ra ADDR <<< "${{ steps.run_script.outputs.labels }}"
+          IFS=',' read -ra ADDR <<< "$LABELS"
           priority_added=false
           for i in "${ADDR[@]}"; do
             # Trim whitespace


### PR DESCRIPTION
## Summary

Fixes GitHub Actions expression injection vulnerability in the Apply Labels step of the issue triage workflow.

## Problem

`${{ steps.run_script.outputs.labels }}` was expanded directly into a shell `run:` block. Since the labels originate from Gemini API output (which processes attacker-controlled issue body), a prompt injection attack can cause the API to return labels containing shell metacharacters (`$()`, `"`, `;`). GitHub Actions expands `${{ }}` before bash parses the script, enabling arbitrary command execution and exfiltration of `GEMINI_API_KEY` and `GITHUB_TOKEN`.

## Fix

Moved `${{ steps.run_script.outputs.labels }}` to the `env:` block as `LABELS`, then reference it as `$LABELS` in the shell. Environment variables are not subject to expression injection.