### PR TITLE
build: update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
         distribution: 'temurin'
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v6
     - name: Install Go
       uses: actions/setup-go@v6
       with:

--- a/.github/workflows/lint-report.yml
+++ b/.github/workflows/lint-report.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Create dummy secrets.properties
         run: echo "MAPS_API_KEY=dummy" > secrets.properties
@@ -43,13 +43,13 @@ jobs:
         run: ./gradlew lint
 
       - name: Upload SARIF for library
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: library/build/reports/lint-results-debug.sarif
+          sarif_file: library/build/reports/lint-results.sarif
           category: library
 
       - name: Upload SARIF for demo
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: demo/build/reports/lint-results-debug.sarif
+          sarif_file: demo/build/reports/lint-results.sarif
           category: demo

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,18 +24,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4.7.1
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Create .gpg key
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
           config-file: release-please-config.json

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -40,7 +40,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Create dummy secrets.properties
         run: echo "MAPS_API_KEY=dummy" > secrets.properties

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         distribution: 'temurin'
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v6
 
     - name: Create dummy secrets.properties
       run: echo "MAPS_API_KEY=dummy" > secrets.properties

--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -34,10 +34,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
This PR updates all GitHub Action workflows to their latest stable major versions (Node 24 era). This is based on the `feat/rewrite-android-maps-utils` branch.

### Changes:
- Updated `actions/checkout` to `v6`
- Updated `actions/setup-java` to `v5`
- Updated `actions/setup-python` to `v6`
- Updated `gradle/actions/setup-gradle` to `v6`
- Updated `googleapis/release-please-action` to `v5`
- Updated `github/codeql-action/upload-sarif` to `v4`
- Migrated `setup-java` distribution from `adopt` to `temurin`
- Fixed SARIF file paths in `lint-report.yml` (removed `-debug` suffix to match `build.gradle.kts` configuration)
- Kept `madrapps/jacoco-report` at `v1.7.2` for precise versioning.

### Integrity Checks:
- Verified that `setup-gradle@v6` doesn't use removed experimental features.
- Verified SARIF paths against project `build.gradle.kts` files.
- No `upload-artifact` usage found, so no breaking changes related to immutable artifact backend.