### PR TITLE
build: migrate unit test coverage from JaCoCo to Kover

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -46,23 +46,23 @@ jobs:
         run: echo "MAPS_API_KEY=dummy" > secrets.properties
 
       - name: Build modules
-        run: ./gradlew build jacocoTestDebugUnitTestReport --stacktrace
+        run: ./gradlew build koverXmlReportDebug koverXmlReportAndroid --stacktrace
 
       # PRs from forks don't get repo secrets on the pull_request trigger, so
       # secrets.SYNCED_GITHUB_TOKEN_REPO is empty and this step always fails for external
       # contributions. continue-on-error keeps that from failing the whole job/check: the
       # build and tests above are still the real signal, this is just a best-effort comment.
-      - name: Jacoco Report to PR
+      - name: Coverage Report to PR
         id: jacoco
         continue-on-error: true
         uses: madrapps/jacoco-report@e51ce1f46f7f8b5331593f935e59cbaf44b84920 # v1.8.0
         with:
           paths: |
-            ${{ github.workspace }}/library/build/jacoco/jacoco.xml,
-            ${{ github.workspace }}/clustering/build/jacoco/jacoco.xml,
-            ${{ github.workspace }}/data/build/jacoco/jacoco.xml,
-            ${{ github.workspace }}/heatmaps/build/jacoco/jacoco.xml,
-            ${{ github.workspace }}/ui/build/jacoco/jacoco.xml
+            ${{ github.workspace }}/library/build/reports/kover/reportAndroid.xml,
+            ${{ github.workspace }}/clustering/build/reports/kover/reportAndroid.xml,
+            ${{ github.workspace }}/data/build/reports/kover/reportDebug.xml,
+            ${{ github.workspace }}/heatmaps/build/reports/kover/reportAndroid.xml,
+            ${{ github.workspace }}/ui/build/reports/kover/reportDebug.xml
           token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
           min-coverage-overall: 26
           min-coverage-changed-files: 60

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,4 @@ jobs:
       run: echo "MAPS_API_KEY=dummy" > secrets.properties
 
     - name: Build modules
-      run: ./gradlew build jacocoTestDebugUnitTestReport --stacktrace
+      run: ./gradlew build koverXmlReportDebug koverXmlReportAndroid --stacktrace

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     implementation(libs.kotlin.gradle.plugin)
     implementation(libs.gradle)
     implementation(libs.dokka.gradle.plugin)
-    implementation(libs.org.jacoco.core)
+    implementation(libs.kover.gradle.plugin)
     implementation(libs.gradle.maven.publish.plugin)
 }
 

--- a/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
@@ -17,57 +17,35 @@
 // buildSrc/src/main/kotlin/PublishingConventionPlugin.kt
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.*
-import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
-import org.gradle.api.tasks.testing.Test
-import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
-import org.gradle.testing.jacoco.tasks.JacocoReport
 
 class PublishingConventionPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.run {
             applyPlugins()
-            configureJacoco()
+            configureKover()
             configureVanniktechPublishing()
         }
     }
 
     private fun Project.applyPlugins() {
         apply(plugin = "com.android.library")
-        apply(plugin = "com.mxalbert.gradle.jacoco-android")
+        apply(plugin = "org.jetbrains.kotlinx.kover")
         apply(plugin = "org.jetbrains.dokka")
         apply(plugin = "com.vanniktech.maven.publish")
     }
 
