### PR TITLE
fix(data): prevent SSRF from untrusted KML/GeoJSON icon and GroundOverlay href

### DIFF
--- a/data/src/main/java/com/google/maps/android/data/kml/DefaultKmlUrlSanitizer.java
+++ b/data/src/main/java/com/google/maps/android/data/kml/DefaultKmlUrlSanitizer.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.maps.android.data.kml;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.util.Locale;
+
+/**
+ * Default, secure {@link KmlUrlSanitizer} used when a layer loads remote icons/overlays.
+ *
+ * <p>Icon and GroundOverlay {@code <href>} values come from the parsed KML/GeoJSON document,
+ * which is frequently untrusted (downloaded, user-provided, or shared). Fetching those URLs
+ * without validation is a Server-Side Request Forgery (SSRF) primitive: a crafted document can
+ * make the app issue requests to loopback, link-local (including the {@code 169.254.169.254}
+ * metadata endpoint), or private-network hosts reachable from the device.
+ *
+ * <p>This sanitizer allows only {@code http}/{@code https} URLs whose host does not resolve to a
+ * loopback, any-local, link-local, site-local (RFC 1918), or multicast address, and returns
+ * {@code null} (block) otherwise. Public icon/overlay URLs continue to load unchanged.
+ */
+public class DefaultKmlUrlSanitizer implements KmlUrlSanitizer {
+
+    @Override
+    public String sanitizeUrl(String url) {
+        if (url == null) {
+            return null;
+        }
+        final URI uri;
+        try {
+            uri = new URI(url);
+        } catch (Exception e) {
+            return null;
+        }
+
+        final String scheme = uri.getScheme();
+        if (scheme == null) {
+            return null;
+        }
+        final String lowerScheme = scheme.toLowerCase(Locale.ROOT);
+        if (!lowerScheme.equals("http") && !lowerScheme.equals("https")) {
+            return null;
+        }
+
+        final String host = uri.getHost();
+        if (host == null || host.isEmpty()) {
+            return null;
+        }
+
+        try {
+            // Block if ANY resolved address is internal, to defeat split-horizon / multi-A tricks.
+            for (InetAddress address : InetAddress.getAllByName(host)) {
+                if (address.isLoopbackAddress()
+                        || address.isAnyLocalAddress()
+                        || address.isLinkLocalAddress()
+                        || address.isSiteLocalAddress()
+                        || address.isMulticastAddress()) {
+                    return null;
+                }
+            }
+        } catch (Exception e) {
+            // Unresolvable host: fail closed.
+            return null;
+        }
+
+        return url;
+    }
+}

--- a/data/src/main/java/com/google/maps/android/data/kml/DefaultKmlUrlSanitizer.java
+++ b/data/src/main/java/com/google/maps/android/data/kml/DefaultKmlUrlSanitizer.java
@@ -28,9 +28,9 @@ import java.util.Locale;
  * make the app issue requests to loopback, link-local (including the {@code 169.254.169.254}
  * metadata endpoint), or private-network hosts reachable from the device.
  *
