### PR TITLE
build: migrate unit test coverage from JaCoCo to Kover

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -46,23 +46,23 @@ jobs:
         run: echo "MAPS_API_KEY=dummy" > secrets.properties
 
       - name: Build modules
-        run: ./gradlew build jacocoTestDebugUnitTestReport --stacktrace
+        run: ./gradlew build koverXmlReportDebug --stacktrace
 
       # PRs from forks don't get repo secrets on the pull_request trigger, so
       # secrets.SYNCED_GITHUB_TOKEN_REPO is empty and this step always fails for external
       # contributions. continue-on-error keeps that from failing the whole job/check: the
       # build and tests above are still the real signal, this is just a best-effort comment.
-      - name: Jacoco Report to PR
+      - name: Coverage Report to PR
         id: jacoco
         continue-on-error: true
         uses: madrapps/jacoco-report@e51ce1f46f7f8b5331593f935e59cbaf44b84920 # v1.8.0
         with:
           paths: |
-            ${{ github.workspace }}/library/build/jacoco/jacoco.xml,
-            ${{ github.workspace }}/clustering/build/jacoco/jacoco.xml,
-            ${{ github.workspace }}/data/build/jacoco/jacoco.xml,
-            ${{ github.workspace }}/heatmaps/build/jacoco/jacoco.xml,
-            ${{ github.workspace }}/ui/build/jacoco/jacoco.xml
+            ${{ github.workspace }}/library/build/reports/kover/reportDebug.xml,
+            ${{ github.workspace }}/clustering/build/reports/kover/reportDebug.xml,
+            ${{ github.workspace }}/data/build/reports/kover/reportDebug.xml,
+            ${{ github.workspace }}/heatmaps/build/reports/kover/reportDebug.xml,
+            ${{ github.workspace }}/ui/build/reports/kover/reportDebug.xml
           token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
           min-coverage-overall: 26
           min-coverage-changed-files: 60

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,4 @@ jobs:
       run: echo "MAPS_API_KEY=dummy" > secrets.properties
 
     - name: Build modules
-      run: ./gradlew build jacocoTestDebugUnitTestReport --stacktrace
+      run: ./gradlew build koverXmlReportDebug --stacktrace

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     implementation(libs.kotlin.gradle.plugin)
     implementation(libs.gradle)
     implementation(libs.dokka.gradle.plugin)
-    implementation(libs.org.jacoco.core)
+    implementation(libs.kover.gradle.plugin)
     implementation(libs.gradle.maven.publish.plugin)
 }
 

--- a/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
@@ -17,57 +17,35 @@
 // buildSrc/src/main/kotlin/PublishingConventionPlugin.kt
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.*
-import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
-import org.gradle.api.tasks.testing.Test
-import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
-import org.gradle.testing.jacoco.tasks.JacocoReport
 
 class PublishingConventionPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.run {
             applyPlugins()
-            configureJacoco()
+            configureKover()
             configureVanniktechPublishing()
         }
     }
 
     private fun Project.applyPlugins() {
         apply(plugin = "com.android.library")
-        apply(plugin = "com.mxalbert.gradle.jacoco-android")
+        apply(plugin = "org.jetbrains.kotlinx.kover")
         apply(plugin = "org.jetbrains.dokka")
         apply(plugin = "com.vanniktech.maven.publish")
     }
 
