### PR TITLE
docs: document Google Navigation SDK compatibility (#1728)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -26,6 +26,16 @@ android-maps-utils = { group = "com.google.maps.android", name = "android-maps-u
 ```
 This aggregator dynamically and transitively pulls all individual submodules. Alternatively, you can choose to import only the specific submodules your app requires (e.g., `android-maps-utils-core` and `android-maps-utils-clustering`).
 
+> [!IMPORTANT]
+> **Google Navigation SDK Compatibility**: If your project integrates the Google Navigation SDK for Android, add an exclusion for `play-services-maps` to prevent duplicate class conflicts:
+> ```kotlin
+> configurations.all {
+>     if (name.contains("navigation", ignoreCase = true)) {
+>         exclude(group = "com.google.android.gms", module = "play-services-maps")
+>     }
+> }
+> ```
+
 ---
 
 ## 2. Kotlin Property Syntax Overrides (Breaking Changes for Kotlin Callers)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ dependencies {
 }
 ```
 
+### Compatibility with Google Navigation SDK for Android
+
+If your project integrates the [Google Navigation SDK for Android](https://developers.google.com/maps/documentation/navigation/android-sdk), you must exclude the transitive `play-services-maps` dependency to prevent duplicate class conflicts:
+
+```kotlin
+configurations.all {
+    if (name.contains("navigation", ignoreCase = true)) {
+        exclude(group = "com.google.android.gms", module = "play-services-maps")
+    }
+}
+```
+
 ## Sample App
 
 <img src="https://developers.google.com/maps/documentation/android-sdk/images/utility-markercluster.png" width="150" align=right>


### PR DESCRIPTION
Adds documentation to README.md and MIGRATION.md explaining how to exclude play-services-maps when integrating the Google Navigation SDK for Android to prevent duplicate class conflicts.

Fixes #1728