### PR TITLE
feat: add constructor parameter for custom Executor in cluster renderers

### DIFF
--- a/library/src/main/java/com/google/maps/android/clustering/view/ClusterRendererMultipleItems.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/ClusterRendererMultipleItems.java
@@ -88,7 +88,7 @@ public class ClusterRendererMultipleItems<T extends ClusterItem> implements Clus
     private final float mDensity;
     private boolean mAnimate;
     private long mAnimationDurationMs;
-    private final Executor mExecutor = Executors.newSingleThreadExecutor();
+    private final Executor mExecutor;
     private final Queue<AnimationTask> ongoingAnimations = new LinkedList<>();
     private static TimeInterpolator animationInterp = new DecelerateInterpolator();
 
@@ -171,7 +171,12 @@ public class ClusterRendererMultipleItems<T extends ClusterItem> implements Clus
     private ClusterManager.OnClusterItemInfoWindowLongClickListener<T> mItemInfoWindowLongClickListener;
 
     public ClusterRendererMultipleItems(Context context, GoogleMap map, ClusterManager<T> clusterManager) {
+        this(context, map, clusterManager, Executors.newSingleThreadExecutor());
+    }
+
+    public ClusterRendererMultipleItems(Context context, GoogleMap map, ClusterManager<T> clusterManager, Executor executor) {
         mMap = map;
+        mExecutor = executor;
         mAnimate = true;
         mAnimationDurationMs = 300;
         mDensity = context.getResources().getDisplayMetrics().density;

--- a/library/src/main/java/com/google/maps/android/clustering/view/DefaultAdvancedMarkersClusterRenderer.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/DefaultAdvancedMarkersClusterRenderer.java
@@ -82,7 +82,7 @@ public class DefaultAdvancedMarkersClusterRenderer<T extends ClusterItem> implem
     private final float mDensity;
     private boolean mAnimate;
     private long mAnimationDurationMs;
-    private final Executor mExecutor = Executors.newSingleThreadExecutor();
+    private final Executor mExecutor;
 
     private static final int[] BUCKETS = {10, 20, 50, 100, 200, 500, 1000};
     private ShapeDrawable mColoredCircleBackground;
@@ -133,7 +133,12 @@ public class DefaultAdvancedMarkersClusterRenderer<T extends ClusterItem> implem
     private ClusterManager.OnClusterItemInfoWindowLongClickListener<T> mItemInfoWindowLongClickListener;
 
     public DefaultAdvancedMarkersClusterRenderer(Context context, GoogleMap map, ClusterManager<T> clusterManager) {
+        this(context, map, clusterManager, Executors.newSingleThreadExecutor());
+    }
+
+    public DefaultAdvancedMarkersClusterRenderer(Context context, GoogleMap map, ClusterManager<T> clusterManager, Executor executor) {
         mMap = map;
+        mExecutor = executor;
         mAnimate = true;
         mAnimationDurationMs = 300;
         mDensity = context.getResources().getDisplayMetrics().density;

--- a/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
@@ -81,7 +81,7 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
     private final float mDensity;
     private boolean mAnimate;
     private long mAnimationDurationMs;
-    private final Executor mExecutor = Executors.newSingleThreadExecutor();
+    private final Executor mExecutor;
 
     private static final int[] BUCKETS = {10, 20, 50, 100, 200, 500, 1000};
     private ShapeDrawable mColoredCircleBackground;
@@ -132,7 +132,12 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
     private ClusterManager.OnClusterItemInfoWindowLongClickListener<T> mItemInfoWindowLongClickListener;
 
     public DefaultClusterRenderer(Context context, GoogleMap map, ClusterManager<T> clusterManager) {
+        this(context, map, clusterManager, Executors.newSingleThreadExecutor());
+    }
+
+    public DefaultClusterRenderer(Context context, GoogleMap map, ClusterManager<T> clusterManager, Executor executor) {
         mMap = map;
+        mExecutor = executor;
         mAnimate = true;
         mAnimationDurationMs = 300;
         mDensity = context.getResources().getDisplayMetrics().density;


### PR DESCRIPTION
Adds overloaded constructors to `ClusterRendererMultipleItems`, `DefaultClusterRenderer`, and `DefaultAdvancedMarkersClusterRenderer` that accept an `Executor` parameter. This allows injecting a synchronous executor (or any custom executor) during testing, resolving issues with `Executors.newSingleThreadExecutor()` creating background threads in test environments.