### PR TITLE
fix: stale QuadItem removal after ClusterItem position updates

### DIFF
--- a/clustering/src/main/java/com/google/maps/android/clustering/algo/NonHierarchicalDistanceBasedAlgorithm.kt
+++ b/clustering/src/main/java/com/google/maps/android/clustering/algo/NonHierarchicalDistanceBasedAlgorithm.kt
@@ -47,6 +47,7 @@ open class NonHierarchicalDistanceBasedAlgorithm<T : ClusterItem> : AbstractAlgo
      */
     @JvmField
     protected val mItems: MutableCollection<QuadItem<T>> = LinkedHashSet()
+    protected val mItemMap = HashMap<T, QuadItem<T>>()
 
     /**
      * Any modifications should be synchronized on mQuadTree.
@@ -61,6 +62,7 @@ open class NonHierarchicalDistanceBasedAlgorithm<T : ClusterItem> : AbstractAlgo
         synchronized(mQuadTree) {
             val result = mItems.add(quadItem)
             if (result) {
+                mItemMap[item] = quadItem
                 mQuadTree.add(quadItem)
             }
             return result
@@ -81,6 +83,7 @@ open class NonHierarchicalDistanceBasedAlgorithm<T : ClusterItem> : AbstractAlgo
     override fun clearItems() {
         synchronized(mQuadTree) {
             mItems.clear()
+            mItemMap.clear()
             mQuadTree.clear()
         }
     }
@@ -88,9 +91,9 @@ open class NonHierarchicalDistanceBasedAlgorithm<T : ClusterItem> : AbstractAlgo
     override fun removeItem(item: T): Boolean {
         // QuadItem delegates hashcode() and equals() to its item so,
         //   removing any QuadItem to that item will remove the item
-        val quadItem = QuadItem(item)
         synchronized(mQuadTree) {
-            val result = mItems.remove(quadItem)
+            val quadItem = mItemMap.remove(item)
+            val result = quadItem != null && mItems.remove(quadItem)
             if (result) {
                 mQuadTree.remove(quadItem)
             }
@@ -104,8 +107,8 @@ open class NonHierarchicalDistanceBasedAlgorithm<T : ClusterItem> : AbstractAlgo
             for (item in items) {
                 // QuadItem delegates hashcode() and equals() to its item so,
                 //   removing any QuadItem to that item will remove the item
-                val quadItem = QuadItem(item)
-                val individualResult = mItems.remove(quadItem)
+                val quadItem = mItemMap.remove(item)
+                val individualResult = quadItem != null && mItems.remove(quadItem)
                 if (individualResult) {
                     mQuadTree.remove(quadItem)
                     result = true

--- a/clustering/src/main/java/com/google/maps/android/clustering/algo/NonHierarchicalDistanceBasedAlgorithm.kt
+++ b/clustering/src/main/java/com/google/maps/android/clustering/algo/NonHierarchicalDistanceBasedAlgorithm.kt
@@ -92,8 +92,8 @@ open class NonHierarchicalDistanceBasedAlgorithm<T : ClusterItem> : AbstractAlgo
         // QuadItem delegates hashcode() and equals() to its item so,
         //   removing any QuadItem to that item will remove the item
         synchronized(mQuadTree) {
-            val quadItem = mItemMap.remove(item)
-            val result = quadItem != null && mItems.remove(quadItem)
+            val quadItem = mItemMap.remove(item) ?: QuadItem(item)
+            val result = mItems.remove(quadItem)
             if (result) {
                 mQuadTree.remove(quadItem)
             }
@@ -107,8 +107,8 @@ open class NonHierarchicalDistanceBasedAlgorithm<T : ClusterItem> : AbstractAlgo
             for (item in items) {
                 // QuadItem delegates hashcode() and equals() to its item so,
                 //   removing any QuadItem to that item will remove the item
-                val quadItem = mItemMap.remove(item)
-                val individualResult = quadItem != null && mItems.remove(quadItem)
+                val quadItem = mItemMap.remove(item) ?: QuadItem(item)
+                val individualResult = mItems.remove(quadItem)
                 if (individualResult) {
                     mQuadTree.remove(quadItem)
                     result = true

--- a/clustering/src/test/java/com/google/maps/android/clustering/QuadItemTest.java
+++ b/clustering/src/test/java/com/google/maps/android/clustering/QuadItemTest.java
@@ -98,7 +98,7 @@ public class QuadItemTest {
   }
 
   private static class TestingItem implements ClusterItem {
-    private final LatLng mPosition;
+    private LatLng mPosition;
     private String mTitle;
 
     TestingItem(String title, double lat, double lng) {
@@ -109,6 +109,9 @@ public class QuadItemTest {
     TestingItem(double lat, double lng) {
       mTitle = "";
       mPosition = new LatLng(lat, lng);
+    }
+    public void setPosition(double lat, double lng) {
+    mPosition = new LatLng(lat, lng);
     }
 
     @NonNull

--- a/clustering/src/test/java/com/google/maps/android/clustering/QuadItemTest.java
+++ b/clustering/src/test/java/com/google/maps/android/clustering/QuadItemTest.java
@@ -97,6 +97,115 @@ public class QuadItemTest {
     }
   }
 
+  @Test
+  public void testUpdateItemAfterPositionChange() {
+    NonHierarchicalDistanceBasedAlgorithm<TestingItem> algo =
+        new NonHierarchicalDistanceBasedAlgorithm<>();
+    TestingItem item = new TestingItem("title1", 0.0, 0.0);
+    algo.addItem(item);
+    assertEquals(1, algo.getItems().size());
+
+    // Update the position of the mutable item
+    item.setPosition(10.0, 10.0);
+
+    // Call updateItem
+    assertTrue("updateItem should return true after position change", algo.updateItem(item));
+    assertEquals(1, algo.getItems().size());
+
+    // Verify that the old QuadItem at (0, 0) was removed from the tree
+    // and only the new position (10, 10) is indexed
+    java.util.Set<? extends Cluster<TestingItem>> clusters = algo.getClusters(4.0f);
+    assertEquals(1, clusters.size());
+    Cluster<TestingItem> cluster = clusters.iterator().next();
+    assertEquals(10.0, cluster.getPosition().latitude, 0.001);
+    assertEquals(10.0, cluster.getPosition().longitude, 0.001);
+  }
+
+  @Test
+  public void testRemoveItemAfterPositionChange() {
+    NonHierarchicalDistanceBasedAlgorithm<TestingItem> algo =
+        new NonHierarchicalDistanceBasedAlgorithm<>();
+    TestingItem item = new TestingItem("title1", 0.0, 0.0);
+    algo.addItem(item);
+    assertEquals(1, algo.getItems().size());
+
+    // Update the position of the mutable item
+    item.setPosition(10.0, 10.0);
+
+    // Removing the item should succeed and remove it from the tree
+    assertTrue("removeItem should return true after position change", algo.removeItem(item));
+    assertEquals(0, algo.getItems().size());
+    assertEquals(0, algo.getClusters(4.0f).size());
+  }
+
+  @Test
+  public void testUpdateItemPreventsStaleQuadTreeEntries() {
+    TestAlgorithm<TestingItem> algo = new TestAlgorithm<>();
+
+    // Add 60 filler items to force PointQuadTree to split (MAX_ELEMENTS = 50)
+    for (int i = 0; i < 60; i++) {
+      algo.addItem(new TestingItem("filler" + i, 10.0 + i * 0.001, 10.0 + i * 0.001));
+    }
+
+    // Add item1 in top-left quadrant
+    TestingItem item1 = new TestingItem("item1", 1.0, 1.0);
+    algo.addItem(item1);
+
+    assertEquals("QuadTree should contain item1 at (1, 1)", 1, algo.getQuadTreeItemCount(1.0, 1.0, 0.001));
+
+    // Move item1 far across quadrant boundary to (50.0, 50.0) and update
+    item1.setPosition(50.0, 50.0);
+    algo.updateItem(item1);
+
+    // Without fix, old QuadItem remains at (1.0, 1.0) in mQuadTree because remove traversed the new coordinates
+    assertEquals("QuadTree should NOT contain stale entry at (1, 1) after update", 0, algo.getQuadTreeItemCount(1.0, 1.0, 0.001));
+    assertEquals("QuadTree should contain item1 at (50, 50)", 1, algo.getQuadTreeItemCount(50.0, 50.0, 0.001));
+  }
+
+  @Test
+  public void testRemoveItemsAfterPositionChange() {
+    NonHierarchicalDistanceBasedAlgorithm<TestingItem> algo =
+        new NonHierarchicalDistanceBasedAlgorithm<>();
+    TestingItem item1 = new TestingItem("title1", 0.0, 0.0);
+    TestingItem item2 = new TestingItem("title2", 1.0, 1.0);
+    algo.addItems(java.util.Arrays.asList(item1, item2));
+    assertEquals(2, algo.getItems().size());
+
+    // Update the position of both items
+    item1.setPosition(10.0, 10.0);
+    item2.setPosition(20.0, 20.0);
+
+    assertTrue("removeItems should return true after position change",
+        algo.removeItems(java.util.Arrays.asList(item1, item2)));
+    assertEquals(0, algo.getItems().size());
+    assertEquals(0, algo.getClusters(4.0f).size());
+  }
+
+  @Test
+  public void testClearItemsAfterPositionChange() {
+    NonHierarchicalDistanceBasedAlgorithm<TestingItem> algo =
+        new NonHierarchicalDistanceBasedAlgorithm<>();
+    TestingItem item1 = new TestingItem("title1", 0.0, 0.0);
+    algo.addItem(item1);
+    item1.setPosition(10.0, 10.0);
+
+    algo.clearItems();
+    assertEquals(0, algo.getItems().size());
+    assertEquals(0, algo.getClusters(4.0f).size());
+  }
+
+  private static class TestAlgorithm<T extends ClusterItem> extends NonHierarchicalDistanceBasedAlgorithm<T> {
+    private static final com.google.maps.android.projection.SphericalMercatorProjection PROJ =
+        new com.google.maps.android.projection.SphericalMercatorProjection(1.0);
+
+    public int getQuadTreeItemCount(double lat, double lng, double span) {
+      com.google.maps.android.geometry.Point p = PROJ.toPoint(new LatLng(lat, lng));
+      com.google.maps.android.geometry.Bounds bounds = new com.google.maps.android.geometry.Bounds(
+          p.x - span, p.x + span, p.y - span, p.y + span);
+      return mQuadTree.search(bounds).size();
+    }
+  }
+
   private static class TestingItem implements ClusterItem {
     private LatLng mPosition;
     private String mTitle;

--- a/demo/src/main/java/com/google/maps/android/utils/demo/ClusteringDiffDemoActivity.java
+++ b/demo/src/main/java/com/google/maps/android/utils/demo/ClusteringDiffDemoActivity.java
@@ -161,6 +161,13 @@ public class ClusteringDiffDemoActivity extends BaseDemoActivity
   }
 
   private void addItems() {
+    // Add 60 filler background markers across Greater London to force PointQuadTree to split into quadrants (MAX_ELEMENTS = 50)
+    for (int i = 0; i < 60; i++) {
+      double lat = 51.3 + (i % 10) * 0.05;
+      double lng = -0.4 + (i / 10) * 0.08;
+      mClusterManager.addItem(new Person(new LatLng(lat, lng), "Citizen " + i, R.drawable.john));
+    }
+
     // Marker in Enfield
     mClusterManager.addItem(new Person(City.ENFIELD.latLng, "John", R.drawable.john));
 
@@ -181,7 +188,7 @@ public class ClusteringDiffDemoActivity extends BaseDemoActivity
     Log.d("ClusterTest", "Item rotated to: " + newLocation.toString() + ", City: " + cityName);
 
     if (itemToUpdate != null) {
-      itemToUpdate = new Person(newLocation, "Teach", R.drawable.teacher);
+      itemToUpdate.setPosition(newLocation);
       mClusterManager.updateItem(itemToUpdate); // Update the marker
       mClusterManager.cluster();
     }

--- a/demo/src/main/java/com/google/maps/android/utils/demo/model/Person.java
+++ b/demo/src/main/java/com/google/maps/android/utils/demo/model/Person.java
@@ -24,11 +24,15 @@ import java.util.Objects;
 public class Person implements ClusterItem {
   public final String name;
   public final int profilePhoto;
-  private final LatLng mPosition;
+  private LatLng mPosition;
 
   public Person(LatLng position, String name, int pictureResource) {
     this.name = name;
     profilePhoto = pictureResource;
+    mPosition = position;
+  }
+
+  public void setPosition(LatLng position) {
     mPosition = position;
   }
 


### PR DESCRIPTION
**Summary**
Fixes an issue where updateItem() may fail to remove the previously indexed QuadItem when a mutable ClusterItem changes position before being updated.

**Reproduction**
The issue occurs when the same mutable ClusterItem instance is reused:
1. Add a ClusterItem to NonHierarchicalDistanceBasedAlgorithm.
2. Update the item's position.
3. Call updateItem(item).
Because the item's position has already changed, removeItem() reconstructs a new QuadItem using the updated coordinates instead of the coordinates used during insertion.

PointQuadTree.remove() then traverses the tree using the updated location, while the original QuadItem is still indexed under its previous location.

**Root Cause**
QuadItem caches the projected point at construction time.
removeItem() currently creates a new QuadItem from the current state of the ClusterItem. If the position has changed, the reconstructed QuadItem no longer represents the object that was originally inserted into the PointQuadTree, causing removal to search the wrong branch.

**Fix**
Store the original QuadItem created during addItem() in an internal lookup map keyed by the corresponding ClusterItem.
removeItem() and removeItems() now retrieve and remove the original QuadItem instance rather than constructing a new wrapper. This ensures removal uses the same cached coordinates that were used during insertion while preserving the existing public API and behavior.

**Validation**
- Existing add, remove, update, and bulk operations continue to behave as before.
- Added coverage for mutable ClusterItem position updates to exercise the affected update path.
- The change is internal, constant-time (O(1) lookup), and does not affect the library's public API.
---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Edit the title of this pull request with a [semantic commit prefix](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#type) (e.g. "fix: "), which is necessary for automated release workflows to decide whether to generate a new release and what type it should be.
- [ ] Will this cause breaking changes to existing Java or Kotlin integrations? If so, ensure the commit has a `BREAKING CHANGE` footer so when this change is integrated a major version update is triggered. See: https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #< #1729> 🦕
