### PR TITLE
build: fix RC release notes comparison baseline

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -80,7 +80,19 @@ jobs:
         run: |
           git tag "v${VERSION}"
           git push origin "v${VERSION}"
-          gh release create "v${VERSION}" \
-            --title "v${VERSION}" \
-            --generate-notes \
-            --prerelease
+
+          # Find the previous tag to use as baseline for release notes
+          PREVIOUS_TAG=$(git tag -l 'v*' --sort=-version:refname --merged HEAD | grep -v "v${VERSION}" | head -1)
+
+          if [ -n "$PREVIOUS_TAG" ]; then
+            gh release create "v${VERSION}" \
+              --title "v${VERSION}" \
+              --generate-notes \
+              --notes-start-tag "$PREVIOUS_TAG" \
+              --prerelease
+          else
+            gh release create "v${VERSION}" \
+              --title "v${VERSION}" \
+              --generate-notes \
+              --prerelease
+          fi


### PR DESCRIPTION
## Summary
Updates the RC release workflow to compare release notes against the previous tag instead of the main branch.

## Changes
- RC01 release notes: diff between last stable release and RC01
- RC02 release notes: diff between RC01 and RC02  
- RC03 release notes: diff between RC02 and RC03
- Falls back to default behavior if no previous tag exists

## Testing
Test by triggering a manual RC release and verifying the release notes only show changes from the previous RC.