### PR TITLE
chore(clustering): use idiomatic poll().let in cluster renderers for null-safety

### DIFF
--- a/clustering/src/main/java/com/google/maps/android/clustering/view/ClusterRendererMultipleItems.kt
+++ b/clustering/src/main/java/com/google/maps/android/clustering/view/ClusterRendererMultipleItems.kt
@@ -764,17 +764,11 @@ open class ClusterRendererMultipleItems<T : ClusterItem> @JvmOverloads construct
          * Perform the next task. Prioritise any on-screen work.
          */
         private fun performNextTask() {
-            if (!mOnScreenRemoveMarkerTasks.isEmpty()) {
-                removeMarker(mOnScreenRemoveMarkerTasks.poll())
-            } else if (!mAnimationTasks.isEmpty()) {
-                mAnimationTasks.poll()?.perform()
-            } else if (!mOnScreenCreateMarkerTasks.isEmpty()) {
-                mOnScreenCreateMarkerTasks.poll()?.perform(this)
-            } else if (!mCreateMarkerTasks.isEmpty()) {
-                mCreateMarkerTasks.poll()?.perform(this)
-            } else if (!mRemoveMarkerTasks.isEmpty()) {
-                removeMarker(mRemoveMarkerTasks.poll())
-            }
+            mOnScreenRemoveMarkerTasks.poll()?.let { removeMarker(it); return }
+            mAnimationTasks.poll()?.let { it.perform(); return }
+            mOnScreenCreateMarkerTasks.poll()?.let { it.perform(this); return }
+            mCreateMarkerTasks.poll()?.let { it.perform(this); return }
+            mRemoveMarkerTasks.poll()?.let { removeMarker(it); return }
         }
 
         private fun removeMarker(m: Marker?) {

--- a/clustering/src/main/java/com/google/maps/android/clustering/view/DefaultAdvancedMarkersClusterRenderer.kt
+++ b/clustering/src/main/java/com/google/maps/android/clustering/view/DefaultAdvancedMarkersClusterRenderer.kt
@@ -693,17 +693,11 @@ open class DefaultAdvancedMarkersClusterRenderer<T : ClusterItem> @JvmOverloads 
          * Perform the next task. Prioritise any on-screen work.
          */
         private fun performNextTask() {
-            if (!mOnScreenRemoveMarkerTasks.isEmpty()) {
-                removeMarker(mOnScreenRemoveMarkerTasks.poll())
-            } else if (!mAnimationTasks.isEmpty()) {
-                mAnimationTasks.poll().perform()
-            } else if (!mOnScreenCreateMarkerTasks.isEmpty()) {
-                mOnScreenCreateMarkerTasks.poll().perform(this)
-            } else if (!mCreateMarkerTasks.isEmpty()) {
-                mCreateMarkerTasks.poll().perform(this)
-            } else if (!mRemoveMarkerTasks.isEmpty()) {
-                removeMarker(mRemoveMarkerTasks.poll())
-            }
+            mOnScreenRemoveMarkerTasks.poll()?.let { removeMarker(it); return }
+            mAnimationTasks.poll()?.let { it.perform(); return }
+            mOnScreenCreateMarkerTasks.poll()?.let { it.perform(this); return }
+            mCreateMarkerTasks.poll()?.let { it.perform(this); return }
+            mRemoveMarkerTasks.poll()?.let { removeMarker(it); return }
         }
 
         private fun removeMarker(m: Marker?) {

--- a/clustering/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.kt
+++ b/clustering/src/main/java/com/google/maps/android/clustering/view/DefaultClusterRenderer.kt
@@ -692,17 +692,11 @@ open class DefaultClusterRenderer<T : ClusterItem> @JvmOverloads constructor(
          * Perform the next task. Prioritise any on-screen work.
          */
         private fun performNextTask() {
-            if (!mOnScreenRemoveMarkerTasks.isEmpty()) {
-                removeMarker(mOnScreenRemoveMarkerTasks.poll())
-            } else if (!mAnimationTasks.isEmpty()) {
-                mAnimationTasks.poll().perform()
-            } else if (!mOnScreenCreateMarkerTasks.isEmpty()) {
-                mOnScreenCreateMarkerTasks.poll().perform(this)
-            } else if (!mCreateMarkerTasks.isEmpty()) {
-                mCreateMarkerTasks.poll().perform(this)
-            } else if (!mRemoveMarkerTasks.isEmpty()) {
-                removeMarker(mRemoveMarkerTasks.poll())
-            }
+            mOnScreenRemoveMarkerTasks.poll()?.let { removeMarker(it); return }
+            mAnimationTasks.poll()?.let { it.perform(); return }
+            mOnScreenCreateMarkerTasks.poll()?.let { it.perform(this); return }
+            mCreateMarkerTasks.poll()?.let { it.perform(this); return }
+            mRemoveMarkerTasks.poll()?.let { removeMarker(it); return }
         }
 
         private fun removeMarker(m: Marker?) {


### PR DESCRIPTION
### Summary

Replaces redundant `!queue.isEmpty()` checks and unsafe `.poll()` platform-type invocations in `performNextTask()` across cluster renderers with idiomatic Kotlin `queue.poll()?.let { ...; return }`.

### Details
- `Queue.poll()` is a Java platform method returning a nullable type (`AnimationTask?`). In strict nullability build environments (such as google3 with `-Xjsr305=strict`), calling `queue.poll().perform()` produces unsafe nullable receiver errors.
- In Kotlin, `queue.poll()` returns `null` if empty, making pre-checks with `!queue.isEmpty()` redundant. Using `poll()?.let` performs a single atomic queue retrieval, safely smart-casts `it` to non-null, and immediately returns once the highest-priority queued task is handled.

### Files Updated
- `DefaultAdvancedMarkersClusterRenderer.kt`
- `DefaultClusterRenderer.kt`
- `ClusterRendererMultipleItems.kt`

### Reviewer
cc @LoyalAbbas
