### PR TITLE
build: make GPG signing conditional in PublishingConventionPlugin for local publishing

### DIFF
--- a/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
@@ -83,7 +83,19 @@ class PublishingConventionPlugin : Plugin<Project> {
             )
 
             publishToMavenCentral()
-            signAllPublications()
+
+            // Only enable GPG publication signing when signing credentials are present.
+            // Why: When signAllPublications() is invoked unconditionally, the Maven Publish plugin
+            // registers GPG signature files (.asc) as mandatory artifacts of the publication.
+            // On local developer machines without GPG keys configured, running tasks such as
+            // './gradlew publishToMavenLocal' fails because the .asc files cannot be generated.
+            // Making signing conditional allows local publishing to succeed without credentials
+            // while ensuring all CI and release pipeline builds are properly signed.
+            val isSigningConfigured = !providers.gradleProperty("signing.keyId").getOrElse("").isEmpty() ||
+                !providers.gradleProperty("signing.secretKeyRingFile").getOrElse("").isEmpty()
+            if (isSigningConfigured) {
+                signAllPublications()
+            }
 
             val artifactIdName = when (project.name) {
                 "maps-utils" -> "android-maps-utils"


### PR DESCRIPTION
### What this PR does

When developers run `./gradlew publishToMavenLocal` on their local machines without configuring GPG signing credentials (`signing.keyId`, `signing.secretKeyRingFile`), the build fails with:
```
Invalid publication 'maven': artifact file does not exist: '.../release-javadoc.jar.asc'
```
This occurred because `signAllPublications()` in `PublishingConventionPlugin.kt` was invoked unconditionally.

This PR wraps `signAllPublications()` so that it only signs when `signing.keyId` or `signing.secretKeyRingFile` is present and non-empty:
```kotlin
val isSigningConfigured = !providers.gradleProperty("signing.keyId").getOrElse("").isEmpty() ||
    !providers.gradleProperty("signing.secretKeyRingFile").getOrElse("").isEmpty()
if (isSigningConfigured) {
    signAllPublications()
}
```

### Verification
- Executed `./gradlew publishToMavenLocal` across all modules: **BUILD SUCCESSFUL** without `.asc` signature errors.
- Verified that all 7 library modules are correctly installed in `~/.m2/repository/com/google/maps/android/`.