-    private fun Project.configureJacoco() {
-        configure<JacocoPluginExtension> {
-            toolVersion = "0.8.12"
-        }
-
-        tasks.withType<Test>().configureEach {
-            extensions.configure(JacocoTaskExtension::class.java) {
-                isIncludeNoLocationClasses = true
-                excludes = listOf("jdk.internal.*")
-            }
-        }
-
-        // com.mxalbert.gradle.jacoco-android (last released for AGP 8.x) auto-detects
-        // classDirectories using paths that predate AGP's built-in Kotlin compiler, so it
-        // only finds javac output and silently misses every Kotlin-compiled class. Point the
-        // debug report tasks at both compiler outputs directly so Kotlin sources are covered.
-        tasks.withType<JacocoReport>().configureEach {
-            if (name.contains("Debug")) {
-                classDirectories.setFrom(
-                    fileTree(layout.buildDirectory.dir("intermediates/javac/debug")) {
-                        include("**/classes/**")
-                        exclude("**/R.class", "**/R\$*.class", "**/BuildConfig.class")
-                    },
-                    fileTree(layout.buildDirectory.dir("intermediates/built_in_kotlinc/debug")) {
-                        include("**/classes/**")
+    private fun Project.configureKover() {
+        configure<KoverProjectExtension> {
+            reports {
+                filters {
+                    excludes {
+                        androidGeneratedClasses()
                     }
-                )
+                }
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ buildscript {
 
     dependencies {
         classpath(libs.gradle)
-        classpath(libs.jacoco.android)
+        classpath(libs.kover.gradle.plugin)
         classpath(libs.secrets.gradle.plugin)
         classpath(libs.kotlin.gradle.plugin)
         classpath(libs.dokka.gradle.plugin)

--- a/clustering/build.gradle.kts
+++ b/clustering/build.gradle.kts
@@ -17,6 +17,7 @@ plugins {
     id("org.jetbrains.kotlin.multiplatform")
     id("com.android.kotlin.multiplatform.library")
     id("org.jetbrains.dokka")
+    id("org.jetbrains.kotlinx.kover")
     // Prototype publishing: KMP auto-creates multiplatform publications, enabling
     // publishToMavenLocal so android-maps-compose can consume this via -PuseMavenLocal=true.
     id("maven-publish")
@@ -24,9 +25,9 @@ plugins {
 
 // NOTE (KMP prototype): the module previously applied android.maps.utils.PublishingConventionPlugin,
 // which is hard-wired to com.android.library + AndroidSingleVariantLibrary publishing. A KMP-aware
-// variant (vanniktech KotlinMultiplatform() publishing + jacoco for the android target) is needed
-// before this module can be released from this branch. Lint publishing (lint-checks), the amu_
-// resourcePrefix and consumer proguard rules from the old build also need re-wiring.
+// variant (vanniktech KotlinMultiplatform() publishing) is needed before this module can be
+// released from this branch. Lint publishing (lint-checks), the amu_ resourcePrefix and consumer
+// proguard rules from the old build also need re-wiring.
 
 kotlin {
     jvmToolchain(17)

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -20,7 +20,6 @@ plugins {
     id("org.jetbrains.dokka")
     id("android.maps.utils.PublishingConventionPlugin")
     id("org.jetbrains.kotlin.plugin.serialization") version libs.versions.kotlin.get()
-    id("jacoco")
 }
 
 android {
@@ -93,19 +92,4 @@ tasks.register("instrumentTest") {
 
 if (System.getenv("JITPACK") != null) {
     apply(plugin = "maven")
-}
-
-tasks.register<JacocoReport>("jacocoDebugReport") {
-    dependsOn("testDebugUnitTest")
-    reports {
-        xml.required.set(true)
-        html.required.set(true)
-    }
-    val debugTree = fileTree(layout.buildDirectory.dir("tmp/kotlin-classes/debug")) {
-        exclude("**/R.class", "**/R$*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*", "android/**/*.*")
-    }
-    val mainSrc = layout.projectDirectory.dir("src/main/java")
-    sourceDirectories.setFrom(files(mainSrc))
-    classDirectories.setFrom(files(debugTree))
-    executionData.setFrom(files(layout.buildDirectory.file("outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,9 +50,8 @@ uiautomator = "2.4.0"
 
 # --- Lint & Analysis ---
 # Versions for code quality and static analysis tools.
-jacoco-android = "0.2.1"
+kover = "0.9.9"
 lint = "32.3.1"
-org-jacoco-core = "0.8.15"
 
 # --- Gradle Plugins ---
 # Versions for Gradle plugins used in the build process.
@@ -117,12 +116,11 @@ uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", versi
 
 # --- Lint & Analysis ---
 # Libraries and tools for static code analysis, linting, and coverage reporting.
-jacoco-android = { module = "com.mxalbert.gradle:jacoco-android", version.ref = "jacoco-android" }
+kover-gradle-plugin = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version.ref = "kover" }
 lint = { module = "com.android.tools.lint:lint", version.ref = "lint" }
 lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "lint" }
 lint-checks = { module = "com.android.tools.lint:lint-checks", version.ref = "lint" }
 lint-tests = { module = "com.android.tools.lint:lint-tests", version.ref = "lint" }
-org-jacoco-core = { module = "org.jacoco:org.jacoco.core", version.ref = "org-jacoco-core" }
 serialization = { module = "io.github.pdvrieze.xmlutil:serialization", version.ref = "serialization" }
 testutils = { module = "com.android.tools:testutils", version.ref = "lint" }
 

--- a/heatmaps/build.gradle.kts
+++ b/heatmaps/build.gradle.kts
@@ -17,13 +17,14 @@ plugins {
     id("org.jetbrains.kotlin.multiplatform")
     id("com.android.kotlin.multiplatform.library")
     id("org.jetbrains.dokka")
+    id("org.jetbrains.kotlinx.kover")
     // Prototype publishing: KMP auto-creates multiplatform publications, enabling
     // publishToMavenLocal so android-maps-compose can consume this via -PuseMavenLocal=true.
     id("maven-publish")
 }
 
 // NOTE (KMP prototype): see clustering/build.gradle.kts — release publishing (vanniktech),
-// jacoco, lint-checks and the amu_ resourcePrefix still need KMP-aware re-wiring.
+// lint-checks and the amu_ resourcePrefix still need KMP-aware re-wiring.
 
 kotlin {
     jvmToolchain(17)

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -17,13 +17,14 @@ plugins {
     id("org.jetbrains.kotlin.multiplatform")
     id("com.android.kotlin.multiplatform.library")
     id("org.jetbrains.dokka")
+    id("org.jetbrains.kotlinx.kover")
     // Prototype publishing: KMP auto-creates multiplatform publications, enabling
     // publishToMavenLocal so android-maps-compose can consume this via -PuseMavenLocal=true.
     id("maven-publish")
 }
 
 // NOTE (KMP prototype): see clustering/build.gradle.kts — release publishing (vanniktech),
-// jacoco, lint-checks and the amu_ resourcePrefix still need KMP-aware re-wiring.
+// lint-checks and the amu_ resourcePrefix still need KMP-aware re-wiring.
 
 abstract class GenerateArtifactIdTask : DefaultTask() {
     @get:OutputDirectory


### PR DESCRIPTION
## Summary

Migrates unit test coverage from JaCoCo to [kotlinx-kover](https://github.com/Kotlin/kotlinx-kover) 0.9.9.

**Why:**
- The `com.mxalbert.gradle:jacoco-android` plugin is effectively unmaintained (last released for AGP 8.x), which forced `PublishingConventionPlugin` to hardcode internal AGP intermediate paths (`intermediates/built_in_kotlinc/debug`) to pick up classes from AGP 9's built-in Kotlin compiler. Kover integrates through AGP's variant APIs, so all of that workaround code is deleted.
- Kover supports Kotlin Multiplatform natively. The KMP modules (`library`, `clustering`, `heatmaps`) had **no working coverage** since their KMP migration: `report.yml` pointed at `jacoco.xml` files that were no longer generated. They now report coverage again.
- Kover filters compiler-generated code, so percentages reflect hand-written Kotlin. Expect a shift versus historical JaCoCo numbers on the first PRs after this merges.

## Changes

- `PublishingConventionPlugin` applies `org.jetbrains.kotlinx.kover` instead of `com.mxalbert.gradle.jacoco-android` and drops the JaCoCo `classDirectories` workaround.
- `library`, `clustering`, `heatmaps` (KMP): apply the Kover plugin directly; the "jacoco needs KMP-aware re-wiring" TODOs are resolved.
- `data`: removes the stale direct `jacoco` plugin and `jacocoDebugReport` task that still referenced the pre-AGP-9 `tmp/kotlin-classes` path.
- CI (`test.yml`, `report.yml`): runs `koverXmlReportDebug` (AGP modules) + `koverXmlReportAndroid` (KMP modules). `madrapps/jacoco-report` supports Kover XML natively, so only the report paths changed; the coverage gates (26% overall / 60% changed files) are unchanged.

## Verification

Full CI command `./gradlew build koverXmlReportDebug koverXmlReportAndroid --stacktrace` passes locally (11m 49s). Line coverage per module from the generated Kover reports:

| Module | Coverage | Note |
|---|---|---|
| library | 91.3% | restored (was missing since KMP migration) |
| heatmaps | 87.0% | restored |
| ui | 77.7% | |
| data | 49.5% | |
| clustering | 31.4% | restored |
