### PR TITLE
Redraw GeoJSON features after style changes

### DIFF
--- a/data/src/main/java/com/google/maps/android/data/geojson/GeoJsonLayer.kt
+++ b/data/src/main/java/com/google/maps/android/data/geojson/GeoJsonLayer.kt
@@ -26,14 +26,37 @@ import com.google.maps.android.collections.PolygonManager
 import com.google.maps.android.collections.PolylineManager
 import com.google.maps.android.data.Geometry
 import com.google.maps.android.data.Layer
+import com.google.maps.android.data.MultiGeometry
+import com.google.maps.android.data.parser.geojson.GeoJsonFeature as ParserGeoJsonFeature
+import com.google.maps.android.data.parser.geojson.GeoJsonFeatureCollection as ParserGeoJsonFeatureCollection
+import com.google.maps.android.data.parser.geojson.GeoJsonGeometry as ParserGeoJsonGeometry
+import com.google.maps.android.data.parser.geojson.GeoJsonGeometryCollection as ParserGeoJsonGeometryCollection
+import com.google.maps.android.data.parser.geojson.GeoJsonLineString as ParserGeoJsonLineString
+import com.google.maps.android.data.parser.geojson.GeoJsonMultiLineString as ParserGeoJsonMultiLineString
+import com.google.maps.android.data.parser.geojson.GeoJsonMultiPoint as ParserGeoJsonMultiPoint
+import com.google.maps.android.data.parser.geojson.GeoJsonMultiPolygon as ParserGeoJsonMultiPolygon
 import com.google.maps.android.data.parser.geojson.GeoJsonParser
+import com.google.maps.android.data.parser.geojson.GeoJsonPoint as ParserGeoJsonPoint
+import com.google.maps.android.data.parser.geojson.GeoJsonPolygon as ParserGeoJsonPolygon
 import com.google.maps.android.data.renderer.UrlIconProvider
 import com.google.maps.android.data.renderer.mapview.MapViewRenderer
+import com.google.maps.android.data.renderer.model.Feature as ModelFeature
+import com.google.maps.android.data.renderer.model.Geometry as ModelGeometry
+import com.google.maps.android.data.renderer.model.LineString as ModelLineString
+import com.google.maps.android.data.renderer.model.LineStyle as ModelLineStyle
+import com.google.maps.android.data.renderer.model.MultiGeometry as ModelMultiGeometry
+import com.google.maps.android.data.renderer.model.Point as ModelPoint
+import com.google.maps.android.data.renderer.model.PointGeometry as ModelPointGeometry
+import com.google.maps.android.data.renderer.model.PointStyle as ModelPointStyle
+import com.google.maps.android.data.renderer.model.Polygon as ModelPolygon
+import com.google.maps.android.data.renderer.model.PolygonStyle as ModelPolygonStyle
 import org.json.JSONException
 import org.json.JSONObject
 import java.io.IOException
 import java.io.InputStream
+import java.util.IdentityHashMap
 import java.util.Observer
