### PR TITLE
fix: prevent NPE in LatLngBounds.contains by adding null checks for positions

### DIFF
--- a/library/src/main/java/com/google/maps/android/clustering/view/ClusterRendererMultipleItems.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/ClusterRendererMultipleItems.java
@@ -524,7 +524,7 @@ public class ClusterRendererMultipleItems<T extends ClusterItem> implements Clus
             }
 
             for (final MarkerWithPosition marker : markersToRemove) {
-                boolean onScreen = visibleBounds.contains(marker.position);
+                boolean onScreen = marker.position != null && visibleBounds.contains(marker.position);
                 if (onScreen && mAnimate) {
                     final Point point = mSphericalMercatorProjection.toPoint(marker.position);
                     final Point closest = findClosestCluster(newClustersOnScreen, point);

--- a/library/src/main/java/com/google/maps/android/clustering/view/DefaultAdvancedMarkersClusterRenderer.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/DefaultAdvancedMarkersClusterRenderer.java
@@ -453,7 +453,7 @@ public class DefaultAdvancedMarkersClusterRenderer<T extends ClusterItem> implem
             if (DefaultAdvancedMarkersClusterRenderer.this.mClusters != null && mAnimate) {
                 existingClustersOnScreen = new ArrayList<>();
                 for (Cluster<T> c : DefaultAdvancedMarkersClusterRenderer.this.mClusters) {
-                    if (shouldRenderAsCluster(c) && visibleBounds.contains(c.getPosition())) {
+                    if (shouldRenderAsCluster(c) && c.getPosition() != null && visibleBounds.contains(c.getPosition())) {
                         Point point = mSphericalMercatorProjection.toPoint(c.getPosition());
                         existingClustersOnScreen.add(point);
                     }
@@ -492,7 +492,7 @@ public class DefaultAdvancedMarkersClusterRenderer<T extends ClusterItem> implem
             if (mAnimate) {
                 newClustersOnScreen = new ArrayList<>();
                 for (Cluster<T> c : clusters) {
-                    if (shouldRenderAsCluster(c) && visibleBounds.contains(c.getPosition())) {
+                    if (shouldRenderAsCluster(c) && c.getPosition() != null && visibleBounds.contains(c.getPosition())) {
                         Point p = mSphericalMercatorProjection.toPoint(c.getPosition());
                         newClustersOnScreen.add(p);
                     }

--- a/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
@@ -492,7 +492,7 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
 
             // Remove the old markers, animating them into clusters if zooming out.
             for (final MarkerWithPosition marker : markersToRemove) {
-                boolean onScreen = visibleBounds.contains(marker.position);
+                boolean onScreen = marker.position != null && visibleBounds.contains(marker.position);
                 // Don't animate when zooming out more than 3 zoom levels.
                 // TODO: drop animation based on speed of device & number of markers to animate.
                 if (!zoomingIn && zoomDelta > -3 && onScreen && mAnimate) {


### PR DESCRIPTION
Does not fix the problem on voracious EOMs, but adds some Null security to prevent issues like in https://github.com/googlemaps/android-maps-utils/issues/1634