### PR TITLE
build: change model name from gemini-2.5-flash to gemini-3.5-flash

### DIFF
--- a/.github/scripts/triage_issue.py
+++ b/.github/scripts/triage_issue.py
@@ -18,8 +18,8 @@ import urllib.request
 import sys
 
 def get_gemini_response(api_key, prompt):
-# Using the stable Gemini 2.5 Flash
-    url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key={api_key}"
+    # Using the stable Gemini 3.5 Flash
+    url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent?key={api_key}"
     headers = {'Content-Type': 'application/json'}
     data = {
         "contents": [{


### PR DESCRIPTION
### Description
This PR fixes a 404 error in the issue triage workflow by updating the model name from `gemini-2.5-flash` to the officially supported and stable `gemini-3.5-flash` model.

### Key Changes
- Updated the Gemini API request URL in `.github/scripts/triage_issue.py` to use `gemini-3.5-flash`.
