### PR TITLE
fix: restrict KML image downloads to http/https schemes

### DIFF
--- a/library/src/main/java/com/google/maps/android/data/kml/KmlRenderer.java
+++ b/library/src/main/java/com/google/maps/android/data/kml/KmlRenderer.java
@@ -538,8 +538,6 @@ public class KmlRenderer extends Renderer {
         protected Bitmap doInBackground(String... params) {
             try {
                 return getBitmapFromUrl(mIconUrl);
-            } catch (MalformedURLException e) {
-                return BitmapFactory.decodeFile(mIconUrl);
             } catch (IOException e) {
                 e.printStackTrace();
             }
@@ -588,8 +586,6 @@ public class KmlRenderer extends Renderer {
         protected Bitmap doInBackground(String... params) {
             try {
                 return getBitmapFromUrl(mGroundOverlayUrl);
-            } catch (MalformedURLException e) {
-                return BitmapFactory.decodeFile(mGroundOverlayUrl);
             } catch (IOException e) {
                 Log.e(LOG_TAG, "Image [" + mGroundOverlayUrl + "] download issue", e);
             }
@@ -621,7 +617,11 @@ public class KmlRenderer extends Renderer {
      * @return the bitmap of that image, scaled according to screen density.
      */
     private Bitmap getBitmapFromUrl(String url) throws IOException {
-        return BitmapFactory.decodeStream(openConnectionCheckRedirects(new URL(url).openConnection()));
+        URL parsedUrl = new URL(url);
+        if (!parsedUrl.getProtocol().equalsIgnoreCase("http") && !parsedUrl.getProtocol().equalsIgnoreCase("https")) {
+            throw new MalformedURLException("Unsupported scheme: " + parsedUrl.getProtocol());
+        }
+        return BitmapFactory.decodeStream(openConnectionCheckRedirects(parsedUrl.openConnection()));
     }
 
     /**

--- a/library/src/test/java/com/google/maps/android/data/kml/KmlRendererTest.java
+++ b/library/src/test/java/com/google/maps/android/data/kml/KmlRendererTest.java
@@ -77,4 +77,42 @@ public class KmlRendererTest {
         assertNotNull(styleMap.get("BlueKey"));
         assertEquals(styles.get("BlueKey"), redStyle);
     }
+
+    @Test
+    public void testBitmapUrlSchemeValidation() throws Exception {
+        KmlRenderer renderer = new KmlRenderer(null, null, null, null, null, null, null);
+        java.lang.reflect.Method method = KmlRenderer.class.getDeclaredMethod("getBitmapFromUrl", String.class);
+        method.setAccessible(true);
+        
+        // Should throw MalformedURLException for file:// scheme
+        try {
+            method.invoke(renderer, "file:///android_asset/image.png");
+            org.junit.Assert.fail("Should have thrown InvocationTargetException containing MalformedURLException");
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            assertTrue(e.getCause() instanceof java.net.MalformedURLException);
+            assertEquals("Unsupported scheme: file", e.getCause().getMessage());
+        }
+
+        // Should throw MalformedURLException for ftp:// scheme
+        try {
+            method.invoke(renderer, "ftp://example.com/image.png");
+            org.junit.Assert.fail("Should have thrown InvocationTargetException containing MalformedURLException");
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            assertTrue(e.getCause() instanceof java.net.MalformedURLException);
+            assertEquals("Unsupported scheme: ftp", e.getCause().getMessage());
+        }
+        
+        // For http/https, it should not throw MalformedURLException with "Unsupported scheme"
+        try {
+            method.invoke(renderer, "http://example.com/image.png");
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            org.junit.Assert.assertFalse(e.getCause().getMessage() != null && e.getCause().getMessage().startsWith("Unsupported scheme"));
+        }
+        
+        try {
+            method.invoke(renderer, "https://example.com/image.png");
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            org.junit.Assert.assertFalse(e.getCause().getMessage() != null && e.getCause().getMessage().startsWith("Unsupported scheme"));
+        }
+    }
 }


### PR DESCRIPTION
Addresses a security vulnerability by enforcing that KML external resources are only downloaded over HTTP/HTTPS, preventing local file access and SSRF. Also removes the fallback to `BitmapFactory.decodeFile()`.