### PR TITLE
fix(visual-testing): add UiScrollable chip scroll support for robust chip selection

### DIFF
--- a/demo/src/androidTest/java/com/google/maps/android/utils/demo/RendererVisualTestBase.kt
+++ b/demo/src/androidTest/java/com/google/maps/android/utils/demo/RendererVisualTestBase.kt
@@ -42,8 +42,22 @@ abstract class RendererVisualTestBase : BaseVisualTest() {
         if (element != null) {
             element.click()
         } else {
-            // Fallback to AI if standard selector fails
-            helper.performActionFromPrompt("Click the $label button or chip", uiDevice, geminiApiKey)
+            val scrollable = androidx.test.uiautomator.UiScrollable(
+                androidx.test.uiautomator.UiSelector().scrollable(true)
+            )
+            val scrolled = try {
+                if (scrollable.exists()) {
+                    scrollable.setAsHorizontalList()
+                    scrollable.scrollTextIntoView(label)
+                } else false
+            } catch (e: Exception) { false }
+
+            val scrolledElement = uiDevice.findObject(By.textContains(label))
+            if (scrolledElement != null) {
+                scrolledElement.click()
+            } else {
+                helper.performActionFromPrompt("Click the $label button or chip", uiDevice, geminiApiKey)
+            }
         }
 
         // Wait for action to settle (bottom sheet collapse, map render)


### PR DESCRIPTION
### Summary of Changes
- Add  horizontal scroll search in  to scroll off-screen bottom sheet chips into view before clicking.
- Prevents UIAutomator element selection failures when chips are laid out off-screen on smaller devices or high-density displays.