### PR TITLE
feat: add manual RC release workflow

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -1,0 +1,86 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release RC
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'RC version (e.g. 4.5.0-rc.1)'
+        required: true
+      branch:
+        description: 'Branch to release from'
+        required: true
+        default: 'main'
+
+permissions:
+  contents: write
+
+jobs:
+  release-rc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.branch }}
+          token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Update version files
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          # .release-please-manifest.json
+          sed -i 's/"\." *: *"[^"]*"/".": "'"$VERSION"'"/' .release-please-manifest.json
+
+          # build.gradle.kts (between release-please markers)
+          sed -i 's/version = "[^"]*"/version = "'"$VERSION"'"/' build.gradle.kts
+
+          # Files with x-release-please-version inline marker
+          for file in llm-integration-prompt.md MIGRATION.md .gemini/skills/android-maps-utils/SKILL.md; do
+            if [ -f "$file" ]; then
+              sed -i "/x-release-please-version/s/[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*[a-zA-Z0-9.-]*/$VERSION/" "$file"
+            fi
+          done
+
+      - name: Commit and push
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git add \
+            .release-please-manifest.json \
+            build.gradle.kts \
+            llm-integration-prompt.md \
+            MIGRATION.md \
+            .gemini/skills/android-maps-utils/SKILL.md
+          git commit -m "chore: release v${VERSION}"
+          git push origin "${{ inputs.branch }}"
+
+      - name: Tag and create pre-release
+        env:
+          VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
+        run: |
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --generate-notes \
+            --prerelease


### PR DESCRIPTION
## Summary

- Adds a `workflow_dispatch`-only workflow (`.github/workflows/release-rc.yml`) to publish release candidates from any branch without merging to `main`
- Never triggers automatically — only runs when manually invoked from the GitHub Actions UI or via `gh workflow run`
- Updates all version files (`build.gradle.kts`, `.release-please-manifest.json`, `MIGRATION.md`, `llm-integration-prompt.md`, `SKILL.md`), commits and pushes to the target branch, creates a tag, and publishes a GitHub pre-release
- The existing `publish.yml` fires automatically on pre-release published, pushing the RC artifact to Maven Central

## How to use

1. GitHub → Actions → **Release RC** → Run workflow
2. Set `version` (e.g. `4.5.0-rc.1`) and `branch` (e.g. `feat/rewrite-android-maps-utils`)
3. The workflow runs from `main` but releases from the specified branch

## Test plan

- [ ] Merge to `main`
- [ ] Trigger the workflow manually with a test version and a feature branch
- [ ] Verify version files are updated, tag is created, and GitHub pre-release appears
- [ ] Verify `publish.yml` is triggered by the pre-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)