### PR TITLE
fix: restore isLayerOnMap() as abstract member of Layer

### DIFF
--- a/data/src/main/java/com/google/maps/android/data/Layer.kt
+++ b/data/src/main/java/com/google/maps/android/data/Layer.kt
@@ -41,6 +41,8 @@ public abstract class Layer {
 
     public abstract fun removeLayerFromMap()
 
+    public abstract fun isLayerOnMap(): Boolean
+
     public fun interface OnFeatureClickListener {
         public fun onFeatureClick(feature: Feature)
     }

--- a/data/src/main/java/com/google/maps/android/data/geojson/GeoJsonLayer.kt
+++ b/data/src/main/java/com/google/maps/android/data/geojson/GeoJsonLayer.kt
@@ -457,7 +457,7 @@ public class GeoJsonLayer : Layer {
 
     public fun getBoundingBox(): LatLngBounds? = mBoundingBox
 
-    public fun isLayerOnMap(): Boolean = mIsLayerOnMap
+    override fun isLayerOnMap(): Boolean = mIsLayerOnMap
 
     override fun toString(): String =
         StringBuilder("Collection{")

--- a/data/src/main/java/com/google/maps/android/data/kml/KmlLayer.kt
+++ b/data/src/main/java/com/google/maps/android/data/kml/KmlLayer.kt
@@ -509,7 +509,7 @@ public class KmlLayer : Layer {
     override val features: Iterable<KmlPlacemark>
         get() = mPlacemarks
 
-    public fun isLayerOnMap(): Boolean = mIsLayerOnMap
+    override fun isLayerOnMap(): Boolean = mIsLayerOnMap
 
     override fun setOnFeatureClickListener(listener: OnFeatureClickListener) {
         mFeatureClickListener = listener

--- a/data/src/test/java/com/google/maps/android/data/geojson/GeoJsonLayerOnMapTest.kt
+++ b/data/src/test/java/com/google/maps/android/data/geojson/GeoJsonLayerOnMapTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.maps.android.data.geojson
+
+import com.google.android.gms.maps.GoogleMap
+import com.google.maps.android.data.Layer
+import io.mockk.mockk
+import org.json.JSONObject
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/** Regression test for https://github.com/googlemaps/android-maps-utils/issues/1746. */
+@RunWith(RobolectricTestRunner::class)
+class GeoJsonLayerOnMapTest {
+    private val emptyFeatureCollection =
+        JSONObject(
+            """
+            { "type": "FeatureCollection", "features": [] }
+            """.trimIndent(),
+        )
+
+    @Test
+    fun isLayerOnMap_isExposedThroughLayerBaseClass() {
+        val layer: Layer = GeoJsonLayer(mockk<GoogleMap>(relaxed = true), emptyFeatureCollection)
+
+        assertFalse(layer.isLayerOnMap())
+    }
+
+    @Test
+    fun isLayerOnMap_reflectsAddAndRemove() {
+        val layer = GeoJsonLayer(mockk<GoogleMap>(relaxed = true), emptyFeatureCollection)
+
+        assertFalse(layer.isLayerOnMap())
+
+        layer.addLayerToMap()
+        assertTrue(layer.isLayerOnMap())
+
+        layer.removeLayerFromMap()
+        assertFalse(layer.isLayerOnMap())
+    }
+}

--- a/data/src/test/java/com/google/maps/android/data/kml/KmlLayerOnMapTest.kt
+++ b/data/src/test/java/com/google/maps/android/data/kml/KmlLayerOnMapTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.maps.android.data.kml
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.android.gms.maps.GoogleMap
+import com.google.maps.android.data.Layer
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/** Regression test for https://github.com/googlemaps/android-maps-utils/issues/1746. */
+@RunWith(RobolectricTestRunner::class)
+class KmlLayerOnMapTest {
+    private val emptyKml =
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <kml xmlns="http://www.opengis.net/kml/2.2">
+          <Document/>
+        </kml>
+        """.trimIndent()
+
+    private fun newLayer(): KmlLayer {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        return KmlLayer(mockk<GoogleMap>(relaxed = true), emptyKml.byteInputStream(), context)
+    }
+
+    @Test
+    fun isLayerOnMap_isExposedThroughLayerBaseClass() {
+        val layer: Layer = newLayer()
+
+        assertFalse(layer.isLayerOnMap())
+    }
+
+    @Test
+    fun isLayerOnMap_reflectsAddAndRemove() {
+        val layer = newLayer()
+
+        assertFalse(layer.isLayerOnMap())
+
+        layer.addLayerToMap()
+        assertTrue(layer.isLayerOnMap())
+
+        layer.removeLayerFromMap()
+        assertFalse(layer.isLayerOnMap())
+    }
+}


### PR DESCRIPTION
## Summary
- Prior to the v5 rewrite, `Layer` exposed `isLayerOnMap()` directly. The rewrite (#1658) kept `addLayerToMap()`/`removeLayerFromMap()`/`getMap()`/`setMap()` as abstract members of `Layer`, but dropped `isLayerOnMap()` from the base class, leaving it duplicated identically in `GeoJsonLayer` and `KmlLayer` with no way to call it through a `Layer` reference.
- Adds `public abstract fun isLayerOnMap(): Boolean` to `Layer` and marks the existing implementations in `GeoJsonLayer`/`KmlLayer` as `override`. No behavior change — the two implementations were already identical.

Fixes #1746

## Test plan
- [x] Added `GeoJsonLayerOnMapTest` and `KmlLayerOnMapTest`, verifying `isLayerOnMap()` is reachable through a `Layer`-typed reference and reflects `addLayerToMap()`/`removeLayerFromMap()` calls.
- [x] `./gradlew :data:testDebugUnitTest` — all 124 tests in the `data` module pass.
- [x] `./gradlew :data:compileDebugKotlin` — compiles cleanly.