- * <p>This sanitizer allows only {@code http}/{@code https} URLs whose host does not resolve to a
- * loopback, any-local, link-local, site-local (RFC 1918), or multicast address, and returns
- * {@code null} (block) otherwise. Public icon/overlay URLs continue to load unchanged.
+ * <p>This sanitizer allows only {@code http}/{@code https} URLs whose host does not resolve to an
+ * internal address (see {@link #isInternalAddress(InetAddress)}), and returns {@code null} (block)
+ * otherwise. Public icon/overlay URLs continue to load unchanged.
  */
 public class DefaultKmlUrlSanitizer implements KmlUrlSanitizer {
 
@@ -62,12 +62,12 @@ public class DefaultKmlUrlSanitizer implements KmlUrlSanitizer {
 
         try {
             // Block if ANY resolved address is internal, to defeat split-horizon / multi-A tricks.
-            for (InetAddress address : InetAddress.getAllByName(host)) {
-                if (address.isLoopbackAddress()
-                        || address.isAnyLocalAddress()
-                        || address.isLinkLocalAddress()
-                        || address.isSiteLocalAddress()
-                        || address.isMulticastAddress()) {
+            InetAddress[] addresses = InetAddress.getAllByName(host);
+            if (addresses.length == 0) {
+                return null;
+            }
+            for (InetAddress address : addresses) {
+                if (isInternalAddress(address)) {
                     return null;
                 }
             }
@@ -77,5 +77,54 @@ public class DefaultKmlUrlSanitizer implements KmlUrlSanitizer {
         }
 
         return url;
+    }
+
+    /**
+     * Returns {@code true} if {@code address} is one that a fetch triggered by an untrusted
+     * document must never reach.
+     *
+     * <p>Covers the ranges recognized by {@link InetAddress} (loopback, wildcard/any-local,
+     * link-local, IPv4 RFC 1918 site-local, multicast) plus ranges that {@code InetAddress} does
+     * not classify but are still internal or special-purpose:
+     *
+     * <ul>
+     *   <li>{@code fc00::/7} IPv6 Unique Local Addresses (RFC 4193) not covered by
+     *       {@code isSiteLocalAddress()}.
+     *   <li>{@code 100.64.0.0/10} IPv4 Carrier-Grade NAT / shared address space (RFC 6598).
+     *   <li>{@code 192.0.0.0/24} IETF protocol assignments (RFC 6890), which includes NAT64 and
+     *       other internal-only special-use addresses.
+     * </ul>
+     */
+    public static boolean isInternalAddress(InetAddress address) {
+        if (address == null) {
+            return true;
+        }
+        if (address.isLoopbackAddress()
+                || address.isAnyLocalAddress()
+                || address.isLinkLocalAddress()
+                || address.isSiteLocalAddress()
+                || address.isMulticastAddress()) {
+            return true;
+        }
+        final byte[] b = address.getAddress();
+        if (b.length == 4) {
+            final int b0 = b[0] & 0xFF;
+            final int b1 = b[1] & 0xFF;
+            final int b2 = b[2] & 0xFF;
+            // 100.64.0.0/10 (CGNAT, RFC 6598): 100.64.0.0 - 100.127.255.255.
+            if (b0 == 100 && (b1 & 0xC0) == 0x40) {
+                return true;
+            }
+            // 192.0.0.0/24 (IETF protocol assignments, RFC 6890).
+            if (b0 == 192 && b1 == 0 && b2 == 0) {
+                return true;
+            }
+        } else if (b.length == 16) {
+            // fc00::/7 (IPv6 Unique Local Addresses, RFC 4193): first byte fc or fd.
+            if ((b[0] & 0xFE) == 0xFC) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/data/src/main/java/com/google/maps/android/data/renderer/UrlIconProvider.kt
+++ b/data/src/main/java/com/google/maps/android/data/renderer/UrlIconProvider.kt
@@ -18,6 +18,8 @@ package com.google.maps.android.data.renderer
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.util.LruCache
+import com.google.maps.android.data.kml.DefaultKmlUrlSanitizer
+import com.google.maps.android.data.kml.KmlUrlSanitizer
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
@@ -35,6 +37,11 @@ import java.util.concurrent.ConcurrentHashMap
  */
 open class UrlIconProvider(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    // Icon/overlay hrefs originate from the (frequently untrusted) KML/GeoJSON document. The
+    // sanitizer is applied before every fetch to prevent SSRF; the secure default blocks
+    // non-http(s) schemes and hosts resolving to loopback/link-local/private ranges. Pass a
+    // custom implementation to widen/narrow the policy, or `null` to disable (not recommended).
+    private val urlSanitizer: KmlUrlSanitizer? = DefaultKmlUrlSanitizer(),
 ) : IconProvider {
     private val memoryCache: LruCache<String, Bitmap>
     private val inFlight = ConcurrentHashMap<String, Deferred<Bitmap?>>()
@@ -93,8 +100,18 @@ open class UrlIconProvider(
     protected open suspend fun loadBitmapFromUrl(urlString: String): Bitmap? =
         withContext(dispatcher) {
             try {
-                val url = URL(urlString)
+                // Validate the (untrusted) href before issuing any request. `null` => blocked.
+                val safeUrl =
+                    if (urlSanitizer != null) {
+                        urlSanitizer.sanitizeUrl(urlString) ?: return@withContext null
+                    } else {
+                        urlString
+                    }
+                val url = URL(safeUrl)
                 val connection = url.openConnection() as HttpURLConnection
+                // Do not auto-follow redirects: a 30x to an internal host would otherwise bypass
+                // the sanitizer's host check (redirect-based SSRF).
+                connection.instanceFollowRedirects = false
                 connection.doInput = true
                 connection.connect()
                 val input = connection.inputStream

--- a/data/src/main/java/com/google/maps/android/data/renderer/UrlIconProvider.kt
+++ b/data/src/main/java/com/google/maps/android/data/renderer/UrlIconProvider.kt
@@ -35,7 +35,7 @@ import java.util.concurrent.ConcurrentHashMap
  * Implementation of [IconProvider] that loads icons from URLs.
  * Uses an [LruCache] to cache loaded icons and handles "thundering herd" by deduplicating in-flight requests.
  */
-open class UrlIconProvider(
+open class UrlIconProvider @JvmOverloads constructor(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
     // Icon/overlay hrefs originate from the (frequently untrusted) KML/GeoJSON document. The
     // sanitizer is applied before every fetch to prevent SSRF; the secure default blocks
@@ -100,25 +100,58 @@ open class UrlIconProvider(
     protected open suspend fun loadBitmapFromUrl(urlString: String): Bitmap? =
         withContext(dispatcher) {
             try {
-                // Validate the (untrusted) href before issuing any request. `null` => blocked.
-                val safeUrl =
-                    if (urlSanitizer != null) {
-                        urlSanitizer.sanitizeUrl(urlString) ?: return@withContext null
-                    } else {
-                        urlString
+                // Follow redirects manually, re-validating every hop through the sanitizer, so a
+                // 30x to an internal host cannot bypass the host check (redirect-based SSRF) while
+                // still supporting legitimate redirects (CDNs, signed S3/GCS URLs).
+                var current: String = urlString
+                var redirectsLeft = MAX_REDIRECTS
+                while (true) {
+                    // Validate the (untrusted) href before issuing any request. `null` => blocked.
+                    val safeUrl =
+                        if (urlSanitizer != null) {
+                            urlSanitizer.sanitizeUrl(current) ?: return@withContext null
+                        } else {
+                            current
+                        }
+                    val url = URL(safeUrl)
+                    val connection = url.openConnection() as HttpURLConnection
+                    try {
+                        // Do not auto-follow: we re-run each redirect target through the sanitizer.
+                        connection.instanceFollowRedirects = false
+                        connection.doInput = true
+                        connection.connect()
+                        val code = connection.responseCode
+                        when {
+                            code in 200..299 -> {
+                                return@withContext connection.inputStream.use {
+                                    BitmapFactory.decodeStream(it)
+                                }
+                            }
+                            code in 300..399 -> {
+                                if (redirectsLeft-- <= 0) return@withContext null
+                                val location =
+                                    connection.getHeaderField("Location")
+                                        ?: return@withContext null
+                                // Resolve relative redirects against the current URL; the next loop
+                                // iteration re-sanitizes the resolved absolute URL before connecting.
+                                current = URL(url, location).toString()
+                            }
+                            else -> return@withContext null
+                        }
+                    } finally {
+                        connection.disconnect()
                     }
-                val url = URL(safeUrl)
-                val connection = url.openConnection() as HttpURLConnection
-                // Do not auto-follow redirects: a 30x to an internal host would otherwise bypass
-                // the sanitizer's host check (redirect-based SSRF).
-                connection.instanceFollowRedirects = false
-                connection.doInput = true
-                connection.connect()
-                val input = connection.inputStream
-                BitmapFactory.decodeStream(input)
+                }
+                @Suppress("UNREACHABLE_CODE")
+                null
             } catch (e: Exception) {
                 e.printStackTrace()
                 null
             }
         }
+
+    private companion object {
+        /** Maximum number of redirects to follow before giving up. */
+        private const val MAX_REDIRECTS = 5
+    }
 }

--- a/data/src/test/java/com/google/maps/android/data/kml/DefaultKmlUrlSanitizerTest.java
+++ b/data/src/test/java/com/google/maps/android/data/kml/DefaultKmlUrlSanitizerTest.java
@@ -53,6 +53,26 @@ public class DefaultKmlUrlSanitizerTest {
     }
 
     @Test
+    public void blocksCarrierGradeNatSharedSpace() {
+        // 100.64.0.0/10 (RFC 6598) is not classified by InetAddress#isSiteLocalAddress().
+        assertNull(sanitizer.sanitizeUrl("http://100.64.0.1/x"));
+        assertNull(sanitizer.sanitizeUrl("http://100.127.255.254/x"));
+    }
+
+    @Test
+    public void blocksIetfProtocolAssignments() {
+        // 192.0.0.0/24 (RFC 6890) special-use range.
+        assertNull(sanitizer.sanitizeUrl("http://192.0.0.1/x"));
+    }
+
+    @Test
+    public void blocksIpv6UniqueLocalAddresses() {
+        // fc00::/7 (RFC 4193) is not classified by InetAddress#isSiteLocalAddress().
+        assertNull(sanitizer.sanitizeUrl("http://[fc00::1]/x"));
+        assertNull(sanitizer.sanitizeUrl("http://[fd12:3456:789a::1]/x"));
+    }
+
+    @Test
     public void blocksNonHttpSchemes() {
         assertNull(sanitizer.sanitizeUrl("file:///etc/passwd"));
         assertNull(sanitizer.sanitizeUrl("ftp://8.8.8.8/x"));
@@ -73,5 +93,14 @@ public class DefaultKmlUrlSanitizerTest {
                 sanitizer.sanitizeUrl("http://8.8.8.8/mapfiles/icon.png"));
         assertEquals("https://8.8.8.8/mapfiles/icon.png",
                 sanitizer.sanitizeUrl("https://8.8.8.8/mapfiles/icon.png"));
+    }
+
+    @Test
+    public void allowsPublicJustOutsideCarrierGradeNat() {
+        // 100.63.255.255 is just below 100.64.0.0/10 and 100.128.0.0 just above: both public.
+        assertEquals("http://100.63.255.255/icon.png",
+                sanitizer.sanitizeUrl("http://100.63.255.255/icon.png"));
+        assertEquals("http://100.128.0.1/icon.png",
+                sanitizer.sanitizeUrl("http://100.128.0.1/icon.png"));
     }
 }

--- a/data/src/test/java/com/google/maps/android/data/kml/DefaultKmlUrlSanitizerTest.java
+++ b/data/src/test/java/com/google/maps/android/data/kml/DefaultKmlUrlSanitizerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.maps.android.data.kml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link DefaultKmlUrlSanitizer}. Uses IP-literal hosts so the tests are
+ * hermetic (no DNS/network required).
+ */
+public class DefaultKmlUrlSanitizerTest {
+
+    private final DefaultKmlUrlSanitizer sanitizer = new DefaultKmlUrlSanitizer();
+
+    @Test
+    public void blocksLoopback() {
+        assertNull(sanitizer.sanitizeUrl("http://127.0.0.1:8080/INTERNAL-ADMIN"));
+        assertNull(sanitizer.sanitizeUrl("http://[::1]/x"));
+    }
+
+    @Test
+    public void blocksLinkLocalMetadataEndpoint() {
+        // 169.254.169.254 is the cloud/instance metadata endpoint.
+        assertNull(sanitizer.sanitizeUrl("http://169.254.169.254/latest/meta-data/"));
+    }
+
+    @Test
+    public void blocksPrivateRfc1918() {
+        assertNull(sanitizer.sanitizeUrl("http://10.0.0.5/internal"));
+        assertNull(sanitizer.sanitizeUrl("http://192.168.1.1/router"));
+        assertNull(sanitizer.sanitizeUrl("http://172.16.0.1/x"));
+    }
+
+    @Test
+    public void blocksAnyLocalAddress() {
+        assertNull(sanitizer.sanitizeUrl("http://0.0.0.0/x"));
+    }
+
+    @Test
+    public void blocksNonHttpSchemes() {
+        assertNull(sanitizer.sanitizeUrl("file:///etc/passwd"));
+        assertNull(sanitizer.sanitizeUrl("ftp://8.8.8.8/x"));
+        assertNull(sanitizer.sanitizeUrl("gopher://8.8.8.8/x"));
+    }
+
+    @Test
+    public void blocksMalformedOrHostless() {
+        assertNull(sanitizer.sanitizeUrl(null));
+        assertNull(sanitizer.sanitizeUrl("not a url"));
+        assertNull(sanitizer.sanitizeUrl("http://"));
+    }
+
+    @Test
+    public void allowsPublicHttpAndHttps() {
+        // 8.8.8.8 is a public address (not loopback/link-local/site-local/multicast/any-local).
+        assertEquals("http://8.8.8.8/mapfiles/icon.png",
+                sanitizer.sanitizeUrl("http://8.8.8.8/mapfiles/icon.png"));
+        assertEquals("https://8.8.8.8/mapfiles/icon.png",
+                sanitizer.sanitizeUrl("https://8.8.8.8/mapfiles/icon.png"));
+    }
+}


### PR DESCRIPTION
## Summary

Icon and GroundOverlay `<href>` URLs are read from the parsed KML/GeoJSON document and fetched **without any validation**, giving a crafted (untrusted) document a **Server-Side Request Forgery (SSRF)** primitive.

- `Style/IconStyle/Icon/href` → `KmlStyle.iconUrl`
- `GroundOverlay/Icon/href` → `KmlGroundOverlay.imageUrl`

Both flow to `UrlIconProvider.loadBitmapFromUrl`, which did:

```kotlin
val url = URL(urlString)
val connection = url.openConnection() as HttpURLConnection
connection.doInput = true
connection.connect()          // <-- request issued; no validation anywhere
```

A malicious KML/GeoJSON (downloaded, shared, or user-provided) can therefore make the app issue requests to **loopback**, **link-local (`169.254.169.254` metadata)**, and **private-network** hosts reachable from the device. `HttpURLConnection` also **follows redirects by default**, so a public-looking href can `302` to an internal target.

The `KmlUrlSanitizer` interface exists but `sanitizeUrl(...)` is **never called anywhere in the codebase** (dead code), and `KmlLayer`/`GeoJsonLayer` hard-code `UrlIconProvider()` with no way to inject one — so there was **no protection by default and no way for a developer to add one**.

### Reproduction (network sequence is verbatim from `loadBitmapFromUrl`)

A KML with `<Icon><href>http://127.0.0.1:8474/INTERNAL</href></Icon>` (or a `169.254.169.254` / RFC1918 host) causes a real request to that host; a redirector href is followed to the internal target. Confirmed against a local listener that logged the inbound requests.

## Fix

- **`DefaultKmlUrlSanitizer`** (new): allows only `http`/`https` whose host does **not** resolve to a loopback / any-local / link-local / site-local (RFC 1918) / multicast address; returns `null` (block) otherwise. Public icon/overlay URLs are unaffected.
- **`UrlIconProvider`** now applies a `KmlUrlSanitizer` (secure default) before every fetch — blocked URLs issue no request — and sets `instanceFollowRedirects = false` to stop redirect-based bypass. Callers may pass a custom sanitizer, or `null` to opt out.
- **Hermetic unit tests** for the sanitizer (IP-literal hosts, no DNS/network).

This makes the previously-dead `KmlUrlSanitizer` functional and the default behavior secure, without changing the public `KmlLayer`/`GeoJsonLayer` API. Verified on a JVM: internal/metadata/RFC1918/redirector/`file://` hrefs are blocked with no request issued, while a public host still loads.

## Scope / notes

- DNS-rebinding between the sanitizer's resolution and the connection's resolution is a known residual limitation of host-based validation; disabling auto-redirects and failing closed on unresolved hosts substantially reduces the attack surface.
