### PR TITLE
build(ci): add workflow_dispatch trigger to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,7 +28,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
           token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
           config-file: release-please-config.json


### PR DESCRIPTION
- Add `workflow_dispatch:` event trigger to `.github/workflows/release-please.yml`.
- Enables maintainers to manually trigger Release Please runs via the GitHub UI or `gh workflow run` CLI when push webhooks are delayed or dropped.