-    private fun Project.configureJacoco() {
-        configure<JacocoPluginExtension> {
-            toolVersion = "0.8.12"
-        }
-
-        tasks.withType<Test>().configureEach {
-            extensions.configure(JacocoTaskExtension::class.java) {
-                isIncludeNoLocationClasses = true
-                excludes = listOf("jdk.internal.*")
-            }
-        }
-
-        // com.mxalbert.gradle.jacoco-android (last released for AGP 8.x) auto-detects
-        // classDirectories using paths that predate AGP's built-in Kotlin compiler, so it
-        // only finds javac output and silently misses every Kotlin-compiled class. Point the
-        // debug report tasks at both compiler outputs directly so Kotlin sources are covered.
-        tasks.withType<JacocoReport>().configureEach {
-            if (name.contains("Debug")) {
-                classDirectories.setFrom(
-                    fileTree(layout.buildDirectory.dir("intermediates/javac/debug")) {
-                        include("**/classes/**")
-                        exclude("**/R.class", "**/R\$*.class", "**/BuildConfig.class")
-                    },
-                    fileTree(layout.buildDirectory.dir("intermediates/built_in_kotlinc/debug")) {
-                        include("**/classes/**")
+    private fun Project.configureKover() {
+        configure<KoverProjectExtension> {
+            reports {
+                filters {
+                    excludes {
+                        androidGeneratedClasses()
                     }
-                )
+                }
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ buildscript {
 
     dependencies {
         classpath(libs.gradle)
-        classpath(libs.jacoco.android)
+        classpath(libs.kover.gradle.plugin)
         classpath(libs.secrets.gradle.plugin)
         classpath(libs.kotlin.gradle.plugin)
         classpath(libs.dokka.gradle.plugin)

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -20,7 +20,6 @@ plugins {
     id("org.jetbrains.dokka")
     id("android.maps.utils.PublishingConventionPlugin")
     id("org.jetbrains.kotlin.plugin.serialization") version libs.versions.kotlin.get()
-    id("jacoco")
 }
 
 android {
@@ -93,19 +92,4 @@ tasks.register("instrumentTest") {
 
 if (System.getenv("JITPACK") != null) {
     apply(plugin = "maven")
-}
-
-tasks.register<JacocoReport>("jacocoDebugReport") {
-    dependsOn("testDebugUnitTest")
-    reports {
-        xml.required.set(true)
-        html.required.set(true)
-    }
-    val debugTree = fileTree(layout.buildDirectory.dir("tmp/kotlin-classes/debug")) {
-        exclude("**/R.class", "**/R$*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*", "android/**/*.*")
-    }
-    val mainSrc = layout.projectDirectory.dir("src/main/java")
-    sourceDirectories.setFrom(files(mainSrc))
-    classDirectories.setFrom(files(debugTree))
-    executionData.setFrom(files(layout.buildDirectory.file("outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,9 +50,8 @@ uiautomator = "2.4.0"
 
 # --- Lint & Analysis ---
 # Versions for code quality and static analysis tools.
-jacoco-android = "0.2.1"
+kover = "0.9.9"
 lint = "32.3.1"
-org-jacoco-core = "0.8.15"
 
 # --- Gradle Plugins ---
 # Versions for Gradle plugins used in the build process.
@@ -116,12 +115,11 @@ uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", versi
 
 # --- Lint & Analysis ---
 # Libraries and tools for static code analysis, linting, and coverage reporting.
-jacoco-android = { module = "com.mxalbert.gradle:jacoco-android", version.ref = "jacoco-android" }
+kover-gradle-plugin = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version.ref = "kover" }
 lint = { module = "com.android.tools.lint:lint", version.ref = "lint" }
 lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "lint" }
 lint-checks = { module = "com.android.tools.lint:lint-checks", version.ref = "lint" }
 lint-tests = { module = "com.android.tools.lint:lint-tests", version.ref = "lint" }
-org-jacoco-core = { module = "org.jacoco:org.jacoco.core", version.ref = "org-jacoco-core" }
 serialization = { module = "io.github.pdvrieze.xmlutil:serialization", version.ref = "serialization" }
 testutils = { module = "com.android.tools:testutils", version.ref = "lint" }
 


### PR DESCRIPTION
## Summary

Migrates unit test coverage from JaCoCo to [kotlinx-kover](https://github.com/Kotlin/kotlinx-kover) 0.9.9. The `com.mxalbert.gradle:jacoco-android` plugin is unmaintained (last released for AGP 8.x) and its class-directory auto-detection predates AGP's built-in Kotlin compiler, which forced a hand-rolled workaround pointing at internal AGP intermediate paths.

## Changes

- `PublishingConventionPlugin` applies Kover instead of JaCoCo, dropping the `classDirectories` workaround. All modules using the convention plugin (`library`, `clustering`, `data`, `heatmaps`, `ui`, `collections`, etc.) get Kover automatically.
- `data`: removed the stale direct `jacoco` plugin and the `jacocoDebugReport` task that still referenced the pre-AGP-9 `tmp/kotlin-classes` path.
- CI (`test.yml`, `report.yml`) runs `koverXmlReportDebug`; `report.yml` points `madrapps/jacoco-report` (which supports Kover XML) at the new `build/reports/kover/reportDebug.xml` paths.
- Version catalog: `jacoco-android` and `org.jacoco.core` replaced by `kover-gradle-plugin`.

## Testing

- `./gradlew :library:koverXmlReportDebug :ui:koverXmlReportDebug :data:koverXmlReportDebug` configures and runs locally.
- CI coverage report on this PR exercises the new report paths.