### PR TITLE
fix: address lint, compiler, and Error Prone warnings

### DIFF
--- a/library/src/main/java/com/google/maps/android/clustering/view/DefaultAdvancedMarkersClusterRenderer.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/DefaultAdvancedMarkersClusterRenderer.java
@@ -427,6 +427,7 @@ public class DefaultAdvancedMarkersClusterRenderer<T extends ClusterItem> implem
         }
 
         @SuppressLint("NewApi")
+        @Override
         public void run() {
             if (!shouldRender(immutableOf(DefaultAdvancedMarkersClusterRenderer.this.mClusters), immutableOf(clusters))) {
                 mCallback.run();
@@ -641,13 +642,16 @@ public class DefaultAdvancedMarkersClusterRenderer<T extends ClusterItem> implem
          */
         public void add(boolean priority, CreateMarkerTask c) {
             lock.lock();
-            sendEmptyMessage(BLANK);
-            if (priority) {
-                mOnScreenCreateMarkerTasks.add(c);
-            } else {
-                mCreateMarkerTasks.add(c);
+            try {
+                sendEmptyMessage(BLANK);
+                if (priority) {
+                    mOnScreenCreateMarkerTasks.add(c);
+                } else {
+                    mCreateMarkerTasks.add(c);
+                }
+            } finally {
+                lock.unlock();
             }
-            lock.unlock();
         }
 
         /**
@@ -658,13 +662,16 @@ public class DefaultAdvancedMarkersClusterRenderer<T extends ClusterItem> implem
          */
         public void remove(boolean priority, Marker m) {
             lock.lock();
-            sendEmptyMessage(BLANK);
-            if (priority) {
-                mOnScreenRemoveMarkerTasks.add(m);
-            } else {
-                mRemoveMarkerTasks.add(m);
+            try {
+                sendEmptyMessage(BLANK);
+                if (priority) {
+                    mOnScreenRemoveMarkerTasks.add(m);
+                } else {
+                    mRemoveMarkerTasks.add(m);
+                }
+            } finally {
+                lock.unlock();
             }
-            lock.unlock();
         }
 
         /**
@@ -676,8 +683,11 @@ public class DefaultAdvancedMarkersClusterRenderer<T extends ClusterItem> implem
          */
         public void animate(MarkerWithPosition marker, LatLng from, LatLng to) {
             lock.lock();
-            mAnimationTasks.add(new AnimationTask(marker, from, to));
-            lock.unlock();
+            try {
+                mAnimationTasks.add(new AnimationTask(marker, from, to));
+            } finally {
+                lock.unlock();
+            }
         }
 
         /**
@@ -690,10 +700,13 @@ public class DefaultAdvancedMarkersClusterRenderer<T extends ClusterItem> implem
          */
         public void animateThenRemove(MarkerWithPosition marker, LatLng from, LatLng to) {
             lock.lock();
-            AnimationTask animationTask = new AnimationTask(marker, from, to);
-            animationTask.removeOnAnimationComplete(mClusterManager.getMarkerManager());
-            mAnimationTasks.add(animationTask);
-            lock.unlock();
+            try {
+                AnimationTask animationTask = new AnimationTask(marker, from, to);
+                animationTask.removeOnAnimationComplete(mClusterManager.getMarkerManager());
+                mAnimationTasks.add(animationTask);
+            } finally {
+                lock.unlock();
+            }
         }
 
         @Override
@@ -757,8 +770,8 @@ public class DefaultAdvancedMarkersClusterRenderer<T extends ClusterItem> implem
          * @return true if there is still work to be processed.
          */
         public boolean isBusy() {
+            lock.lock();
             try {
-                lock.lock();
                 return !(mCreateMarkerTasks.isEmpty() && mOnScreenCreateMarkerTasks.isEmpty() &&
                         mOnScreenRemoveMarkerTasks.isEmpty() && mRemoveMarkerTasks.isEmpty() &&
                         mAnimationTasks.isEmpty()

--- a/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
+++ b/library/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.java
@@ -418,6 +418,7 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
         }
 
         @SuppressLint("NewApi")
+        @Override
         public void run() {
             if (!shouldRender(immutableOf(DefaultClusterRenderer.this.mClusters), immutableOf(clusters))) {
                 mCallback.run();
@@ -632,13 +633,16 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
          */
         public void add(boolean priority, CreateMarkerTask c) {
             lock.lock();
-            sendEmptyMessage(BLANK);
-            if (priority) {
-                mOnScreenCreateMarkerTasks.add(c);
-            } else {
-                mCreateMarkerTasks.add(c);
+            try {
+                sendEmptyMessage(BLANK);
+                if (priority) {
+                    mOnScreenCreateMarkerTasks.add(c);
+                } else {
+                    mCreateMarkerTasks.add(c);
+                }
+            } finally {
+                lock.unlock();
             }
-            lock.unlock();
         }
 
         /**
@@ -649,13 +653,16 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
          */
         public void remove(boolean priority, Marker m) {
             lock.lock();
-            sendEmptyMessage(BLANK);
-            if (priority) {
-                mOnScreenRemoveMarkerTasks.add(m);
-            } else {
-                mRemoveMarkerTasks.add(m);
+            try {
+                sendEmptyMessage(BLANK);
+                if (priority) {
+                    mOnScreenRemoveMarkerTasks.add(m);
+                } else {
+                    mRemoveMarkerTasks.add(m);
+                }
+            } finally {
+                lock.unlock();
             }
-            lock.unlock();
         }
 
         /**
@@ -667,8 +674,11 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
          */
         public void animate(MarkerWithPosition marker, LatLng from, LatLng to) {
             lock.lock();
-            mAnimationTasks.add(new AnimationTask(marker, from, to));
-            lock.unlock();
+            try {
+                mAnimationTasks.add(new AnimationTask(marker, from, to));
+            } finally {
+                lock.unlock();
+            }
         }
 
         /**
@@ -681,10 +691,13 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
          */
         public void animateThenRemove(MarkerWithPosition marker, LatLng from, LatLng to) {
             lock.lock();
-            AnimationTask animationTask = new AnimationTask(marker, from, to);
-            animationTask.removeOnAnimationComplete(mClusterManager.getMarkerManager());
-            mAnimationTasks.add(animationTask);
-            lock.unlock();
+            try {
+                AnimationTask animationTask = new AnimationTask(marker, from, to);
+                animationTask.removeOnAnimationComplete(mClusterManager.getMarkerManager());
+                mAnimationTasks.add(animationTask);
+            } finally {
+                lock.unlock();
+            }
         }
 
         @Override
@@ -748,8 +761,8 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements ClusterRen
          * @return true if there is still work to be processed.
          */
         public boolean isBusy() {
+            lock.lock();
             try {
-                lock.lock();
                 return !(mCreateMarkerTasks.isEmpty() && mOnScreenCreateMarkerTasks.isEmpty() &&
                         mOnScreenRemoveMarkerTasks.isEmpty() && mRemoveMarkerTasks.isEmpty() &&
                         mAnimationTasks.isEmpty()

--- a/library/src/main/java/com/google/maps/android/data/geojson/GeoJsonLayer.java
+++ b/library/src/main/java/com/google/maps/android/data/geojson/GeoJsonLayer.java
@@ -172,6 +172,8 @@ public class GeoJsonLayer extends Layer {
      *
      * @return iterable of Feature elements
      */
+    @Override
+    @SuppressWarnings("unchecked")
     public Iterable<GeoJsonFeature> getFeatures() {
         return (Iterable<GeoJsonFeature>) super.getFeatures();
     }

--- a/library/src/main/java/com/google/maps/android/data/kml/KmlContainerParser.java
+++ b/library/src/main/java/com/google/maps/android/data/kml/KmlContainerParser.java
@@ -80,7 +80,7 @@ import static org.xmlpull.v1.XmlPullParser.START_TAG;
         String containerId = null;
         HashMap<String, String> containerProperties = new HashMap<String, String>();
         HashMap<String, KmlStyle> containerStyles = new HashMap<String, KmlStyle>();
-        HashMap<? extends Feature, Object> containerPlacemarks = new HashMap<>();
+        HashMap<KmlPlacemark, Object> containerPlacemarks = new HashMap<>();
         ArrayList<KmlContainer> nestedContainers = new ArrayList<KmlContainer>();
         HashMap<String, String> containerStyleMaps = new HashMap<String, String>();
         HashMap<KmlGroundOverlay, GroundOverlay> containerGroundOverlays
@@ -105,7 +105,7 @@ import static org.xmlpull.v1.XmlPullParser.START_TAG;
                 } else if (parser.getName().equals(STYLE)) {
                     setContainerStyle(parser, containerStyles);
                 } else if (parser.getName().equals(PLACEMARK)) {
-                    setContainerPlacemark(parser, (HashMap<KmlPlacemark, Object>) containerPlacemarks);
+                    setContainerPlacemark(parser, containerPlacemarks);
                 } else if (parser.getName().equals(EXTENDED_DATA)) {
                     setExtendedDataProperties(parser, containerProperties);
                 } else if (parser.getName().equals(GROUND_OVERLAY)) {
@@ -116,7 +116,7 @@ import static org.xmlpull.v1.XmlPullParser.START_TAG;
             eventType = parser.next();
         }
 
-        return new KmlContainer(containerProperties, containerStyles, (HashMap<KmlPlacemark, Object>) containerPlacemarks,
+        return new KmlContainer(containerProperties, containerStyles, containerPlacemarks,
                 containerStyleMaps, nestedContainers, containerGroundOverlays, containerId);
     }
 

--- a/library/src/main/java/com/google/maps/android/data/kml/KmlLayer.java
+++ b/library/src/main/java/com/google/maps/android/data/kml/KmlLayer.java
@@ -25,10 +25,10 @@ import androidx.annotation.RawRes;
 
 import com.google.android.gms.maps.GoogleMap;
 import com.google.maps.android.collections.GroundOverlayManager;
-import com.google.maps.android.data.Layer;
 import com.google.maps.android.collections.MarkerManager;
 import com.google.maps.android.collections.PolygonManager;
 import com.google.maps.android.collections.PolylineManager;
+import com.google.maps.android.data.Layer;
 import com.google.maps.android.data.Renderer;
 
 import org.xmlpull.v1.XmlPullParser;
@@ -39,6 +39,7 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -337,7 +338,7 @@ public class KmlLayer extends Layer {
                     if (entryCount > maxKmzEntryCount) {
                         throw new IOException("Zip bomb detected! Max number of entries exceeded: " + maxKmzEntryCount);
                     }
-                    if (parser == null && entry.getName().toLowerCase().endsWith(".kml")) {
+                    if (parser == null && entry.getName().toLowerCase(Locale.ROOT).endsWith(".kml")) {
                         parser = parseKml(countingStream);
                     } else {
                         Bitmap bitmap = BitmapFactory.decodeStream(countingStream);
@@ -474,6 +475,7 @@ public class KmlLayer extends Layer {
      *
      * @return true if there is at least 1 container within the KmlLayer, false otherwise
      */
+    @Override
     public boolean hasContainers() {
         return super.hasContainers();
     }
@@ -483,6 +485,7 @@ public class KmlLayer extends Layer {
      *
      * @return iterable of KmlContainerInterface objects
      */
+    @Override
     public Iterable<KmlContainer> getContainers() {
         return super.getContainers();
     }
@@ -492,6 +495,7 @@ public class KmlLayer extends Layer {
      *
      * @return iterable of KmlGroundOverlay objects
      */
+    @Override
     public Iterable<KmlGroundOverlay> getGroundOverlays() {
         return super.getGroundOverlays();
     }

--- a/library/src/main/java/com/google/maps/android/data/kml/KmlRenderer.java
+++ b/library/src/main/java/com/google/maps/android/data/kml/KmlRenderer.java
@@ -204,6 +204,7 @@ public class KmlRenderer extends Renderer {
      *
      * @param map map to place placemark, container, style and ground overlays on
      */
+    @Override
     public void setMap(GoogleMap map) {
         removeLayerFromMap();
         super.setMap(map);
@@ -499,6 +500,7 @@ public class KmlRenderer extends Renderer {
     private void addGroundOverlayToMap(String groundOverlayUrl,
                                        HashMap<KmlGroundOverlay, GroundOverlay> groundOverlays, boolean containerVisibility) {
         BitmapDescriptor groundOverlayBitmap = getCachedGroundOverlayImage(groundOverlayUrl);
+        HashMap<KmlGroundOverlay, GroundOverlay> groundOverlaysToUpdate = new HashMap<>();
         for (KmlGroundOverlay kmlGroundOverlay : groundOverlays.keySet()) {
             if (kmlGroundOverlay.getImageUrl().equals(groundOverlayUrl)) {
                 GroundOverlayOptions groundOverlayOptions = kmlGroundOverlay.getGroundOverlayOptions()
@@ -507,9 +509,10 @@ public class KmlRenderer extends Renderer {
                 if (!containerVisibility) {
                     mapGroundOverlay.setVisible(false);
                 }
-                groundOverlays.put(kmlGroundOverlay, mapGroundOverlay);
+                groundOverlaysToUpdate.put(kmlGroundOverlay, mapGroundOverlay);
             }
         }
+        groundOverlays.putAll(groundOverlaysToUpdate);
     }
 
     /**


### PR DESCRIPTION
Addresses various lint, compiler (generics/rawtypes), and Error Prone warnings across DefaultAdvancedMarkersClusterRenderer, DefaultClusterRenderer, KmlLayer, KmlRenderer, and GeoJsonLayer.

These changes ensure clean compile hygiene and safety under modern generics and strict locking checks.