### PR TITLE
feat: add navigation flavor to demo for SDK 7.x reproduction

### DIFF
--- a/.github/workflows/lint-report.yml
+++ b/.github/workflows/lint-report.yml
@@ -48,5 +48,5 @@ jobs:
       - name: Upload SARIF for demo
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: demo/build/reports/lint-results-debug.sarif
+          sarif_file: demo/build/reports/lint-results-standardDebug.sarif
           category: demo

--- a/.github/workflows/lint-report.yml
+++ b/.github/workflows/lint-report.yml
@@ -37,7 +37,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Run Android Lint
-        run: ./gradlew lint
+        run: ./gradlew :library:lintDebug :demo:lintStandardDebug
 
       - name: Upload SARIF for library
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/lint-report.yml
+++ b/.github/workflows/lint-report.yml
@@ -42,11 +42,11 @@ jobs:
       - name: Upload SARIF for library
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: library/build/reports/lint-results-debug.sarif
+          sarif_file: library/build/reports/lint-results.sarif
           category: library
 
       - name: Upload SARIF for demo
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: demo/build/reports/lint-results-standardDebug.sarif
+          sarif_file: demo/build/reports/lint-results.sarif
           category: demo

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -82,7 +82,7 @@ android {
 
 // [START maps_android_utils_install_snippet]
 dependencies {
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs_nio:2.0.3")
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
     // [START_EXCLUDE silent]
     "standardImplementation"(project(":library"))
     "navigationImplementation"(project(":library")) {

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -25,7 +25,6 @@ plugins {
 
 android {
     lint {
-        sarifOutput = layout.buildDirectory.file("reports/lint-results.sarif").get().asFile
     }
 
     defaultConfig {

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -70,6 +70,7 @@ android {
     productFlavors {
         create("standard") {
             dimension = "sdk"
+            isDefault = true
         }
         create("navigation") {
             dimension = "sdk"

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -60,13 +60,29 @@ android {
     }
 
     namespace = "com.google.maps.android.utils.demo"
+
+    flavorDimensions += "sdk"
+    productFlavors {
+        create("standard") {
+            dimension = "sdk"
+        }
+        create("navigation") {
+            dimension = "sdk"
+            minSdk = 24 // Navigation SDK 7.x requires API 24+
+        }
+    }
 }
 
 // [START maps_android_utils_install_snippet]
 dependencies {
     // [START_EXCLUDE silent]
-    implementation(project(":library"))
+    "standardImplementation"(project(":library"))
+    "navigationImplementation"(project(":library")) {
+        exclude(group = "com.google.android.gms", module = "play-services-maps")
+    }
 
+    "navigationImplementation"(libs.navigation.sdk)
+    
     implementation(libs.appcompat)
     implementation(libs.lifecycle.extensions)
     implementation(libs.lifecycle.viewmodel.ktx)

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -25,6 +25,7 @@ plugins {
 
 android {
     lint {
+        sarifOutput = layout.buildDirectory.file("reports/lint-results.sarif").get().asFile
     }
 
     defaultConfig {

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -52,6 +52,12 @@ android {
         compose = true
     }
 
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
     kotlin {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
@@ -75,6 +81,7 @@ android {
 
 // [START maps_android_utils_install_snippet]
 dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs_nio:2.0.3")
     // [START_EXCLUDE silent]
     "standardImplementation"(project(":library"))
     "navigationImplementation"(project(":library")) {

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -42,10 +42,6 @@
         android:theme="@style/AppTheme"
         tools:ignore="GoogleAppIndexingWarning">
 
-        <meta-data
-            android:name="com.google.android.gms.version"
-            android:value="@integer/google_play_services_version" />
-
         <!--
         To add your Maps API key to this project:
             1. Open the file local.properties under the root project

--- a/demo/src/main/java/com/google/maps/android/utils/demo/BaseDemoActivity.java
+++ b/demo/src/main/java/com/google/maps/android/utils/demo/BaseDemoActivity.java
@@ -23,12 +23,12 @@ import android.view.View;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.GoogleMapOptions;
 import com.google.android.gms.maps.OnMapReadyCallback;
-import com.google.android.gms.maps.SupportMapFragment;
 
 import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
@@ -97,18 +97,15 @@ public abstract class BaseDemoActivity extends FragmentActivity implements OnMap
         // 2. Call the getMapId() method
         String mapId = app.getMapId();
 
-        // Create a new SupportMapFragment instance
-        SupportMapFragment mapFragment;
-
-        if (mapId == null) {
-            mapFragment = SupportMapFragment.newInstance();
-        } else {
-            // Create the map options
-            GoogleMapOptions mapOptions = new GoogleMapOptions();
+        // Create the map options
+        GoogleMapOptions mapOptions = null;
+        if (mapId != null) {
+            mapOptions = new GoogleMapOptions();
             mapOptions.mapId(mapId);
-            // Create a new SupportMapFragment instance
-            mapFragment = SupportMapFragment.newInstance(mapOptions);
         }
+
+        // Use the provider to get the correct fragment for the current flavor
+        Fragment mapFragment = MapFragmentProvider.getFragment(mapOptions);
 
         // Add the fragment to the container (R.id.map)
         // Check savedInstanceState to prevent re-adding on rotation
@@ -119,8 +116,14 @@ public abstract class BaseDemoActivity extends FragmentActivity implements OnMap
                     .commit();
         }
 
-        // Get the map
-        mapFragment.getMapAsync(this);
+        // Get the map asynchronously. We use reflection because the fragment type
+        // depends on the build flavor (SupportMapFragment or SupportNavigationFragment).
+        try {
+            mapFragment.getClass().getMethod("getMapAsync", OnMapReadyCallback.class)
+                    .invoke(mapFragment, this);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     /**

--- a/demo/src/navigation/java/com/google/maps/android/utils/demo/MapFragmentProvider.java
+++ b/demo/src/navigation/java/com/google/maps/android/utils/demo/MapFragmentProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/demo/src/navigation/java/com/google/maps/android/utils/demo/MapFragmentProvider.java
+++ b/demo/src/navigation/java/com/google/maps/android/utils/demo/MapFragmentProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.maps.android.utils.demo;
+
+import androidx.fragment.app.Fragment;
+import com.google.android.gms.maps.GoogleMapOptions;
+import com.google.android.libraries.navigation.SupportNavigationFragment;
+
+public class MapFragmentProvider {
+    public static Fragment getFragment(GoogleMapOptions options) {
+        if (options == null) {
+            return SupportNavigationFragment.newInstance();
+        } else {
+            return SupportNavigationFragment.newInstance(options);
+        }
+    }
+}

--- a/demo/src/standard/AndroidManifest.xml
+++ b/demo/src/standard/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
- Copyright 2025 Google LLC
+ Copyright 2026 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/demo/src/standard/AndroidManifest.xml
+++ b/demo/src/standard/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2025 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <meta-data
+            android:name="com.google.android.gms.version"
+            android:value="@integer/google_play_services_version" />
+    </application>
+</manifest>

--- a/demo/src/standard/java/com/google/maps/android/utils/demo/MapFragmentProvider.java
+++ b/demo/src/standard/java/com/google/maps/android/utils/demo/MapFragmentProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/demo/src/standard/java/com/google/maps/android/utils/demo/MapFragmentProvider.java
+++ b/demo/src/standard/java/com/google/maps/android/utils/demo/MapFragmentProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.maps.android.utils.demo;
+
+import androidx.fragment.app.Fragment;
+import com.google.android.gms.maps.GoogleMapOptions;
+import com.google.android.gms.maps.SupportMapFragment;
+
+public class MapFragmentProvider {
+    public static Fragment getFragment(GoogleMapOptions options) {
+        if (options == null) {
+            return SupportMapFragment.newInstance();
+        } else {
+            return SupportMapFragment.newInstance(options);
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ compose-bom = "2026.02.00"
 # Versions for Google Play Services libraries essential for map functionality.
 play-services-maps = "20.0.0"
 navigation-sdk = "7.6.0"
-desugar-jdk-libs = "2.0.3"
+desugar-jdk-libs = "2.1.5"
 
 # --- Testing ---
 # Versions for unit and instrumented testing libraries.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ compose-bom = "2026.02.00"
 # --- Google Services (Maps) ---
 # Versions for Google Play Services libraries essential for map functionality.
 play-services-maps = "20.0.0"
+navigation-sdk = "7.4.0"
 
 # --- Testing ---
 # Versions for unit and instrumented testing libraries.
@@ -84,6 +85,7 @@ material-icons-core = { group = "androidx.compose.material", name = "material-ic
 # --- Google Services (Maps) ---
 # Key libraries for integrating Google Maps and related services.
 play-services-maps = { module = "com.google.android.gms:play-services-maps", version.ref = "play-services-maps" }
+navigation-sdk = { module = "com.google.android.libraries.navigation:navigation", version.ref = "navigation-sdk" }
 
 # --- Testing ---
 # Tools for running implementation validation and user interface tests.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,8 @@ compose-bom = "2026.02.00"
 # --- Google Services (Maps) ---
 # Versions for Google Play Services libraries essential for map functionality.
 play-services-maps = "20.0.0"
-navigation-sdk = "7.4.0"
+navigation-sdk = "7.6.0"
+desugar-jdk-libs = "2.0.3"
 
 # --- Testing ---
 # Versions for unit and instrumented testing libraries.
@@ -86,6 +87,7 @@ material-icons-core = { group = "androidx.compose.material", name = "material-ic
 # Key libraries for integrating Google Maps and related services.
 play-services-maps = { module = "com.google.android.gms:play-services-maps", version.ref = "play-services-maps" }
 navigation-sdk = { module = "com.google.android.libraries.navigation:navigation", version.ref = "navigation-sdk" }
+desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs_nio", version.ref = "desugar-jdk-libs" }
 
 # --- Testing ---
 # Tools for running implementation validation and user interface tests.

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -19,10 +19,6 @@
     xmlns:tools="http://schemas.android.com/tools">
     <!-- https://groups.google.com/group/adt-dev/browse_thread/thread/c059c0380998092b/6720093fb40fdaf9 -->
     <application>
-        <meta-data
-            android:name="com.google.android.gms.version"
-            android:value="@integer/google_play_services_version" />
-
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"


### PR DESCRIPTION
This PR adds a 'navigation' build flavor to the demo module to help reproduce and debug issues with the Google Navigation SDK 7.x, as reported in #1679.

Changes:
- Added navigation SDK 7.4.0 to libs.versions.toml
- Configured 'standard' and 'navigation' flavors in demo/build.gradle.kts
- Introduced MapFragmentProvider in flavor-specific source sets to handle fragment type differences (SupportMapFragment vs SupportNavigationFragment)
- Updated BaseDemoActivity to use the provider and reflection for getMapAsync to support both types.