### PR TITLE
fix: use lngCorrection naming consistently

### DIFF
--- a/library/src/main/java/com/google/maps/android/PolyUtil.kt
+++ b/library/src/main/java/com/google/maps/android/PolyUtil.kt
@@ -427,11 +427,11 @@ object PolyUtil {
         val s2lat = Math.toRadians(end.latitude)
         val s2lng = Math.toRadians(end.longitude)
 
-        val lonCorrection = cos(s1lat)
+        val lngCorrection = cos(s1lat)
         val s2s1lat = s2lat - s1lat
-        val s2s1lng = (s2lng - s1lng) * lonCorrection
+        val s2s1lng = (s2lng - s1lng) * lngCorrection
         val u =
-            ((s0lat - s1lat) * s2s1lat + (s0lng - s1lng) * lonCorrection * s2s1lng) /
+            ((s0lat - s1lat) * s2s1lat + (s0lng - s1lng) * lngCorrection * s2s1lng) /
                 (s2s1lat * s2s1lat + s2s1lng * s2s1lng)
 
         if (u <= 0) {


### PR DESCRIPTION
Thank you for opening a Pull Request!

---

- [x] An issue was opened before the change
- [x] The title uses a semantic commit prefix
- [x] This does not cause breaking changes to Java or Kotlin integrations
- [x] Tests and linter pass
- [x] Code coverage does not decrease
- [x] No documentation update is necessary for this internal rename

Fixes #1382 🦕

## Summary

- rename the local `lonCorrection` identifier to `lngCorrection`
- use the longitude abbreviation consistently in `PolyUtil.distanceToLine`
- leave all calculations and runtime behavior unchanged

## Testing

- `./gradlew :library:testDebugUnitTest --tests com.google.maps.android.PolyUtilTest`
- `./gradlew :library:build :library:lintDebug --stacktrace`

## AI disclosure

This behavior-neutral naming correction was prepared and independently reviewed with AI assistance.