+
 
 @Deprecated("Use the new platform-agnostic data layer and renderer instead.")
 public class GeoJsonLayer : Layer {
@@ -41,8 +64,9 @@ public class GeoJsonLayer : Layer {
     private var mBoundingBox: LatLngBounds? = null
     private var mRenderer: MapViewRenderer? = null
     private var mIsLayerOnMap = false
-    private val mFeatureMap = HashMap<GeoJsonFeature, com.google.maps.android.data.renderer.model.Feature>()
-    private val mModelToLegacyFeatures = java.util.IdentityHashMap<com.google.maps.android.data.renderer.model.Feature, GeoJsonFeature>()
+    private val mFeatureMap = HashMap<GeoJsonFeature, ModelFeature>()
+    private val mModelToLegacyFeatures = IdentityHashMap<ModelFeature, GeoJsonFeature>()
+
     private var mFeatureClickListener: OnFeatureClickListener? = null
     private val mFeatureObserver = Observer { observable, _ ->
         if (observable is GeoJsonFeature) onFeatureChanged(observable)
@@ -88,7 +112,7 @@ public class GeoJsonLayer : Layer {
 
         // Map parsed object to our legacy GeoJsonFeature instances
         when (parsed) {
-            is com.google.maps.android.data.parser.geojson.GeoJsonFeatureCollection -> {
+            is ParserGeoJsonFeatureCollection -> {
                 parsed.features.forEach { feature ->
                     val legacyGeometry = feature.geometry?.let { toLegacyGeometry(it) }
                     val legacyProps = feature.properties?.filterValues { it != null }?.mapValues { it.value as String }
@@ -103,7 +127,7 @@ public class GeoJsonLayer : Layer {
                 }
             }
 
-            is com.google.maps.android.data.parser.geojson.GeoJsonFeature -> {
+            is ParserGeoJsonFeature -> {
                 val legacyGeometry = parsed.geometry?.let { toLegacyGeometry(it) }
                 val legacyProps = parsed.properties?.filterValues { it != null }?.mapValues { it.value as String }
                 val legacyFeature = GeoJsonFeature(legacyGeometry, parsed.id, legacyProps, null)
@@ -115,7 +139,7 @@ public class GeoJsonLayer : Layer {
                 mFeatures.add(legacyFeature)
             }
 
-            is com.google.maps.android.data.parser.geojson.GeoJsonGeometry -> {
+            is ParserGeoJsonGeometry -> {
                 val legacyGeometry = toLegacyGeometry(parsed)
                 val legacyFeature = GeoJsonFeature(legacyGeometry, null, null, null)
 
@@ -136,36 +160,37 @@ public class GeoJsonLayer : Layer {
         mRenderer = map?.let { MapViewRenderer(it, UrlIconProvider()) }
     }
 
-    private fun toLegacyGeometry(geometry: com.google.maps.android.data.parser.geojson.GeoJsonGeometry): Geometry =
+    private fun toLegacyGeometry(geometry: ParserGeoJsonGeometry): Geometry =
         when (geometry) {
-            is com.google.maps.android.data.parser.geojson.GeoJsonPoint -> {
+            is ParserGeoJsonPoint -> {
                 GeoJsonPoint(LatLng(geometry.coordinates.lat, geometry.coordinates.lng), geometry.coordinates.alt)
             }
 
-            is com.google.maps.android.data.parser.geojson.GeoJsonLineString -> {
+            is ParserGeoJsonLineString -> {
                 GeoJsonLineString(geometry.coordinates.map { LatLng(it.lat, it.lng) }, geometry.coordinates.mapNotNull { it.alt })
             }
 
-            is com.google.maps.android.data.parser.geojson.GeoJsonPolygon -> {
+            is ParserGeoJsonPolygon -> {
                 GeoJsonPolygon(geometry.coordinates.map { ring -> ring.map { LatLng(it.lat, it.lng) } })
             }
 
-            is com.google.maps.android.data.parser.geojson.GeoJsonMultiPoint -> {
+            is ParserGeoJsonMultiPoint -> {
                 GeoJsonMultiPoint(geometry.coordinates.map { GeoJsonPoint(LatLng(it.lat, it.lng), it.alt) })
             }
 
-            is com.google.maps.android.data.parser.geojson.GeoJsonMultiLineString -> {
+            is ParserGeoJsonMultiLineString -> {
                 GeoJsonMultiLineString(geometry.coordinates.map { GeoJsonLineString(it.map { c -> LatLng(c.lat, c.lng) }) })
             }
 
-            is com.google.maps.android.data.parser.geojson.GeoJsonMultiPolygon -> {
+            is ParserGeoJsonMultiPolygon -> {
                 GeoJsonMultiPolygon(geometry.coordinates.map { GeoJsonPolygon(it.map { ring -> ring.map { c -> LatLng(c.lat, c.lng) } }) })
             }
 
-            is com.google.maps.android.data.parser.geojson.GeoJsonGeometryCollection -> {
+            is ParserGeoJsonGeometryCollection -> {
                 GeoJsonGeometryCollection(geometry.geometries.map { toLegacyGeometry(it) })
             }
         }
+
 
     private fun calculateBoundingBox() {
         val boundsBuilder = LatLngBounds.builder()
@@ -193,7 +218,7 @@ public class GeoJsonLayer : Layer {
                     }
                 }
 
-                is com.google.maps.android.data.MultiGeometry -> {
+                is MultiGeometry -> {
                     includeMultiGeometryBounds(geometry, boundsBuilder)
                     hasPoints = true
                 }
@@ -205,7 +230,7 @@ public class GeoJsonLayer : Layer {
     }
 
     private fun includeMultiGeometryBounds(
-        multiGeometry: com.google.maps.android.data.MultiGeometry,
+        multiGeometry: MultiGeometry,
         builder: LatLngBounds.Builder,
     ) {
         multiGeometry.getGeometryObject().forEach { geom ->
@@ -213,10 +238,11 @@ public class GeoJsonLayer : Layer {
                 is GeoJsonPoint -> builder.include(geom.getCoordinates())
                 is GeoJsonLineString -> geom.getCoordinates().forEach { builder.include(it) }
                 is GeoJsonPolygon -> geom.getOuterBoundaryCoordinates().forEach { builder.include(it) }
-                is com.google.maps.android.data.MultiGeometry -> includeMultiGeometryBounds(geom, builder)
+                is MultiGeometry -> includeMultiGeometryBounds(geom, builder)
             }
         }
     }
+
 
     override fun getMap(): GoogleMap? = mGoogleMap
 
@@ -249,7 +275,7 @@ public class GeoJsonLayer : Layer {
         mIsLayerOnMap = false
     }
 
-    private fun toModelFeature(feature: GeoJsonFeature): com.google.maps.android.data.renderer.model.Feature {
+    private fun toModelFeature(feature: GeoJsonFeature): ModelFeature {
         val existing = mFeatureMap[feature]
         if (existing != null) return existing
 
@@ -259,9 +285,9 @@ public class GeoJsonLayer : Layer {
 
         val style =
             when (modelGeometry) {
-                is com.google.maps.android.data.renderer.model.PointGeometry -> {
+                is ModelPointGeometry -> {
                     val pointStyle = feature.pointStyle ?: mDefaultPointStyle
-                    com.google.maps.android.data.renderer.model.PointStyle(
+                    ModelPointStyle(
                         // The renderer derives the marker's alpha from the color's alpha channel, so encode the
                         // legacy style's alpha into an otherwise-black color (hue 0 keeps the default marker look).
                         // A transparent color here (e.g. 0) would render the marker invisible.
@@ -272,18 +298,18 @@ public class GeoJsonLayer : Layer {
                     )
                 }
 
-                is com.google.maps.android.data.renderer.model.LineString -> {
+                is ModelLineString -> {
                     val lineStyle = feature.lineStringStyle ?: mDefaultLineStringStyle
-                    com.google.maps.android.data.renderer.model.LineStyle(
+                    ModelLineStyle(
                         color = lineStyle.color,
                         width = lineStyle.getWidth(),
                         geodesic = lineStyle.isGeodesic(),
                     )
                 }
 
-                is com.google.maps.android.data.renderer.model.Polygon -> {
+                is ModelPolygon -> {
                     val polygonStyle = feature.polygonStyle ?: mDefaultPolygonStyle
-                    com.google.maps.android.data.renderer.model.PolygonStyle(
+                    ModelPolygonStyle(
                         fillColor = polygonStyle.fillColor,
                         strokeColor = polygonStyle.getStrokeColor(),
                         strokeWidth = polygonStyle.getStrokeWidth(),
@@ -291,10 +317,10 @@ public class GeoJsonLayer : Layer {
                     )
                 }
 
-                is com.google.maps.android.data.renderer.model.MultiGeometry -> {
+                is ModelMultiGeometry -> {
                     if (geometry is GeoJsonMultiPolygon) {
                         val polygonStyle = feature.polygonStyle ?: mDefaultPolygonStyle
-                        com.google.maps.android.data.renderer.model.PolygonStyle(
+                        ModelPolygonStyle(
                             fillColor = polygonStyle.fillColor,
                             strokeColor = polygonStyle.getStrokeColor(),
                             strokeWidth = polygonStyle.getStrokeWidth(),
@@ -308,19 +334,17 @@ public class GeoJsonLayer : Layer {
                 }
             }
 
-        val modelFeature =
-            com.google.maps.android.data.renderer.model
-                .Feature(modelGeometry, style, properties)
+        val modelFeature = ModelFeature(modelGeometry, style, properties)
         mFeatureMap[feature] = modelFeature
         mModelToLegacyFeatures[modelFeature] = feature
         return modelFeature
     }
 
-    private fun toModelGeometry(geometry: Geometry): com.google.maps.android.data.renderer.model.Geometry =
+    private fun toModelGeometry(geometry: Geometry): ModelGeometry =
         when (geometry) {
             is GeoJsonPoint -> {
-                com.google.maps.android.data.renderer.model.PointGeometry(
-                    com.google.maps.android.data.renderer.model.Point(
+                ModelPointGeometry(
+                    ModelPoint(
                         geometry.getCoordinates().latitude,
                         geometry.getCoordinates().longitude,
                         geometry.getAltitude(),
@@ -329,33 +353,31 @@ public class GeoJsonLayer : Layer {
             }
 
             is GeoJsonLineString -> {
-                com.google.maps.android.data.renderer.model.LineString(
+                ModelLineString(
                     geometry.getCoordinates().map {
-                        com.google.maps.android.data.renderer.model
-                            .Point(it.latitude, it.longitude)
+                        ModelPoint(it.latitude, it.longitude)
                     },
                 )
             }
 
             is GeoJsonPolygon -> {
-                com.google.maps.android.data.renderer.model.Polygon(
+                ModelPolygon(
                     geometry.getOuterBoundaryCoordinates().map {
-                        com.google.maps.android.data.renderer.model.Point(
+                        ModelPoint(
                             it.latitude,
                             it.longitude,
                         )
                     },
                     geometry.getInnerBoundaryCoordinates().map { inner ->
                         inner.map {
-                            com.google.maps.android.data.renderer.model
-                                .Point(it.latitude, it.longitude)
+                            ModelPoint(it.latitude, it.longitude)
                         }
                     },
                 )
             }
 
-            is com.google.maps.android.data.MultiGeometry -> {
-                com.google.maps.android.data.renderer.model.MultiGeometry(
+            is MultiGeometry -> {
+                ModelMultiGeometry(
                     geometry.getGeometryObject().map { toModelGeometry(it) },
                 )
             }
@@ -364,6 +386,7 @@ public class GeoJsonLayer : Layer {
                 throw IllegalArgumentException("Unknown geometry type")
             }
         }
+
 
     override val features: Iterable<GeoJsonFeature>
         get() = mFeatures

--- a/data/src/main/java/com/google/maps/android/data/geojson/GeoJsonLayer.kt
+++ b/data/src/main/java/com/google/maps/android/data/geojson/GeoJsonLayer.kt
@@ -33,6 +33,7 @@ import org.json.JSONException
 import org.json.JSONObject
 import java.io.IOException
 import java.io.InputStream
+import java.util.Observer
 
 @Deprecated("Use the new platform-agnostic data layer and renderer instead.")
 public class GeoJsonLayer : Layer {
@@ -41,8 +42,11 @@ public class GeoJsonLayer : Layer {
     private var mRenderer: MapViewRenderer? = null
     private var mIsLayerOnMap = false
     private val mFeatureMap = HashMap<GeoJsonFeature, com.google.maps.android.data.renderer.model.Feature>()
-    private val mModelToLegacyFeatures = HashMap<com.google.maps.android.data.renderer.model.Feature, GeoJsonFeature>()
+    private val mModelToLegacyFeatures = java.util.IdentityHashMap<com.google.maps.android.data.renderer.model.Feature, GeoJsonFeature>()
     private var mFeatureClickListener: OnFeatureClickListener? = null
+    private val mFeatureObserver = Observer { observable, _ ->
+        if (observable is GeoJsonFeature) onFeatureChanged(observable)
+    }
 
     public interface GeoJsonOnFeatureClickListener : OnFeatureClickListener
 
@@ -123,6 +127,7 @@ public class GeoJsonLayer : Layer {
             }
         }
 
+        mFeatures.forEach { it.addObserver(mFeatureObserver) }
         // Calculate bounding box
         calculateBoundingBox()
     }
@@ -231,8 +236,7 @@ public class GeoJsonLayer : Layer {
     override fun addLayerToMap() {
         val renderer = mRenderer ?: return
         mFeatures.forEach { feature ->
-            val modelFeature = toModelFeature(feature)
-            renderer.addFeature(modelFeature)
+            if (feature.getGeometry() != null) renderer.addFeature(toModelFeature(feature))
         }
         mIsLayerOnMap = true
     }
@@ -240,8 +244,7 @@ public class GeoJsonLayer : Layer {
     override fun removeLayerFromMap() {
         val renderer = mRenderer ?: return
         mFeatures.forEach { feature ->
-            val modelFeature = toModelFeature(feature)
-            renderer.removeFeature(modelFeature)
+            mFeatureMap[feature]?.let { renderer.removeFeature(it) }
         }
         mIsLayerOnMap = false
     }
@@ -286,6 +289,18 @@ public class GeoJsonLayer : Layer {
                         strokeWidth = polygonStyle.getStrokeWidth(),
                         geodesic = polygonStyle.isGeodesic(),
                     )
+                }
+
+                is com.google.maps.android.data.renderer.model.MultiGeometry -> {
+                    if (geometry is GeoJsonMultiPolygon) {
+                        val polygonStyle = feature.polygonStyle ?: mDefaultPolygonStyle
+                        com.google.maps.android.data.renderer.model.PolygonStyle(
+                            fillColor = polygonStyle.fillColor,
+                            strokeColor = polygonStyle.getStrokeColor(),
+                            strokeWidth = polygonStyle.getStrokeWidth(),
+                            geodesic = polygonStyle.isGeodesic(),
+                        )
+                    } else null
                 }
 
                 else -> {
@@ -354,20 +369,35 @@ public class GeoJsonLayer : Layer {
         get() = mFeatures
 
     public fun addFeature(feature: GeoJsonFeature) {
-        mFeatures.add(feature)
-        if (mIsLayerOnMap) {
+        if (!mFeatures.contains(feature)) {
+            mFeatures.add(feature)
+            feature.addObserver(mFeatureObserver)
+        }
+        if (mIsLayerOnMap && feature.getGeometry() != null) {
             mRenderer?.addFeature(toModelFeature(feature))
         }
     }
 
     public fun removeFeature(feature: GeoJsonFeature) {
-        mFeatures.remove(feature)
+        if (!mFeatures.remove(feature)) return
+        feature.deleteObserver(mFeatureObserver)
         val modelFeature = mFeatureMap.remove(feature)
         if (modelFeature != null) {
             mModelToLegacyFeatures.remove(modelFeature)
             if (mIsLayerOnMap) {
                 mRenderer?.removeFeature(modelFeature)
             }
+        }
+    }
+
+    private fun onFeatureChanged(feature: GeoJsonFeature) {
+        mFeatureMap.remove(feature)?.let { oldModel ->
+            mModelToLegacyFeatures.remove(oldModel)
+            if (mIsLayerOnMap) mRenderer?.removeFeature(oldModel)
+        }
+        if (mFeatures.contains(feature) && feature.getGeometry() != null) {
+            val updatedModel = toModelFeature(feature)
+            if (mIsLayerOnMap) mRenderer?.addFeature(updatedModel)
         }
     }
 

--- a/data/src/main/java/com/google/maps/android/data/renderer/mapview/MapViewRenderer.kt
+++ b/data/src/main/java/com/google/maps/android/data/renderer/mapview/MapViewRenderer.kt
@@ -109,12 +109,14 @@ class MapViewRenderer(
     }
 
     override fun addFeature(feature: Feature) {
+        removeFeature(feature)
         val mapObjects = mutableListOf<Any>()
         addGeometry(feature.geometry, feature, mapObjects)
         if (mapObjects.isNotEmpty()) {
             renderedFeatures[feature] = mapObjects
         }
     }
+
 
     /**
      * Renders a single [geometry] (recursing into [MultiGeometry] members) with [feature]'s style and

--- a/data/src/test/java/com/google/maps/android/data/geojson/GeoJsonLayerObserverTest.kt
+++ b/data/src/test/java/com/google/maps/android/data/geojson/GeoJsonLayerObserverTest.kt
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.maps.android.data.geojson
+
+import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.Polygon
+import com.google.android.gms.maps.model.PolygonOptions
+import com.google.maps.android.data.Feature
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GeoJsonLayerObserverTest {
+    @Test
+    fun addedPolygonStyleChange_removesAndRedrawsFeature() {
+        val map = mockk<GoogleMap>(relaxed = true)
+        val firstPolygon = mockk<Polygon>(relaxed = true)
+        val secondPolygon = mockk<Polygon>(relaxed = true)
+        val options = mutableListOf<PolygonOptions>()
+        every { map.addPolygon(capture(options)) } returnsMany listOf(firstPolygon, secondPolygon)
+        val layer = emptyLayer(map)
+        val (feature, style) = polygonFeature(INITIAL_COLOR)
+
+        layer.addLayerToMap()
+        layer.addFeature(feature)
+        style.fillColor = UPDATED_COLOR
+
+        verify(exactly = 1) { firstPolygon.remove() }
+        verify(exactly = 2) { map.addPolygon(any<PolygonOptions>()) }
+        assertEquals(INITIAL_COLOR, options[0].fillColor)
+        assertEquals(UPDATED_COLOR, options[1].fillColor)
+    }
+
+    @Test
+    fun parsedFeatureStyleChangeWhileOffMap_isUsedWhenLayerIsReadded() {
+        val map = mockk<GoogleMap>(relaxed = true)
+        val firstPolygon = mockk<Polygon>(relaxed = true)
+        val secondPolygon = mockk<Polygon>(relaxed = true)
+        val options = mutableListOf<PolygonOptions>()
+        every { map.addPolygon(capture(options)) } returnsMany listOf(firstPolygon, secondPolygon)
+        val layer =
+            GeoJsonLayer(
+                map,
+                JSONObject(
+                    """{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,0]]]}}""",
+                ),
+            )
+        val feature = layer.features.single()
+
+        layer.addLayerToMap()
+        layer.removeLayerFromMap()
+        feature.polygonStyle!!.fillColor = UPDATED_COLOR
+
+        layer.addLayerToMap()
+
+        verify(exactly = 1) { firstPolygon.remove() }
+        verify(exactly = 2) { map.addPolygon(any<PolygonOptions>()) }
+        assertEquals(UPDATED_COLOR, options.last().fillColor)
+    }
+
+    @Test
+    fun removedFeature_stopsObservingStyleChanges() {
+        val map = mockk<GoogleMap>(relaxed = true)
+        val polygon = mockk<Polygon>(relaxed = true)
+        every { map.addPolygon(any<PolygonOptions>()) } returns polygon
+        val layer = emptyLayer(map)
+        val (feature, style) = polygonFeature(INITIAL_COLOR)
+        layer.addLayerToMap()
+        layer.addFeature(feature)
+
+        assertEquals(1, feature.countObservers())
+        layer.removeFeature(feature)
+        assertEquals(0, feature.countObservers())
+        style.fillColor = UPDATED_COLOR
+
+        verify(exactly = 1) { polygon.remove() }
+        verify(exactly = 1) { map.addPolygon(any<PolygonOptions>()) }
+    }
+
+    @Test
+    fun featureWithoutGeometry_isIgnoredByLayerLifecycle() {
+        val map = mockk<GoogleMap>(relaxed = true)
+        val layer = emptyLayer(map)
+        val feature = GeoJsonFeature(null, null, null, null)
+
+        layer.addLayerToMap()
+        layer.addFeature(feature)
+        layer.removeLayerFromMap()
+        layer.addLayerToMap()
+
+        assertEquals(listOf(feature), layer.features.toList())
+        verify(exactly = 0) { map.addPolygon(any<PolygonOptions>()) }
+    }
+
+    @Test
+    fun multiPolygonStyleChange_redrawsAndRemovesAllChildrenWithParentClickLookup() {
+        val map = mockk<GoogleMap>(relaxed = true)
+        val polygons = List(4) { mockk<Polygon>(relaxed = true) }
+        val options = mutableListOf<PolygonOptions>()
+        val polygonClickListener = slot<GoogleMap.OnPolygonClickListener>()
+        every { map.addPolygon(capture(options)) } returnsMany polygons
+        every { map.setOnPolygonClickListener(capture(polygonClickListener)) } just Runs
+        val layer = emptyLayer(map)
+        val (feature, style) = multiPolygonFeature(INITIAL_COLOR)
+        var clickedFeature: Feature? = null
+
+        layer.addLayerToMap()
+        layer.setOnFeatureClickListener { clickedFeature = it }
+        layer.addFeature(feature)
+        style.fillColor = UPDATED_COLOR
+
+        assertEquals(listOf(INITIAL_COLOR, INITIAL_COLOR, UPDATED_COLOR, UPDATED_COLOR), options.map { it.fillColor })
+        verify(exactly = 1) { polygons[0].remove() }
+        verify(exactly = 1) { polygons[1].remove() }
+
+        polygonClickListener.captured.onPolygonClick(polygons[2])
+        assertSame(feature, clickedFeature)
+
+        layer.removeFeature(feature)
+
+        verify(exactly = 1) { polygons[2].remove() }
+        verify(exactly = 1) { polygons[3].remove() }
+    }
+
+    @Test
+    fun addingSameFeatureTwice_replacesRenderingWithoutDuplicatingLifecycle() {
+        val map = mockk<GoogleMap>(relaxed = true)
+        val firstPolygon = mockk<Polygon>(relaxed = true)
+        val secondPolygon = mockk<Polygon>(relaxed = true)
+        every { map.addPolygon(any<PolygonOptions>()) } returnsMany listOf(firstPolygon, secondPolygon)
+        val layer = emptyLayer(map)
+        val (feature, style) = polygonFeature(INITIAL_COLOR)
+
+        layer.addLayerToMap()
+        layer.addFeature(feature)
+        layer.addFeature(feature)
+
+        assertEquals(listOf(feature), layer.features.toList())
+        assertEquals(1, feature.countObservers())
+        verify(exactly = 1) { firstPolygon.remove() }
+
+        layer.removeFeature(feature)
+        style.fillColor = UPDATED_COLOR
+
+        assertEquals(emptyList<GeoJsonFeature>(), layer.features.toList())
+        assertEquals(0, feature.countObservers())
+        verify(exactly = 1) { secondPolygon.remove() }
+        verify(exactly = 2) { map.addPolygon(any<PolygonOptions>()) }
+    }
+
+    @Test
+    fun equalModelFeatures_clickLookupUsesModelIdentity() {
+        val map = mockk<GoogleMap>(relaxed = true)
+        val firstPolygon = mockk<Polygon>(relaxed = true)
+        val secondPolygon = mockk<Polygon>(relaxed = true)
+        val polygonClickListener = slot<GoogleMap.OnPolygonClickListener>()
+        every { map.addPolygon(any<PolygonOptions>()) } returnsMany listOf(firstPolygon, secondPolygon)
+        every { map.setOnPolygonClickListener(capture(polygonClickListener)) } just Runs
+        val layer = emptyLayer(map)
+        val (firstFeature) = polygonFeature(INITIAL_COLOR)
+        val (secondFeature) = polygonFeature(INITIAL_COLOR)
+        var clickedFeature: Feature? = null
+
+        layer.addLayerToMap()
+        layer.setOnFeatureClickListener { clickedFeature = it }
+        layer.addFeature(firstFeature)
+        layer.addFeature(secondFeature)
+
+        polygonClickListener.captured.onPolygonClick(firstPolygon)
+        assertSame(firstFeature, clickedFeature)
+        polygonClickListener.captured.onPolygonClick(secondPolygon)
+        assertSame(secondFeature, clickedFeature)
+    }
+
+    private fun emptyLayer(map: GoogleMap): GeoJsonLayer =
+        GeoJsonLayer(
+            map,
+            JSONObject("""{"type":"FeatureCollection","features":[]}"""),
+        )
+
+    private fun polygonFeature(fillColor: Int): Pair<GeoJsonFeature, GeoJsonPolygonStyle> {
+        val geometry =
+            GeoJsonPolygon(
+                listOf(
+                    listOf(
+                        LatLng(0.0, 0.0),
+                        LatLng(0.0, 1.0),
+                        LatLng(1.0, 1.0),
+                        LatLng(0.0, 0.0),
+                    ),
+                ),
+            )
+        val style = GeoJsonPolygonStyle().apply { this.fillColor = fillColor }
+        return GeoJsonFeature(geometry, null, null, null).also { it.polygonStyle = style } to style
+    }
+
+    private fun multiPolygonFeature(fillColor: Int): Pair<GeoJsonFeature, GeoJsonPolygonStyle> {
+        val firstPolygon = polygon(0.0)
+        val secondPolygon = polygon(2.0)
+        val style = GeoJsonPolygonStyle().apply { this.fillColor = fillColor }
+        return GeoJsonFeature(GeoJsonMultiPolygon(listOf(firstPolygon, secondPolygon)), null, null, null)
+            .also { it.polygonStyle = style } to style
+    }
+
+    private fun polygon(offset: Double): GeoJsonPolygon =
+        GeoJsonPolygon(
+            listOf(
+                listOf(
+                    LatLng(offset, offset),
+                    LatLng(offset, offset + 1.0),
+                    LatLng(offset + 1.0, offset + 1.0),
+                    LatLng(offset, offset),
+                ),
+            ),
+        )
+
+    private companion object {
+        const val INITIAL_COLOR = -15654349
+        const val UPDATED_COLOR = -12298906
+    }
+}

--- a/data/src/test/java/com/google/maps/android/data/renderer/MapViewRendererTest.kt
+++ b/data/src/test/java/com/google/maps/android/data/renderer/MapViewRendererTest.kt
@@ -20,6 +20,8 @@ import com.google.android.gms.maps.model.AdvancedMarkerOptions
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
+import com.google.android.gms.maps.model.Polygon as MapPolygon
+
 import com.google.android.gms.maps.model.PolygonOptions
 import com.google.android.gms.maps.model.Polyline
 import com.google.android.gms.maps.model.PolylineOptions
@@ -32,11 +34,13 @@ import com.google.maps.android.data.renderer.model.Point
 import com.google.maps.android.data.renderer.model.PointGeometry
 import com.google.maps.android.data.renderer.model.Polygon
 import com.google.maps.android.data.renderer.model.PolygonStyle
+
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.Test
 
 /**
@@ -153,7 +157,7 @@ class MapViewRendererTest {
     }
 
     @Test
-fun testRemoveFeature_multiGeometry_removesAllRenderedObjects() {
+    fun testRemoveFeature_multiGeometry_removesAllRenderedObjects() {
         // Given
         val mockMap = mockk<GoogleMap>(relaxed = true)
         val mockIconProvider = mockk<IconProvider>(relaxed = true)
@@ -304,5 +308,42 @@ fun testRemoveFeature_multiGeometry_removesAllRenderedObjects() {
 
         // Then
         verify(exactly = 1) { mockPolygon.remove() }
+    }
+
+    @Test
+    fun nestedMultiGeometry_childrenBelongToParentFeature() {
+        val map = mockk<GoogleMap>(relaxed = true)
+        val firstPolygon = mockk<MapPolygon>(relaxed = true)
+        val secondPolygon = mockk<MapPolygon>(relaxed = true)
+        every { map.addPolygon(any<PolygonOptions>()) } returnsMany listOf(firstPolygon, secondPolygon)
+        val renderer = MapViewRenderer(map, mockk(relaxed = true))
+        val polygon =
+            Polygon(
+                listOf(
+                    Point(0.0, 0.0),
+                    Point(0.0, 1.0),
+                    Point(1.0, 1.0),
+                    Point(0.0, 0.0),
+                ),
+            )
+        val feature =
+            Feature(
+                MultiGeometry(
+                    listOf(
+                        polygon,
+                        MultiGeometry(listOf(polygon.copy())),
+                    ),
+                ),
+            )
+
+        renderer.addFeature(feature)
+
+        assertSame(feature, renderer.getFeatureForMapObject(firstPolygon))
+        assertSame(feature, renderer.getFeatureForMapObject(secondPolygon))
+
+        renderer.removeFeature(feature)
+
+        verify(exactly = 1) { firstPolygon.remove() }
+        verify(exactly = 1) { secondPolygon.remove() }
     }
 }


### PR DESCRIPTION
Fixes #1050.

Observe legacy GeoJSON features so style and geometry changes invalidate the cached renderer model and redraw map objects with the updated values. Repeated insertion remains idempotent, removed features detach their observer, and null-geometry features remain safe across the layer lifecycle.

Multi-geometries now keep their rendered children under the parent feature, preserving complete removal and click lookup. Multi-polygons also carry their polygon style into the renderer.

Tests:
- data module unit tests, including focused redraw and renderer ownership regressions
- data module lint
- data debug assembly
- diff whitespace check
