### PR TITLE
ci: support GEMINI_MODEL repository variable in triage-issue workflow

### DIFF
--- a/.github/scripts/triage_issue.py
+++ b/.github/scripts/triage_issue.py
@@ -18,8 +18,8 @@ import urllib.request
 import sys
 
 def get_gemini_response(api_key, prompt):
-    # Using the stable Gemini 3.5 Flash
-    url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent?key={api_key}"
+    model = os.getenv("GEMINI_MODEL", "gemini-3.8-flash")
+    url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
     headers = {'Content-Type': 'application/json'}
     data = {
         "contents": [{

--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -45,6 +45,7 @@ jobs:
         id: run_script
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GEMINI_MODEL: ${{ vars.GEMINI_MODEL }}
           ISSUE_TITLE: ${{ github.event.issue.title || github.event.inputs.title }}
           ISSUE_BODY: ${{ github.event.issue.body || github.event.inputs.body }}
         run: |


### PR DESCRIPTION
## Summary
Configures the `Issue Triage with Gemini` workflow and script to read and utilize the `GEMINI_MODEL` repository variable.

### Changes
- Updated `.github/scripts/triage_issue.py` to use `os.getenv("GEMINI_MODEL", "gemini-3.8-flash")` instead of hardcoding `gemini-3.5-flash`.
- Updated `.github/workflows/triage-issue.yml` to pass `GEMINI_MODEL: ${{ vars.GEMINI_MODEL }}` in the step environment.