### PR TITLE
fix: disable XML external entities in KML parser

### DIFF
--- a/library/src/main/java/com/google/maps/android/data/kml/KmlLayer.java
+++ b/library/src/main/java/com/google/maps/android/data/kml/KmlLayer.java
@@ -198,6 +198,8 @@ public class KmlLayer extends Layer {
      */
     private static XmlPullParser createXmlParser(InputStream stream) throws XmlPullParserException {
         XmlPullParserFactory factory = XmlPullParserFactory.newInstance();
+        factory.setFeature(XmlPullParser.FEATURE_PROCESS_DOCDECL, false);
+        factory.setFeature(XmlPullParser.FEATURE_VALIDATION, false);
         factory.setNamespaceAware(true);
         XmlPullParser parser = factory.newPullParser();
         parser.setInput(stream, null);

--- a/library/src/test/java/com/google/maps/android/data/kml/KmlTestUtil.java
+++ b/library/src/test/java/com/google/maps/android/data/kml/KmlTestUtil.java
@@ -36,6 +36,8 @@ public class KmlTestUtil {
     static XmlPullParser createParser(String fileName) throws XmlPullParserException, IOException {
         InputStream stream = KmlTestUtil.class.getClassLoader().getResourceAsStream(fileName);
         XmlPullParserFactory factory = XmlPullParserFactory.newInstance();
+        factory.setFeature(XmlPullParser.FEATURE_PROCESS_DOCDECL, false);
+        factory.setFeature(XmlPullParser.FEATURE_VALIDATION, false);
         factory.setNamespaceAware(true);
         XmlPullParser parser = factory.newPullParser();
         parser.setInput(stream, null);


### PR DESCRIPTION
Disables XML External Entity (XXE) features in `XmlPullParserFactory` to prevent security vulnerabilities during KML parsing.