### PR TITLE
feat(data): add support for parsing GroundOverlay with LatLonQuad bounds

### DIFF
--- a/data/src/main/java/com/google/maps/android/data/parser/kml/KmlModel.kt
+++ b/data/src/main/java/com/google/maps/android/data/parser/kml/KmlModel.kt
@@ -102,6 +102,9 @@ data class GroundOverlay(
     @XmlElement(true)
     @XmlSerialName("LatLonBox", namespace = KML_NAMESPACE, prefix = "")
     val latLonBox: LatLonBox? = null,
+    @XmlElement(true)
+    @XmlSerialName("LatLonQuad", namespace = KML_NAMESPACE, prefix = "")
+    val latLonQuad: LatLonQuad? = null,
 )
 
 @Serializable
@@ -131,6 +134,17 @@ data class LatLonBox(
     @XmlSerialName("rotation", namespace = KML_NAMESPACE, prefix = "")
     val rotation: Double? = null,
 )
+
+@Serializable
+@XmlSerialName("LatLonQuad", namespace = KML_NAMESPACE, prefix = "")
+data class LatLonQuad(
+    @XmlElement(true)
+    @XmlSerialName("coordinates", namespace = KML_NAMESPACE, prefix = "")
+    @Serializable(with = LatLngAltListSerializer::class)
+    val coordinates: List<LatLngAlt> = emptyList(),
+)
+
+
 
 fun Kml.findByPlacemarksById(id: String): List<Placemark> =
     buildList {

--- a/data/src/main/java/com/google/maps/android/data/renderer/mapper/KmlMapper.kt
+++ b/data/src/main/java/com/google/maps/android/data/renderer/mapper/KmlMapper.kt
@@ -15,7 +15,10 @@
  */
 package com.google.maps.android.data.renderer.mapper
 
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.SphericalUtil
 import com.google.maps.android.data.parser.kml.Folder
+
 import com.google.maps.android.data.parser.kml.Kml
 import com.google.maps.android.data.parser.kml.Placemark
 import com.google.maps.android.data.renderer.model.DataLayer
@@ -173,14 +176,7 @@ private fun Placemark.toRendererFeature(
 }
 
 private fun KmlGroundOverlay.toRendererFeature(): Feature {
-    val geometry =
-        GroundOverlay(
-            north = latLonBox?.north ?: 0.0,
-            south = latLonBox?.south ?: 0.0,
-            east = latLonBox?.east ?: 0.0,
-            west = latLonBox?.west ?: 0.0,
-            rotation = latLonBox?.rotation?.toFloat() ?: 0f,
-        )
+    val geometry = toRendererGeometry()
     val style =
         GroundOverlayStyle(
             iconUrl = icon?.href,
@@ -193,6 +189,62 @@ private fun KmlGroundOverlay.toRendererFeature(): Feature {
 
     return Feature(geometry, style = style, properties = properties)
 }
+
+private fun KmlGroundOverlay.toRendererGeometry(): GroundOverlay {
+    if (latLonBox != null) {
+        return GroundOverlay(
+            north = latLonBox.north,
+            south = latLonBox.south,
+            east = latLonBox.east,
+            west = latLonBox.west,
+            rotation = latLonBox.rotation?.toFloat() ?: 0f,
+        )
+    }
+    if (latLonQuad != null && latLonQuad.coordinates.size >= 4) {
+        val sw = latLonQuad.coordinates[0]
+        val se = latLonQuad.coordinates[1]
+        val ne = latLonQuad.coordinates[2]
+        val nw = latLonQuad.coordinates[3]
+
+        val swLatLng = LatLng(sw.latitude, sw.longitude)
+        val seLatLng = LatLng(se.latitude, se.longitude)
+        val neLatLng = LatLng(ne.latitude, ne.longitude)
+        val nwLatLng = LatLng(nw.latitude, nw.longitude)
+
+        val nRot = 90.0 - bearing(nwLatLng, neLatLng)
+        val sRot = 270.0 - bearing(seLatLng, swLatLng)
+        val rotation = -(nRot + sRot) / 2.0
+
+        val n = (ne.latitude + nw.latitude) / 2.0
+        val s = (se.latitude + sw.latitude) / 2.0
+        val e = (ne.longitude + se.longitude) / 2.0
+        val w = (nw.longitude + sw.longitude) / 2.0
+
+        return GroundOverlay(
+            north = n,
+            south = s,
+            east = e,
+            west = w,
+            rotation = rotation.toFloat(),
+        )
+    }
+    return GroundOverlay(
+        north = 0.0,
+        south = 0.0,
+        east = 0.0,
+        west = 0.0,
+        rotation = 0f,
+    )
+}
+
+private fun bearing(
+    from: LatLng,
+    to: LatLng,
+): Double {
+    val h = SphericalUtil.computeHeading(from, to)
+    return if (h < 0) h + 360.0 else h
+}
+
 
 private fun KmlStyle.toRendererStyle(geometry: Geometry): Style? =
     when (geometry) {

--- a/data/src/test/java/com/google/maps/android/data/parser/GroundOverlayTest.kt
+++ b/data/src/test/java/com/google/maps/android/data/parser/GroundOverlayTest.kt
@@ -46,4 +46,42 @@ class GroundOverlayTest {
         val style = feature.style as GroundOverlayStyle
         assertEquals("https://developers.google.com/kml/documentation/images/etna.jpg", style.iconUrl)
     }
+
+    @Test
+    fun testGroundOverlayWithLatLonQuadParsing() {
+        val kmlString =
+            """
+            <kml xmlns="http://www.opengis.net/kml/2.2">
+              <Document>
+                <GroundOverlay>
+                  <name>Quad Overlay</name>
+                  <Icon>
+                    <href>https://developers.google.com/kml/documentation/images/etna.jpg</href>
+                  </Icon>
+                  <LatLonQuad>
+                    <coordinates>
+                      -0.15,51.2 -0.10,51.2 -0.10,51.4 -0.15,51.4
+                    </coordinates>
+                  </LatLonQuad>
+                </GroundOverlay>
+              </Document>
+            </kml>
+            """.trimIndent()
+
+        val kml = KmlParser().parse(kmlString.byteInputStream())
+        val layer = KmlMapper.toLayer(kml)
+
+        assertEquals(1, layer.features.size)
+        val feature = layer.features[0]
+
+        assertTrue(feature.geometry is GroundOverlay)
+        val groundOverlay = feature.geometry as GroundOverlay
+
+        assertEquals(51.4, groundOverlay.north, 0.000001)
+        assertEquals(51.2, groundOverlay.south, 0.000001)
+        assertEquals(-0.10, groundOverlay.east, 0.000001)
+        assertEquals(-0.15, groundOverlay.west, 0.000001)
+        assertEquals(0.0f, groundOverlay.rotation, 0.001f)
+    }
 }
+

--- a/data/src/test/java/com/google/maps/android/data/renderer/mapper/KmlMapperTest.kt
+++ b/data/src/test/java/com/google/maps/android/data/renderer/mapper/KmlMapperTest.kt
@@ -246,4 +246,40 @@ class KmlMapperTest {
         assertEquals("Stroke color should match", 0xffa52714.toInt(), style.strokeColor)
         assertEquals("Stroke width should match", 1.2f, style.strokeWidth, 0.01f)
     }
+
+    @Test
+    fun `test GroundOverlay with LatLonQuad to Scene`() {
+        val kmlString =
+            """
+            <kml xmlns="http://www.opengis.net/kml/2.2">
+              <Document>
+                <GroundOverlay>
+                  <name>Quad Overlay</name>
+                  <Icon>
+                    <href>https://developers.google.com/kml/documentation/images/etna.jpg</href>
+                  </Icon>
+                  <LatLonQuad>
+                    <coordinates>
+                      -0.15,51.2 -0.10,51.2 -0.10,51.4 -0.15,51.4
+                    </coordinates>
+                  </LatLonQuad>
+                </GroundOverlay>
+              </Document>
+            </kml>
+            """.trimIndent()
+        val kml =
+            com.google.maps.android.data.parser.kml
+                .KmlParser()
+                .parse(kmlString.byteInputStream())
+        val scene = KmlMapper.toScene(kml)
+        assertEquals(1, scene.features.size)
+        val feature = scene.features[0]
+        val geometry = feature.geometry as com.google.maps.android.data.renderer.model.GroundOverlay
+        assertEquals(51.4, geometry.north, 0.000001)
+        assertEquals(51.2, geometry.south, 0.000001)
+        assertEquals(-0.10, geometry.east, 0.000001)
+        assertEquals(-0.15, geometry.west, 0.000001)
+        assertEquals(0.0f, geometry.rotation, 0.001f)
+    }
 }
+

--- a/demo/src/androidTest/java/com/google/maps/android/utils/demo/RendererVisualTest.kt
+++ b/demo/src/androidTest/java/com/google/maps/android/utils/demo/RendererVisualTest.kt
@@ -72,8 +72,11 @@ class RendererVisualTest : RendererVisualTestBase() {
             launchActivity()
             clickButton("Ground Overlay")
             collapseBottomSheet()
-            verifyMapContent("Does the map show an image overlay of Mount Etna, a volcano, superimposed on the base map near Sicily?")
+            verifyMapContent(
+                "Does the map show two image overlays of Mount Etna side by side in Sicily, one standard rectangular overlay on Mount Etna and a second quadrilateral overlay just west of it?",
+            )
         }
+
 
     @Test
     fun testBrightAngelLayer() =

--- a/demo/src/main/assets/ground_overlay.kml
+++ b/demo/src/main/assets/ground_overlay.kml
@@ -4,7 +4,7 @@
     <name>Ground Overlays</name>
     <description>Examples of Ground Overlays</description>
     <GroundOverlay>
-      <name>Large-scale overlay on terrain</name>
+      <name>Large-scale overlay on terrain (LatLonBox)</name>
       <description>Overlay showing Mount Etna erupting on July 13th, 2001.</description>
       <Icon>
         <href>https://developers.google.com/kml/documentation/images/etna.jpg</href>
@@ -17,5 +17,19 @@
         <rotation>-0.1556640799496235</rotation>
       </LatLonBox>
     </GroundOverlay>
+    <GroundOverlay>
+      <name>Quad overlay west of Etna (LatLonQuad)</name>
+      <description>Overlay defined by LatLonQuad corner coordinates</description>
+      <Icon>
+        <href>https://developers.google.com/kml/documentation/images/etna.jpg</href>
+      </Icon>
+      <LatLonQuad>
+        <coordinates>
+          13.80,37.46 14.55,37.46 14.55,37.91 13.80,37.91
+        </coordinates>
+      </LatLonQuad>
+    </GroundOverlay>
   </Folder>
 </kml>
+
+


### PR DESCRIPTION
Reimplements KML `<LatLonQuad>` GroundOverlay parsing and mapping on the Kotlin data layer (`KmlModel.kt` and `KmlMapper.kt`).

### Summary of Changes
- Supports corner coordinate arrays (`<coordinates>SW SE NE NW</coordinates>`), computing the rectified bounding box and average rotation using spherical bearing calculations from `SphericalUtil`.
- Adds regression tests in `GroundOverlayTest` and `KmlMapperTest` that fail on unpatched code and pass with LatLonQuad support.
- Adds a sample LatLonQuad overlay to `ground_overlay.kml` and updates `RendererVisualTest` to visually verify both Mount Etna overlays side-by-side on-device.

Replaces and closes #1396.